### PR TITLE
Migrate from deprecated slot syntax

### DIFF
--- a/frontend/src/component/album/clipboard.vue
+++ b/frontend/src/component/album/clipboard.vue
@@ -10,15 +10,17 @@
           :left="rtl"
           :class="`p-clipboard ${!rtl ? '--ltr' : '--rtl'} p-album-clipboard`"
       >
-        <v-btn
-            slot="activator" fab
-            dark
-            color="accent darken-2"
-            class="action-menu"
-        >
-          <v-icon v-if="selection.length === 0">menu</v-icon>
-          <span v-else class="count-clipboard">{{ selection.length }}</span>
-        </v-btn>
+        <template v-slot:activator>
+          <v-btn
+              fab
+              dark
+              color="accent darken-2"
+              class="action-menu"
+          >
+            <v-icon v-if="selection.length === 0">menu</v-icon>
+            <span v-else class="count-clipboard">{{ selection.length }}</span>
+          </v-btn>
+        </template>
 
         <v-btn
             v-if="$config.feature('share')" fab dark

--- a/frontend/src/component/file/clipboard.vue
+++ b/frontend/src/component/file/clipboard.vue
@@ -11,15 +11,17 @@
           :left="rtl"
           :class="`p-clipboard ${!rtl ? '--ltr' : '--rtl'} p-file-clipboard`"
       >
-        <v-btn
-            slot="activator" fab
-            dark
-            color="accent darken-2"
-            class="action-menu"
-        >
-          <v-icon v-if="selection.length === 0">menu</v-icon>
-          <span v-else class="count-clipboard">{{ selection.length }}</span>
-        </v-btn>
+        <template v-slot:activator>
+          <v-btn
+              fab
+              dark
+              color="accent darken-2"
+              class="action-menu"
+          >
+            <v-icon v-if="selection.length === 0">menu</v-icon>
+            <span v-else class="count-clipboard">{{ selection.length }}</span>
+          </v-btn>
+        </template>
 
         <v-btn
             v-if="$config.feature('download')" fab dark

--- a/frontend/src/component/label/clipboard.vue
+++ b/frontend/src/component/label/clipboard.vue
@@ -11,15 +11,17 @@
           :left="rtl"
           :class="`p-clipboard ${!rtl ? '--ltr' : '--rtl'} p-label-clipboard`"
       >
-        <v-btn
-            slot="activator" fab
-            dark
-            color="accent darken-2"
-            class="action-menu"
-        >
-          <v-icon v-if="selection.length === 0">menu</v-icon>
-          <span v-else class="count-clipboard">{{ selection.length }}</span>
-        </v-btn>
+        <template v-slot:activator>
+          <v-btn
+              fab
+              dark
+              color="accent darken-2"
+              class="action-menu"
+          >
+            <v-icon v-if="selection.length === 0">menu</v-icon>
+            <span v-else class="count-clipboard">{{ selection.length }}</span>
+          </v-btn>
+        </template>
 
         <!-- v-btn
                 fab

--- a/frontend/src/component/navigation.vue
+++ b/frontend/src/component/navigation.vue
@@ -72,14 +72,16 @@
         </v-list-tile>
 
         <v-list-group v-if="!isMini" prepend-icon="image_search" no-action>
-          <v-list-tile slot="activator" to="/browse" class="nav-browse" @click.stop="">
-            <v-list-tile-content>
-              <v-list-tile-title>
-                <translate key="Search">Search</translate>
-                <span v-if="config.count.all > 0" :class="`nav-count ${rtl ? '--rtl' : ''}`">{{ config.count.all }}</span>
-              </v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
+          <template v-slot:activator>
+            <v-list-tile to="/browse" class="nav-browse" @click.stop="">
+              <v-list-tile-content>
+                <v-list-tile-title>
+                  <translate key="Search">Search</translate>
+                  <span v-if="config.count.all > 0" :class="`nav-count ${rtl ? '--rtl' : ''}`">{{ config.count.all }}</span>
+                </v-list-tile-title>
+              </v-list-tile-content>
+            </v-list-tile>
+          </template>
 
           <v-list-tile :to="{name: 'browse', query: { q: 'mono:true quality:3 photo:true' }}" :exact="true" @click.stop="">
             <v-list-tile-content>
@@ -146,14 +148,16 @@
         </v-list-tile>
 
         <v-list-group v-if="!isMini && $config.feature('albums')" prepend-icon="photo_album" no-action>
-          <v-list-tile slot="activator" to="/albums" class="nav-albums" @click.stop="">
-            <v-list-tile-content>
-              <v-list-tile-title>
-                <translate key="Albums">Albums</translate>
-                <span v-if="config.count.albums > 0" :class="`nav-count ${rtl ? '--rtl' : ''}`">{{ config.count.albums }}</span>
-              </v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
+          <template v-slot:activator>
+            <v-list-tile to="/albums" class="nav-albums" @click.stop="">
+              <v-list-tile-content>
+                <v-list-tile-title>
+                  <translate key="Albums">Albums</translate>
+                  <span v-if="config.count.albums > 0" :class="`nav-count ${rtl ? '--rtl' : ''}`">{{ config.count.albums }}</span>
+                </v-list-tile-title>
+              </v-list-tile-content>
+            </v-list-tile>
+          </template>
 
           <v-list-tile to="/unsorted" class="nav-unsorted">
             <v-list-tile-content>
@@ -246,15 +250,17 @@
         </v-list-tile>
 
         <v-list-group v-if="!isMini" v-show="$config.feature('places')" prepend-icon="place" no-action>
-          <v-list-tile slot="activator" to="/places" class="nav-places" @click.stop="">
-            <v-list-tile-content>
-              <v-list-tile-title>
-                <translate key="Places">Places</translate>
-                <span v-show="config.count.places > 0"
-                      :class="`nav-count ${rtl ? '--rtl' : ''}`">{{ config.count.places }}</span>
-              </v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
+          <template v-slot:activator>
+            <v-list-tile to="/places" class="nav-places" @click.stop="">
+              <v-list-tile-content>
+                <v-list-tile-title>
+                  <translate key="Places">Places</translate>
+                  <span v-show="config.count.places > 0"
+                        :class="`nav-count ${rtl ? '--rtl' : ''}`">{{ config.count.places }}</span>
+                </v-list-tile-title>
+              </v-list-tile-content>
+            </v-list-tile>
+          </template>
 
           <v-list-tile to="/states" class="nav-states" @click.stop="">
             <v-list-tile-content>
@@ -307,13 +313,15 @@
         </v-list-tile>
 
         <v-list-group v-if="!isMini && $config.feature('library')" prepend-icon="camera_roll" no-action>
-          <v-list-tile slot="activator" to="/library" class="nav-library" @click.stop="">
-            <v-list-tile-content>
-              <v-list-tile-title>
-                <translate key="Library">Library</translate>
-              </v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
+          <template v-slot:activator>
+            <v-list-tile to="/library" class="nav-library" @click.stop="">
+              <v-list-tile-content>
+                <v-list-tile-title>
+                  <translate key="Library">Library</translate>
+                </v-list-tile-title>
+              </v-list-tile-content>
+            </v-list-tile>
+          </template>
 
           <v-list-tile v-show="$config.feature('files')" to="/library/files" class="nav-originals" @click.stop="">
             <v-list-tile-content>
@@ -356,13 +364,15 @@
           </v-list-tile>
 
           <v-list-group v-else prepend-icon="settings" no-action>
-            <v-list-tile slot="activator" to="/settings" class="nav-settings" @click.stop="">
-              <v-list-tile-content>
-                <v-list-tile-title>
-                  <translate key="Settings">Settings</translate>
-                </v-list-tile-title>
-              </v-list-tile-content>
-            </v-list-tile>
+            <template v-slot:activator>
+              <v-list-tile to="/settings" class="nav-settings" @click.stop="">
+                <v-list-tile-content>
+                  <v-list-tile-title>
+                    <translate key="Settings">Settings</translate>
+                  </v-list-tile-title>
+                </v-list-tile-content>
+              </v-list-tile>
+            </template>
 
             <v-list-tile :to="{ name: 'about' }" :exact="true" class="nav-about" @click.stop="">
               <v-list-tile-content>

--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -10,15 +10,17 @@
           :left="rtl"
           :class="`p-clipboard ${!rtl ? '--ltr' : '--rtl'} p-photo-clipboard`"
       >
-        <v-btn
-            slot="activator" fab
-            dark
-            color="accent darken-2"
-            class="action-menu"
-        >
-          <v-icon v-if="selection.length === 0">menu</v-icon>
-          <span v-else class="count-clipboard">{{ selection.length }}</span>
-        </v-btn>
+        <template v-slot:activator>
+          <v-btn
+              fab
+              dark
+              color="accent darken-2"
+              class="action-menu"
+          >
+            <v-icon v-if="selection.length === 0">menu</v-icon>
+            <span v-else class="count-clipboard">{{ selection.length }}</span>
+          </v-btn>
+        </template>
 
         <v-btn
             v-if="context !== 'archive' && context !== 'review' && config.settings.features.share" fab dark

--- a/frontend/src/share/album/clipboard.vue
+++ b/frontend/src/share/album/clipboard.vue
@@ -9,15 +9,16 @@
           class="p-clipboard p-album-clipboard"
           id="t-clipboard"
       >
-        <v-btn
-            fab dark
-            slot="activator"
-            color="accent darken-2"
-            class="action-menu"
-        >
-          <v-icon v-if="selection.length === 0">menu</v-icon>
-          <span v-else class="count-clipboard">{{ selection.length }}</span>
-        </v-btn>
+        <template v-slot:activator>
+          <v-btn
+              fab dark
+              color="accent darken-2"
+              class="action-menu"
+          >
+            <v-icon v-if="selection.length === 0">menu</v-icon>
+            <span v-else class="count-clipboard">{{ selection.length }}</span>
+          </v-btn>
+        </template>
 
         <v-btn
             fab dark small

--- a/frontend/src/share/photo/clipboard.vue
+++ b/frontend/src/share/photo/clipboard.vue
@@ -9,15 +9,17 @@
           transition="slide-y-reverse-transition"
           class="p-clipboard p-photo-clipboard"
       >
-        <v-btn
-            slot="activator" fab
-            dark
-            color="accent darken-2"
-            class="action-menu"
-        >
-          <v-icon v-if="selection.length === 0">menu</v-icon>
-          <span v-else class="count-clipboard">{{ selection.length }}</span>
-        </v-btn>
+        <template v-slot:activator>
+          <v-btn
+              fab
+              dark
+              color="accent darken-2"
+              class="action-menu"
+          >
+            <v-icon v-if="selection.length === 0">menu</v-icon>
+            <span v-else class="count-clipboard">{{ selection.length }}</span>
+          </v-btn>
+        </template>
 
         <v-btn
             v-if="context !== 'archive'" fab dark


### PR DESCRIPTION
This syntax appears to be one where Vuetify does use the new syntax in the docs at least in 2.0: https://vuetifyjs.com/en/getting-started/upgrade-guide/#activators