### PR TITLE
Remove use of string-strip-html

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7887,20 +7887,10 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "optional": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -7924,20 +7914,10 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
-    "lodash.trim": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
-      "integrity": "sha1-NkJefukL5KpeJ7zruFt9EepHqlc="
-    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
-    "lodash.without": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -11109,37 +11089,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
-    "ranges-apply": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ranges-apply/-/ranges-apply-3.2.3.tgz",
-      "integrity": "sha512-lc5jJU3ecZZyY3oifVziIR40rzbK7lTHn+l5iAKTg0yQdR43wj5UtpVqW57Zt3eWSuQI6wqa2RNhdk5FNCPZOA==",
-      "requires": {
-        "ranges-merge": "^5.0.3"
-      }
-    },
-    "ranges-merge": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/ranges-merge/-/ranges-merge-5.0.3.tgz",
-      "integrity": "sha512-UPV4IZVpySzOK8MVfPY8VhMPpT/WKG2V/9HCar3e4zM7h97ml2BKKfkdCcR2PgqGEUDLJr25dElKDo94/5tIMw==",
-      "requires": {
-        "ranges-sort": "^3.13.3"
-      }
-    },
-    "ranges-push": {
-      "version": "3.7.22",
-      "resolved": "https://registry.npmjs.org/ranges-push/-/ranges-push-3.7.22.tgz",
-      "integrity": "sha512-stqx+AKzEl/62QdbGhn6pKO5dWFf5H5xT59y14KrruUn+QW2M6skq5jsJ3RdpKpmYVDfjGnOiQGL12bzb7xcPw==",
-      "requires": {
-        "ranges-merge": "^5.0.3",
-        "string-collapse-leading-whitespace": "^3.0.2",
-        "string-trim-spaces-only": "^2.8.23"
-      }
-    },
-    "ranges-sort": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/ranges-sort/-/ranges-sort-3.13.3.tgz",
-      "integrity": "sha512-5S9d5SHb3/phG3EaniXqR9hJiN5EnQjityNRktq3XIxt0TDnouB8glWb61QANZFYdGQ70A5YUNQ8eX/Jmlw6nQ=="
-    },
     "raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
@@ -12475,44 +12424,11 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string-collapse-leading-whitespace": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/string-collapse-leading-whitespace/-/string-collapse-leading-whitespace-3.0.2.tgz",
-      "integrity": "sha512-1+cuXaqe4d9ut/evICLjHcg5AAWwLKu3mMRhSBrhb4Z+lzAWN8sVspHraZad8FrBc8XJ3bzsjknSN5aMCO4tkg=="
-    },
     "string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
       "optional": true
-    },
-    "string-left-right": {
-      "version": "2.3.31",
-      "resolved": "https://registry.npmjs.org/string-left-right/-/string-left-right-2.3.31.tgz",
-      "integrity": "sha512-xsMj1WXOpqPEwPC1pVULyXXZuegyx0f4H07L7QafkyC+S60c2D7h8ANb3qoywaQ9exJYqA1l6wz0Q1oTsbXs9Q==",
-      "requires": {
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isplainobject": "^4.0.6"
-      }
-    },
-    "string-strip-html": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-4.5.1.tgz",
-      "integrity": "sha512-8zyUgZgehIoBWMUYuxZ75RoMWOKc1xlDi18sdENYnF3oI9XUUfK+9o1e7trEQ7SP8yEsMAvema7/oG/oEbb6lQ==",
-      "requires": {
-        "ent": "^2.2.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.trim": "^4.5.1",
-        "lodash.without": "^4.4.0",
-        "ranges-apply": "^3.1.11",
-        "ranges-push": "^3.7.15",
-        "string-left-right": "^2.3.25"
-      }
-    },
-    "string-trim-spaces-only": {
-      "version": "2.8.23",
-      "resolved": "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-2.8.23.tgz",
-      "integrity": "sha512-MQAksLUGqogkq8qjDBjsASojgEZUZKU2S+cYvH0u9yXrJUWUih9YuNfFK0RtIxSiRvS/dPg9V44dR8GO4nEn5w=="
     },
     "string-width": {
       "version": "4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,7 +105,6 @@
     "sass-loader": "^7.3.1",
     "sinon": "^9.2.2",
     "sockette": "^2.0.6",
-    "string-strip-html": "^4.5.1",
     "style-loader": "^0.23.1",
     "sugarss": "^2.0.0",
     "svg-url-loader": "^5.0.1",

--- a/frontend/src/common/util.js
+++ b/frontend/src/common/util.js
@@ -125,4 +125,8 @@ export default class Util {
       return str;
     }
   }
+
+  static encodeHTML(text) {
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
+  }
 }

--- a/frontend/src/common/viewer.js
+++ b/frontend/src/common/viewer.js
@@ -31,7 +31,7 @@ https://docs.photoprism.org/developer-guide/
 import PhotoSwipe from "photoswipe";
 import PhotoSwipeUI_Default from "photoswipe/dist/photoswipe-ui-default.js";
 import Event from "pubsub-js";
-import stripHtml from "string-strip-html";
+import Util from "./util"
 
 const thumbs = window.__CONFIG__.thumbs;
 
@@ -125,7 +125,7 @@ class Viewer {
           return false;
         }
 
-        captionEl.children[0].innerHTML = stripHtml(item.title);
+        captionEl.children[0].innerHTML = Util.encodeHTML(item.title);
 
         if (item.playable) {
           captionEl.children[0].innerHTML +=
@@ -134,7 +134,7 @@ class Viewer {
 
         if (item.description) {
           captionEl.children[0].innerHTML +=
-            '<br><span class="description">' + stripHtml(item.description) + "</span>";
+            '<br><span class="description">' + Util.encodeHTML(item.description) + "</span>";
         }
 
         if (item.playable) {


### PR DESCRIPTION
Closes https://github.com/photoprism/photoprism/issues/826.

This removes a dozen npm packages from the frontend bundle by using our own `encodeHTML` function [as suggested in the OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-1-html-encode-before-inserting-untrusted-data-into-html-element-content).