### PR TITLE
Update gitignore for static assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /frontend/tests/screenshots
 /assets/nasnet
 /assets/nsfw
+/assets/static/build/
 /package-lock.json
 /frontend/tests_output
 *.log

--- a/assets/static/build/.gitignore
+++ b/assets/static/build/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
It's helpful to me to be able to run `rm -rf assets/static/build/` while testing changes to the frontend. I can't easily do that right now because I end up deleting `assets/static/build/.gitignore`. I was hoping we could move the ignore of that directory into the main `.gitignore`