### PR TITLE
Show 12 columns on desktop screens

### DIFF
--- a/frontend/src/component/photo/mosaic.vue
+++ b/frontend/src/component/photo/mosaic.vue
@@ -26,7 +26,7 @@
               :data-uid="photo.UID"
               v-bind:class="{ selected: $clipboard.has(photo) }"
               class="p-photo"
-              xs4 sm3 md2 xl1 d-flex
+              xs4 sm3 md2 lg1 xl1 d-flex
       >
         <v-hover>
           <v-card tile slot-scope="{ hover }"


### PR DESCRIPTION
Fix for issue #453 

Sets 12 columns on large screens (1264px < width < 1904px). Tile sizes on mosaic view don't exceed the default thumbnail size.

