### PR TITLE
Frontend: fix lazy loading for albums

### DIFF
--- a/frontend/src/pages/album/photos.vue
+++ b/frontend/src/pages/album/photos.vue
@@ -132,6 +132,7 @@
                 const params = {
                     count: this.pageSize,
                     offset: this.offset,
+                    album: this.uuid,
                 };
 
                 Object.assign(params, this.lastFilter);


### PR DESCRIPTION
just a really small fix to load only the images belonging to a specific album