### PR TITLE
Move advance search arrow next to search bar

### DIFF
--- a/frontend/src/component/photo/toolbar.vue
+++ b/frontend/src/component/photo/toolbar.vue
@@ -14,6 +14,10 @@
                     @click:clear="clearQuery"
                     @keyup.enter.native="filterChange"
       ></v-text-field>
+      <v-btn icon class="p-expand-search" :title="$gettext('Expand Search')"
+             @click.stop="searchExpanded = !searchExpanded">
+        <v-icon>{{ searchExpanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}</v-icon>
+      </v-btn>
 
       <v-spacer></v-spacer>
 
@@ -36,10 +40,6 @@
         <v-icon>cloud_upload</v-icon>
       </v-btn>
 
-      <v-btn icon class="p-expand-search" :title="$gettext('Expand Search')"
-             @click.stop="searchExpanded = !searchExpanded">
-        <v-icon>{{ searchExpanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}</v-icon>
-      </v-btn>
     </v-toolbar>
 
     <v-card v-show="searchExpanded"


### PR DESCRIPTION
Hey, 
here is a teeny tiny PR, to dip my toes in the water...

I just discovered photoprism, really nice job, hope you guys can keep up the good work and grow this open ecosystem 👍 
so, back to this PR... 
I found that it's kinda weird that the expand search button is THAT far from the search field, 

here is a proposal to make it closer, to respect the "locality" in UX...

What do you think?

PIC:
<img width="896" alt="image" src="https://user-images.githubusercontent.com/177003/99914483-f2653880-2cfd-11eb-85ae-7236f13918dc.png">

