### PR TITLE
Parallelize Darktable

### DIFF
--- a/internal/photoprism/convert.go
+++ b/internal/photoprism/convert.go
@@ -112,12 +112,12 @@ func (c *Convert) ConvertCommand(mf *MediaFile, jpegName string, xmpName string)
 			result = exec.Command(c.conf.SipsBin(), "-s", "format", "jpeg", "--out", jpegName, mf.FileName())
 		} else if c.conf.DarktableBin() != "" {
 			// Only one instance of darktable-cli allowed due to locking
-			useMutex = true
+			//useMutex = true
 
 			if xmpName != "" {
-				result = exec.Command(c.conf.DarktableBin(), mf.FileName(), xmpName, jpegName)
+				result = exec.Command(c.conf.DarktableBin(), "--apply-custom-presets", "false", mf.FileName(), xmpName, jpegName)
 			} else {
-				result = exec.Command(c.conf.DarktableBin(), mf.FileName(), jpegName)
+				result = exec.Command(c.conf.DarktableBin(), "--apply-custom-presets", "false", mf.FileName(), jpegName)
 			}
 		} else {
 			return nil, useMutex, fmt.Errorf("convert: no raw to jpeg converter installed (%s)", mf.Base(c.conf.Settings().Index.Group))


### PR DESCRIPTION
By adding the `--apply-custom-presets false` option to the `darktable-cli` command line, Darktable [doesn't read from `data.db`](https://github.com/darktable-org/darktable/blob/release-3.1.0/src/cli/main.c#L248) and so doesn't lock `data.db` and `darktable-cli` can be run in parallel.

It might be a good idea to make this optional but I thought this was a start.