### PR TITLE
Fix type in nginx docs

### DIFF
--- a/frontend/src/pages/help/websockets.vue
+++ b/frontend/src/pages/help/websockets.vue
@@ -46,7 +46,7 @@ ProxyRequests off
             <pre>
 http {
   server {
-    server_mame example.com
+    server_name example.com
     client_max_body_size 500M;
     
     location / {


### PR DESCRIPTION
Fix small typo in nginx documentation: `server_mame` => `server_name`