### PR TITLE
Fix inconsistent naming for PHOTOPRISM_READONLY

### DIFF
--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -26,7 +26,7 @@ var GlobalFlags = []cli.Flag{
 	cli.BoolFlag{
 		Name:   "read-only, r",
 		Usage:  "run in read-only mode",
-		EnvVar: "PHOTOPRISM_READ_ONLY",
+		EnvVar: "PHOTOPRISM_READONLY",
 	},
 	cli.BoolFlag{
 		Name:   "public, p",


### PR DESCRIPTION
The actual name used throughout all Docker and YAML config files is `PHOTOPRISM_READONLY`