### PR TITLE
Migrate from deprecated slot-scoped syntax

### DIFF
--- a/frontend/src/component/photo/cards.vue
+++ b/frontend/src/component/photo/cards.vue
@@ -28,8 +28,8 @@
           xs12 sm6 md4 lg3 xlg2 xxxl1 d-flex
           :class="{ 'is-selected': photo.Selected, portrait: photo.Portrait }"
       >
-        <v-hover>
-          <v-card slot-scope="{ hover }" tile
+        <v-hover v-slot="{ hover }">
+          <v-card tile
                   :dark="photo.Selected"
                   :class="photo.Selected ? 'selected elevation-10 ma-0 accent darken-1 white--text select-transition' : 'elevation-0 ma-1 accent lighten-3 select-transition'"
                   @contextmenu="onContextMenu($event, index)">

--- a/frontend/src/component/photo/mosaic.vue
+++ b/frontend/src/component/photo/mosaic.vue
@@ -28,8 +28,8 @@
           class="p-photo"
           xs4 sm3 md2 lg1 d-flex
       >
-        <v-hover>
-          <v-card slot-scope="{ hover }" tile
+        <v-hover v-slot="{ hover }">
+          <v-card tile
                   :class="photo.Selected ? 'selected elevation-10 ma-0 select-transition' : 'elevation-0 ma-1 select-transition'"
                   :title="photo.Title"
                   @contextmenu="onContextMenu($event, index)">

--- a/frontend/src/pages/albums.vue
+++ b/frontend/src/pages/albums.vue
@@ -85,8 +85,8 @@
               class="p-album"
               xs6 sm4 md3 lg2 xxl1 d-flex
           >
-            <v-hover>
-              <v-card slot-scope="{ hover }" tile
+            <v-hover v-slot="{ hover }">
+              <v-card tile
                       class="accent lighten-3"
                       :dark="selection.includes(album.UID)"
                       :class="selection.includes(album.UID) ? 'elevation-10 ma-0 accent darken-1 white--text' : 'elevation-0 ma-1 accent lighten-3'"

--- a/frontend/src/pages/discover/colors.vue
+++ b/frontend/src/pages/discover/colors.vue
@@ -14,9 +14,9 @@
 
             xs3 d-flex grow
         >
-          <v-hover>
+          <v-hover v-slot="{ hover }">
             <v-card :to="{name: 'photos', query: { color: color.name }}" :dark="useDark(color)"
-                    :color="color.example" slot-scope="{ hover }" :flat="!hover"
+                    :color="color.example" :flat="!hover"
                     class="clickable py-1">
               <v-card-text class="px-0 py-5 body-2">{{ color.label }}</v-card-text>
             </v-card>

--- a/frontend/src/pages/labels.vue
+++ b/frontend/src/pages/labels.vue
@@ -62,8 +62,8 @@
               :data-uid="label.UID"
               xs6 sm4 md3 lg2 xxl1 d-flex
           >
-            <v-hover>
-              <v-card slot-scope="{ hover }" tile
+            <v-hover v-slot="{ hover }">
+              <v-card tile
                       class="accent lighten-3"
                       :dark="selection.includes(label.UID)"
                       :class="selection.includes(label.UID) ? 'elevation-10 ma-0 accent darken-1 white--text' : 'elevation-0 ma-1 accent lighten-3'"

--- a/frontend/src/pages/library/files.vue
+++ b/frontend/src/pages/library/files.vue
@@ -52,8 +52,8 @@
               class="p-file"
               xs6 sm4 md3 lg2 xxl1 d-flex
           >
-            <v-hover>
-              <v-card slot-scope="{ hover }" tile
+            <v-hover v-slot="{ hover }">
+              <v-card tile
                       class="accent lighten-3 clickable"
                       :dark="selection.includes(model.UID)"
                       :class="selection.includes(model.UID) ? 'elevation-10 ma-0 darken-1 white--text' : 'elevation-0 ma-1 lighten-3'"

--- a/frontend/src/share/albums.vue
+++ b/frontend/src/share/albums.vue
@@ -36,8 +36,8 @@
               class="p-album"
               xs6 sm4 md3 lg2 xxl1 d-flex
           >
-            <v-hover>
-              <v-card slot-scope="{ hover }" tile
+            <v-hover v-slot="{ hover }">
+              <v-card tile
                       class="accent lighten-3"
                       :dark="selection.includes(album.UID)"
                       :class="selection.includes(album.UID) ? 'elevation-10 ma-0 accent darken-1 white--text' : 'elevation-0 ma-1 accent lighten-3'"

--- a/frontend/src/share/photo/cards.vue
+++ b/frontend/src/share/photo/cards.vue
@@ -24,8 +24,8 @@
           xs12 sm6 md4 lg3 xlg2 xxxl1 d-flex
           :class="{ 'is-selected': photo.Selected, portrait: photo.Portrait }"
       >
-        <v-hover>
-          <v-card slot-scope="{ hover }" tile
+        <v-hover v-slot="{ hover }">
+          <v-card tile
                   :dark="photo.Selected"
                   :class="photo.Selected ? 'selected elevation-10 ma-0 accent darken-1 white--text select-transition' : 'elevation-0 ma-1 accent lighten-3 select-transition'"
                   @contextmenu="onContextMenu($event, index)">

--- a/frontend/src/share/photo/mosaic.vue
+++ b/frontend/src/share/photo/mosaic.vue
@@ -24,8 +24,8 @@
           class="p-photo"
           xs4 sm3 md2 lg1 d-flex
       >
-        <v-hover>
-          <v-card slot-scope="{ hover }" tile
+        <v-hover v-slot="{ hover }">
+          <v-card tile
                   :class="photo.Selected ? 'selected elevation-10 ma-0 select-transition' : 'elevation-0 ma-1 select-transition'"
                   :title="photo.Title"
                   @contextmenu="onContextMenu($event, index)">


### PR DESCRIPTION
I was having quite a bit of difficulty understanding some of the Vue documentation since we were using a deprecated syntax, so I wanted to update it to make it easier to follow. I tested this a little, but would appreciate if you could test it as well since you know the application better