### PR TITLE
Make aware that bcrypt is supported in dockerfile

### DIFF
--- a/docker/photoprism/docker-compose.yml
+++ b/docker/photoprism/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       PHOTOPRISM_DEBUG: "false"
       PHOTOPRISM_READONLY: "false"
       PHOTOPRISM_PUBLIC: "false"
-      PHOTOPRISM_ADMIN_PASSWORD: "photoprism"
+      PHOTOPRISM_ADMIN_PASSWORD: "photoprism" #Also supports bcrypt hashes. Replace all "$" with "$$".
     volumes:
       - "~/Pictures/Originals:/home/photoprism/Pictures/Originals" # [local path]:[container path]
       - "~/Pictures/Import:/home/photoprism/Pictures/Import" # [local path]:[container path] (optional)


### PR DESCRIPTION
Just quickly adding that bcrypt is supported in the dockerfile. I did the edit in the dockerfile linked over at  [docker hub](https://hub.docker.com/r/photoprism/photoprism) Anywhere else this could be stated? 