### PR TITLE
Add size cap parameter to Darktable to avoid huge JPEGs

### DIFF
--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -106,6 +106,7 @@ func configAction(ctx *cli.Context) error {
 	fmt.Printf("%-25s %d\n", "thumb-limit", conf.ThumbLimit())
 	fmt.Printf("%-25s %s\n", "thumb-path", conf.ThumbPath())
 	fmt.Printf("%-25s %d\n", "jpeg-quality", conf.JpegQuality())
+	fmt.Printf("%-25s %d\n", "darktable-max-size", conf.DarktableMaxSize())
 
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,3 +254,8 @@ func (c *Config) OriginalsLimit() int64 {
 	// Megabyte.
 	return c.params.OriginalsLimit * 1024 * 1024
 }
+
+// DarktableMaxSize returns the maximum dimension in pixels.
+func (c *Config) DarktableMaxSize() int {
+	return c.params.DarktableMaxSize
+}

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -286,4 +286,10 @@ var GlobalFlags = []cli.Flag{
 		Value:  90,
 		EnvVar: "PHOTOPRISM_JPEG_QUALITY",
 	},
+	cli.IntFlag{
+		Name:   "darktable-max-size",
+		Usage:  "Set to the maximum size of the sidecar images created by Darktable (in pixels), or 0 for no limit",
+		Value:  0,
+		EnvVar: "PHOTOPRISM_DARKTABLE_MAX_SIZE",
+	},
 }

--- a/internal/config/params.go
+++ b/internal/config/params.go
@@ -84,6 +84,7 @@ type Params struct {
 	ThumbSize          int    `yaml:"thumb-size" flag:"thumb-size"`
 	ThumbLimit         int    `yaml:"thumb-limit" flag:"thumb-limit"`
 	JpegQuality        int    `yaml:"jpeg-quality" flag:"jpeg-quality"`
+	DarktableMaxSize   int    `yaml:"darktable-max-size" flag:"darktable-max-size"`
 }
 
 // NewParams creates a new configuration entity by using two methods:

--- a/internal/photoprism/convert.go
+++ b/internal/photoprism/convert.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/karrick/godirwalk"
@@ -113,11 +114,12 @@ func (c *Convert) ConvertCommand(mf *MediaFile, jpegName string, xmpName string)
 		} else if c.conf.DarktableBin() != "" {
 			// Only one instance of darktable-cli allowed due to locking
 			useMutex = true
+			maxSize := strconv.Itoa(c.conf.DarktableMaxSize())
 
 			if xmpName != "" {
-				result = exec.Command(c.conf.DarktableBin(), mf.FileName(), xmpName, jpegName)
+				result = exec.Command(c.conf.DarktableBin(), "--width", maxSize, "--height", maxSize, mf.FileName(), xmpName, jpegName)
 			} else {
-				result = exec.Command(c.conf.DarktableBin(), mf.FileName(), jpegName)
+				result = exec.Command(c.conf.DarktableBin(), "--width", maxSize, "--height", maxSize, mf.FileName(), jpegName)
 			}
 		} else {
 			return nil, useMutex, fmt.Errorf("convert: no raw to jpeg converter installed (%s)", mf.Base(c.conf.Settings().Index.Group))


### PR DESCRIPTION
By default, PhotoPrism leaves the `height` and `width` parameters of `darktable-cli` untouched. When the RAW images are quite large, the JPEGs derived from them can be too (when I gave PhotoPrism my RAWs it ended up writing ~260GB of JPEG previews).

This pull request adds a user-configurable cap that will be propagated through to `darktable-cli`, that can limit the maximum size of the image.

A nice side-effect is that this should also make `darktable-cli` slightly faster, if only because the JPEG encoder has to write a smaller image.