### PR TITLE
Fix button class action-toggle-fullscreen

### DIFF
--- a/frontend/src/component/photo/viewer.vue
+++ b/frontend/src/component/photo/viewer.vue
@@ -33,7 +33,7 @@
             <v-icon v-else size="16" color="white">favorite_border</v-icon>
           </button>
 
-          <button class="pswp__button pswp__button--fs action-toogle-fullscreen" :title="$gettext('Fullscreen')"></button>
+          <button class="pswp__button pswp__button--fs action-toggle-fullscreen" :title="$gettext('Fullscreen')"></button>
 
           <button class="pswp__button pswp__button--zoom action-zoom" :title="$gettext('Zoom in/out')"></button>
 


### PR DESCRIPTION
This looks like a typo that might also be a problem. But I don't see where `action-toogle-fullscreen` or `action-toggle-fullscreen` is actually used by anything - so maybe it makes no difference?