### PR TITLE
Improve Docker entrypoint signal handling.

### DIFF
--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -33,4 +33,4 @@ RUN photoprism index
 RUN photoprism moments
 
 # Start PhotoPrism server
-CMD photoprism --public start
+CMD ["photoprism", "--public", "start"]

--- a/docker/photoprism/Dockerfile
+++ b/docker/photoprism/Dockerfile
@@ -121,4 +121,4 @@ COPY --chown=root:root /docker/photoprism/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Run server
-CMD photoprism start
+CMD ["photoprism", "start"]

--- a/docker/photoprism/arm64/Dockerfile
+++ b/docker/photoprism/arm64/Dockerfile
@@ -212,4 +212,4 @@ COPY --chown=root:root /docker/photoprism/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Run server
-CMD photoprism start
+CMD ["photoprism", "start"]

--- a/docker/photoprism/arm64/docker-compose.yml
+++ b/docker/photoprism/arm64/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - 2342:2342 # [local port]:[container port]
     # Uncomment the following lines to enable regular health checks (causes automatic restarts):
     # healthcheck:
-    #   test: "photoprism status"
+    #   test: ["CMD", "photoprism", "status"]
     #   interval: 60s
     #   timeout: 15s
     #   retries: 5

--- a/docker/photoprism/docker-compose.yml
+++ b/docker/photoprism/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - 2342:2342 # [local port]:[container port]
     # Uncomment the following lines to enable regular health checks (causes automatic restarts):
     # healthcheck:
-    #   test: "photoprism status"
+    #   test: ["CMD", "photoprism", "status"]
     #   interval: 60s
     #   timeout: 15s
     #   retries: 5

--- a/docker/photoprism/entrypoint.sh
+++ b/docker/photoprism/entrypoint.sh
@@ -15,7 +15,7 @@ else
   "$@" &
 fi
 
-photoprism_pid=$!
+PHOTOPRISM_PID=$!
 
-trap "kill $photoprism_pid" INT TERM
+trap "kill $PHOTOPRISM_PID" INT TERM
 wait

--- a/docker/photoprism/entrypoint.sh
+++ b/docker/photoprism/entrypoint.sh
@@ -7,10 +7,15 @@ fi
 if [[ ${UID} ]] && [[ ${GID} ]] && [[ ${UID} != "0" ]] && [[ $(id -u) = "0" ]]; then
   usermod -u ${UID} photoprism
   usermod -g ${GID} photoprism
-  exec gosu ${UID}:${GID} "$@"
+  gosu ${UID}:${GID} "$@" &
 elif [[ ${UID} ]] && [[ ${UID} != "0" ]] && [[ $(id -u) = "0" ]]; then
   usermod -u ${UID} photoprism
-  exec gosu ${UID} "$@"
+  gosu ${UID} "$@" &
 else
-  exec "$@"
+  "$@" &
 fi
+
+photoprism_pid=$!
+
+trap "kill $photoprism_pid" INT TERM
+wait


### PR DESCRIPTION
The current Docker entrypoint script is responsible for handling any UID/GID switching requested by the user, and then handing off the rest of the container lifecycle to a different program like `gosu`. Now, this new program is responsible for handling incoming signals, like `SIGINT` and `SIGTERM`, since PID 1 is expected to handle these signals and pass them to the right process and PID 1 was replaced during the call to `exec`. 

This would typically be fine since [the `photoprism start` command does signal capturing and processing.](https://github.com/photoprism/photoprism/blob/1f48582a1f15a9554eca40aa69fe5b7fa7b24b02/internal/commands/start.go#L115) However, since the Dockerfile sets the default command as `CMD photoprism start`, this leads the Docker engine to use `/bin/sh -c "photoprism start"` (https://docs.docker.com/engine/reference/builder/#cmd) - meaning that PID 1 would be set to `/bin/sh`, which by default does not have the signal capturing and processing capabilities.

The solution here would either be to modify the Dockerfile to say `CMD ["photoprism", "start"]` or to modify `entrypoint.sh` to process `SIGINT` and `SIGTERM`. I opted to do both since that would cover pretty much every case.

Before:

```
$ docker run --rm --name photoprism -p 2342:2342 -e PHOTOPRISM_ADMIN_PASSWORD=password -e PHOTOPRISM_READONLY=true -v /tmp/photo/appdata:/photoprism/storage -v /tmp/photo/orig:/photoprism/originals:ro photoprism/photoprism:devel
time="2020-10-11T21:03:01Z" level=info msg="read-only mode enabled"
time="2020-10-11T21:03:01Z" level=info msg="webdav: /originals/ waiting for connection"
time="2020-10-11T21:03:01Z" level=info msg="webdav: /import/ not available in read-only mode"
time="2020-10-11T21:03:01Z" level=info msg="starting web server at 0.0.0.0:2342"
^C^C^C^C^C

...

$ docker stop -t 0 photoprism 
photoprism
```

(`docker-compose` has a default stop timeout of 10 seconds when doing `docker-compose down`.)

After:

```
$ docker run --rm --name photoprism -p 2342:2342 -e PHOTOPRISM_ADMIN_PASSWORD=password -e PHOTOPRISM_READONLY=true -v /tmp/photo/appdata:/photoprism/storage -v /tmp/photo/orig:/photoprism/originals:ro photoprism/photoprism:devel
time="2020-10-11T21:03:01Z" level=info msg="read-only mode enabled"
time="2020-10-11T21:03:01Z" level=info msg="webdav: /originals/ waiting for connection"
time="2020-10-11T21:03:01Z" level=info msg="webdav: /import/ not available in read-only mode"
time="2020-10-11T21:03:01Z" level=info msg="starting web server at 0.0.0.0:2342"
^Ctime="2020-10-11T21:03:02Z" level=info msg="shutting down..."
time="2020-10-11T21:03:02Z" level=info msg="shutting down workers"
time="2020-10-11T21:03:02Z" level=info msg="closed database connection"
time="2020-10-11T21:03:02Z" level=info msg="shutting down web server"
time="2020-10-11T21:03:02Z" level=info msg="web server shutdown complete"
```