### PR TITLE
Migrate templates containing both slot and slot-scope

### DIFF
--- a/frontend/src/component/photo/list.vue
+++ b/frontend/src/component/photo/list.vue
@@ -31,7 +31,7 @@
                   item-key="ID"
                   :no-data-text="notFoundMessage"
     >
-      <template slot="items" slot-scope="props">
+      <template v-slot:items="props">
         <td style="user-select: none;" :data-uid="props.item.UID" class="result" :class="props.item.classes()">
           <v-img :key="props.item.Hash"
                  :src="props.item.thumbnailUrl('tile_50')"

--- a/frontend/src/pages/settings/sync.vue
+++ b/frontend/src/pages/settings/sync.vue
@@ -10,7 +10,7 @@
         item-key="ID"
         :no-data-text="$gettext('No servers configured.')"
     >
-      <template slot="items" slot-scope="props" class="p-account">
+      <template v-slot:items="props" class="p-account">
         <td>
           <button class="secondary-dark--text" @click.stop.prevent="edit(props.item)">
             {{ props.item.AccName }}

--- a/frontend/src/share/photo/list.vue
+++ b/frontend/src/share/photo/list.vue
@@ -27,7 +27,7 @@
                   item-key="ID"
                   :no-data-text="notFoundMessage"
     >
-      <template slot="items" slot-scope="props">
+      <template slot:items="props">
         <td style="user-select: none;" :data-uid="props.item.UID" class="result" :class="props.item.classes()">
           <v-img :key="props.item.Hash"
                  :src="props.item.thumbnailUrl('tile_50')"


### PR DESCRIPTION
The old syntax was deprecated in Vue 2.6. This makes it a lot easier to follow the Vue documentation

I tested that the page renders. Not sure if there's anything else I would need to test