### PR TITLE
Do not print starting web server before starting web server

### DIFF
--- a/internal/commands/start.go
+++ b/internal/commands/start.go
@@ -106,8 +106,6 @@ func startAction(ctx *cli.Context) error {
 		}
 	}
 
-	log.Infof("starting web server at %s:%d", conf.HttpServerHost(), conf.HttpServerPort())
-
 	if conf.ReadOnly() {
 		log.Infof("read-only mode enabled")
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,6 +40,8 @@ func Start(ctx context.Context, conf *config.Config) {
 	}
 
 	go func() {
+		log.Infof("starting web server at %s", server.Addr)
+
 		if err := server.ListenAndServe(); err != nil {
 			if err == http.ErrServerClosed {
 				log.Info("web server shutdown complete")


### PR DESCRIPTION
Things can go wrong and abort in `server.Start()` before the webserver is
started. This commit will move the log message to where the webserver is
started to avoid confusing a user debugging a problem.

This was motivated by me trying to start the photoprism server and not realizing that the unrelated error `html/template: pattern matches no files:` was recovered by server.Start() *before* it got to `ListenAndServe()` thereby leading me to believe that a web server would indeed be listening when it was not.

This PR simply moves the `log.Infof()` to a point when we're sure we're actually trying to start the webserver.