### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/fsutil/file.go
+++ b/internal/fsutil/file.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 )
 
-// Returns true if file exists
+// Exists returns true if file exists
 func Exists(filename string) bool {
 	info, err := os.Stat(filename)
 
 	return err == nil && !info.IsDir()
 }
 
-// Returns full path; ~ replaced with actual home directory
+// ExpandedFilename returns full path; ~ replaced with actual home directory
 func ExpandedFilename(filename string) string {
 	if filename == "" {
 		panic("filename was empty")

--- a/internal/fsutil/hash.go
+++ b/internal/fsutil/hash.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-// Returns sha1 hash of file as string
+// Hash returns sha1 hash of file as string
 func Hash(filename string) string {
 	var result []byte
 

--- a/internal/test/capture.go
+++ b/internal/test/capture.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-// Returns output to stdout and stderr for testing
+// Capture returns output to stdout and stderr for testing
 func Capture(f func()) string {
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/internal/test/context.go
+++ b/internal/test/context.go
@@ -6,7 +6,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Returns example cli context for testing
+// CliContext returns example cli context for testing
 func CliContext() *cli.Context {
 	globalSet := flag.NewFlagSet("test", 0)
 	globalSet.Bool("debug", false, "doc")


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?