### PR TITLE
add sql_mode in docker-compose.travis.yml

### DIFF
--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -24,7 +24,7 @@ services:
 
   database:
     image: mysql:latest
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=1024
+    command: mysqld --sql_mode="" --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=1024
     environment:
       MYSQL_ROOT_PASSWORD: photoprism
       MYSQL_USER: photoprism


### PR DESCRIPTION
fix #79 

It can be avoiding the error message to add sql_mode.

https://github.com/jinzhu/gorm/issues/595

I think the message is in itself the problem of gorm.