### PR TITLE
HTTP status code change

### DIFF
--- a/internal/api/photos.go
+++ b/internal/api/photos.go
@@ -60,7 +60,7 @@ func LikePhoto(router *gin.RouterGroup, conf photoprism.Config) {
 			photo := search.FindPhotoByID(photoId)
 			photo.PhotoFavorite = true
 			conf.GetDb().Save(&photo)
-			c.JSON(http.StatusAccepted, http.Response{})
+			c.JSON(http.StatusOK, http.Response{})
 		} else {
 			log.Printf("could not find image for id: %s", err.Error())
 			c.Data(http.StatusNotFound, "image", []byte(""))
@@ -82,7 +82,7 @@ func DislikePhoto(router *gin.RouterGroup, conf photoprism.Config) {
 			photo := search.FindPhotoByID(photoId)
 			photo.PhotoFavorite = false
 			conf.GetDb().Save(&photo)
-			c.JSON(http.StatusAccepted, http.Response{})
+			c.JSON(http.StatusOK, http.Response{})
 		} else {
 			log.Printf("could not find image for id: %s", err.Error())
 			c.Data(http.StatusNotFound, "image", []byte(""))

--- a/internal/api/photos_test.go
+++ b/internal/api/photos_test.go
@@ -24,7 +24,7 @@ func TestLikePhoto(t *testing.T) {
 
 	result := PerformRequest(app, "POST", "/api/v1/photos/1/like")
 
-	assert.Equal(t, http.StatusAccepted, result.Code)
+	assert.Equal(t, http.StatusOK, result.Code)
 }
 
 func TestDislikePhoto(t *testing.T) {
@@ -34,5 +34,5 @@ func TestDislikePhoto(t *testing.T) {
 
 	result := PerformRequest(app, "DELETE", "/api/v1/photos/1/like")
 
-	assert.Equal(t, http.StatusAccepted, result.Code)
+	assert.Equal(t, http.StatusOK, result.Code)
 }


### PR DESCRIPTION
This is the slight code change as mentioned in the issue https://github.com/photoprism/photoprism/issues/76 that 
DislikePhoto and LikePhoto should return http.StatusOK (200) instead of http.StatusAccepted (202)
I've executed "make test" without any problem.