### PR TITLE
Implement archive action in photo viewer

### DIFF
--- a/frontend/src/component/photo/viewer.vue
+++ b/frontend/src/component/photo/viewer.vue
@@ -27,6 +27,11 @@
             <v-icon size="16" color="white">edit</v-icon>
           </button>
 
+          <button class="pswp__button action-archive hidden-shared-only" style="background: none;"
+                  @click.exact="onArchive" :title="$gettext('Archive')">
+            <v-icon size="16" color="white">archive</v-icon>
+          </button>
+
           <button class="pswp__button action-like hidden-shared-only" style="background: none;"
                   @click.exact="onLike" :title="$gettext('Like')">
             <v-icon v-if="item.favorite" size="16" color="white">favorite</v-icon>
@@ -115,6 +120,9 @@
             },
             onLike() {
                 this.item.toggleLike();
+            },
+            onArchive() {
+              this.item.archive().then(() => Notify.success(this.$gettext("Selection archived")));
             },
             onPlay() {
                 if (this.item && this.item.playable) {

--- a/frontend/src/model/thumb.js
+++ b/frontend/src/model/thumb.js
@@ -60,6 +60,11 @@ export class Thumb extends Model {
         }
     }
 
+    archive() {
+        this.favorite = !this.favorite;
+        return Api.post("batch/photos/archive", {"photos": [this.uid]});
+    }
+
     static thumbNotFound() {
         const result = {
             uid: "",


### PR DESCRIPTION
So I just gave it a try in order to better understand the codebase (and fight with WSL2, docker and alpine... ).
This implementation still has some todos:

1. The api does not seem to expose if a photo is currently archived or not. So it is not possible to correctly reflect the button. The correct implementation would be to behave as a toggle, just as the 'like' button does. Depending on the state, the action would alternate between 'archive' and 'restore'. Am I missing something, or do we need to add 'archived' to the API?
2. I used the Notify component, but I just can't seem to figure out where this message is displayed. Feedback for the user really is necessary here, otherwise he will be confused if hitting the button worked. 

What else could be missing?