### PR TITLE
Update package-lock to fully remove moment

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8562,11 +8562,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",


### PR DESCRIPTION
Both `Chart.js` and `moment-timezone` had dependencies on `moment`, so it wasn't fully removed with either of those PRs individually