### PR TITLE
Handle filenames with special characters in them #131

### DIFF
--- a/internal/photoprism/indexer.go
+++ b/internal/photoprism/indexer.go
@@ -380,6 +380,11 @@ func (i *Indexer) IndexAll() map[string]bool {
 	indexed := make(map[string]bool)
 
 	err := filepath.Walk(i.originalsPath(), func(filename string, fileInfo os.FileInfo, err error) error {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Printf("Could not index file %s due to an unexpected error: %s", filename, err)
+			}
+		}()
 		if err != nil || indexed[filename] {
 			return nil
 		}

--- a/internal/photoprism/mediafile.go
+++ b/internal/photoprism/mediafile.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -269,7 +270,8 @@ func (m *MediaFile) EditedFilename() string {
 // RelatedFiles returns files which are related to this file.
 func (m *MediaFile) RelatedFiles() (result MediaFiles, mainFile *MediaFile, err error) {
 	baseFilename := m.DirectoryBasename()
-
+	// escape any meta characters in the file name
+	baseFilename = regexp.QuoteMeta(baseFilename)
 	matches, err := filepath.Glob(baseFilename + "*")
 
 	if err != nil {


### PR DESCRIPTION
1. Catch and log unexpected errors due to failure of any individual files, but continue processing the remaining files
2. Escape filenames with special/meta characters so that they can match any related files without failures