### PR TITLE
[CLI]: Add --skip-unchanged flag for index command #187

### DIFF
--- a/internal/commands/index.go
+++ b/internal/commands/index.go
@@ -11,11 +11,19 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Re-indexes all photos in originals directory (photo library)
+// indexes all photos in originals directory (photo library)
 var IndexCommand = cli.Command{
 	Name:   "index",
-	Usage:  "Re-indexes all originals",
+	Usage:  "indexes all originals",
+	Flags:  indexFlags,
 	Action: indexAction,
+}
+
+var indexFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:  "all, a",
+		Usage: "re-index all originals, including unchanged ones",
+	},
 }
 
 func indexAction(ctx *cli.Context) error {
@@ -45,8 +53,12 @@ func indexAction(ctx *cli.Context) error {
 
 	ind := photoprism.NewIndex(conf, tf, nd)
 
-	opt := photoprism.IndexOptionsAll()
-	files := ind.Start(opt)
+	var files map[string]bool
+	if ctx.Bool("all") {
+		files = ind.Start(photoprism.IndexOptionsAll())
+	} else {
+		files = ind.Start(photoprism.IndexOptionsNone())
+	}
 
 	elapsed := time.Since(start)
 


### PR DESCRIPTION
I took the liberty of taking a first try at this one as I need to create a cron out of it for my gallery.
I've not added a test for this yet, but I can look into verifying which mediafiles were skipped during indexing in `Index.Start`.

### Description
In order to provide the same flexibility as the API, expose the
`SkipUnchanged` flag contained in `IndexOptions`. Although the indexing
process is changing rapidly, and so re-indexing all photos might the
right way to go for now. This flag will be very useful, once indexing is
stable.

For more info refer to https://github.com/photoprism/photoprism/issues/187
