### PR TITLE
Fix context path, because Dockerfile is inside this folder, Fixes #197

### DIFF
--- a/docker/tensorflow/Dockerfile
+++ b/docker/tensorflow/Dockerfile
@@ -57,8 +57,8 @@ RUN mv bazel-0.24.1-linux-x86_64 /usr/local/bin/bazel && chmod 755 /usr/local/bi
 
 # Configure TensorFlow
 WORKDIR "/home/tensorflow/tensorflow-1.14.0"
-COPY /docker/tensorflow/*.sh ./
-COPY /docker/tensorflow/*.diff ./
-COPY /docker/tensorflow/.tf_configure.bazelrc .tf_configure.bazelrc
-COPY /docker/tensorflow/Makefile Makefile
+COPY ./*.sh ./
+COPY ./*.diff ./
+COPY ./.tf_configure.bazelrc .tf_configure.bazelrc
+COPY ./Makefile Makefile
 RUN make patch


### PR DESCRIPTION
Otherwise you get:
```
Step 17/23 : RUN mv bazel-0.24.1-linux-x86_64 /usr/local/bin/bazel && chmod 755 /usr/local/bin/bazel
 ---> Running in 3b297256f0ff
Removing intermediate container 3b297256f0ff
 ---> d7167bbc338b
Step 18/23 : WORKDIR "/home/tensorflow/tensorflow-1.14.0"
 ---> Running in 54586f1a4fa7
Removing intermediate container 54586f1a4fa7
 ---> fa0883db291f
Step 19/23 : COPY /docker/tensorflow/*.sh ./
COPY failed: no source files were specified
```

Don't wanna catch you on https://github.com/photoprism/photoprism/issues/197#issuecomment-574428070 , but know that every peace of software has a bug, and change is a new peace of software ;)