### PR TITLE
Upgrading to tensorflow 2.x

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -80,7 +80,7 @@ RUN sh -c "echo 'deb http://download.opensuse.org/repositories/home:/pmdpalma:/U
 ENV LD_LIBRARY_PATH /root/.local/lib:/usr/local/lib:/usr/lib:/lib
 ENV TF_CPP_MIN_LOG_LEVEL 0
 RUN curl -L \
-   "https://dl.photoprism.org/tensorflow/linux/libtensorflow-linux-cpu-1.15.2.tar.gz" | \
+   "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-2.3.1.tar.gz" | \
    tar -C "/usr" -xz
 RUN ldconfig
 

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
 	github.com/studio-b12/gowebdav v0.0.0-20200929080739-bdacfab94796
-	github.com/tensorflow/tensorflow v1.15.2
+	github.com/tensorflow/tensorflow v2.1.0+incompatible
 	github.com/tidwall/gjson v1.6.4
 	github.com/tidwall/match v1.0.2 // indirect
 	github.com/ulule/deepcopier v0.0.0-20200430083143-45decc6639b6

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,12 @@ github.com/studio-b12/gowebdav v0.0.0-20200929080739-bdacfab94796 h1:vkok9HUaplV
 github.com/studio-b12/gowebdav v0.0.0-20200929080739-bdacfab94796/go.mod h1:gCcfDlA1Y7GqOaeEKw5l9dOGx1VLdc/HuQSlQAaZ30s=
 github.com/tensorflow/tensorflow v1.15.2 h1:7/f/A664Tml/nRJg04+p3StcrsT53mkcvmxYHXI21Qo=
 github.com/tensorflow/tensorflow v1.15.2/go.mod h1:itOSERT4trABok4UOoG+X4BoKds9F3rIsySdn+Lvu90=
+github.com/tensorflow/tensorflow v2.1.0+incompatible h1:piL4AzfPuv67+gbsKo2IhIecCe4ILpN0294O8ZrxneI=
+github.com/tensorflow/tensorflow v2.1.0+incompatible/go.mod h1:itOSERT4trABok4UOoG+X4BoKds9F3rIsySdn+Lvu90=
+github.com/tensorflow/tensorflow v2.3.1+incompatible h1:44Q8jLdwktDbzAaP6QuRWFl8oAk3a6DE15CJ7t5eGD4=
+github.com/tensorflow/tensorflow v2.3.1+incompatible/go.mod h1:itOSERT4trABok4UOoG+X4BoKds9F3rIsySdn+Lvu90=
+github.com/tensorflow/tensorflow v2.4.0+incompatible h1:ctP9NUX0hXaNw0TMsCfgLguNoy9wIaKkw02LJFtqnQc=
+github.com/tensorflow/tensorflow v2.4.0+incompatible/go.mod h1:itOSERT4trABok4UOoG+X4BoKds9F3rIsySdn+Lvu90=
 github.com/tidwall/gjson v1.6.3 h1:aHoiiem0dr7GHkW001T1SMTJ7X5PvyekH5WX0whWGnI=
 github.com/tidwall/gjson v1.6.3/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
 github.com/tidwall/gjson v1.6.4 h1:JKsCsJqRVFz8eYCsQ5E/ANRbK6CanAtA9IUvGsXklyo=


### PR DESCRIPTION
This is a draft PR for now primarily to explore and discuss what is needed to upgrade to tensorflow 2.x.

I've identified the following things so far:

- I think there isn't yet an official release of go-tensorflow for the 2.x version? All of the 2.x versions [here](https://pkg.go.dev/github.com/tensorflow/tensorflow@v2.4.0+incompatible/tensorflow/go?tab=versions) have an `+incompatible` tag. One can still depend on these but I wonder what that exactly means?
- The most recent [pre-built](https://www.tensorflow.org/install/lang_c) tensorflow C library is 2.3.1 but the go package for this version [fails to install](https://github.com/tensorflow/tensorflow/issues/41808). Hence I am using the go package for 2.1.0 but version 2.3.1 of the C library.

### Open questions

- I think CI is using the latest development image from docker hub and hence not picking up my changes to the Dockerfile. As such, I don't think it is actually linking against tensorflow 2.3.1. Should I be sending a separate PR for updating the development image?
- The tests seem to pass already by just upgrading to the latest go package. Maybe we can:
1. Merge this without the Dockerfile changes
2. Update the docker images to have the new tensorflow version
3. Use the new docker images in CI

Thinking about it, we should probably first release new versions of the docker images and then upgrade the tensorflow go dependency + docker image in one patch.