### PR TITLE
optimize photos search sql request

### DIFF
--- a/internal/query/photo_search.go
+++ b/internal/query/photo_search.go
@@ -37,9 +37,9 @@ func PhotoSearch(f form.PhotoSearch) (results PhotoResults, count int, err error
 		lenses.lens_make, lenses.lens_model,
 		places.place_label, places.place_city, places.place_state, places.place_country`).
 		Joins("JOIN files ON photos.id = files.photo_id AND files.file_missing = 0 AND files.deleted_at IS NULL").
-		Joins("JOIN cameras ON photos.camera_id = cameras.id").
-		Joins("JOIN lenses ON photos.lens_id = lenses.id").
-		Joins("JOIN places ON photos.place_id = places.id")
+		Joins("LEFT JOIN cameras ON photos.camera_id = cameras.id").
+		Joins("LEFT JOIN lenses ON photos.lens_id = lenses.id").
+		Joins("LEFT JOIN places ON photos.place_id = places.id")
 
 	if !f.Hidden {
 		s = s.Where("files.file_type = 'jpg' OR files.file_video = 1")


### PR DESCRIPTION
My local PhotoPrism database has about 19k photos. And retrieving of the list of photos works too slow (2.3 - 4 seconds for 360 items in mosaic mode). I looked at the query plan and found something strange: request plan starts from retrieving the whole table "cameras" and all other tables joins to this table.

Original request and its plan:
```
SELECT photos.*,   files.id AS file_id, files.file_uid, files.instance_id, files.file_primary, files.file_missing, files.file_name,   files.file_root, files.file_hash, files.file_codec, files.file_type, files.file_mime, files.file_width,   files.file_height, files.file_portrait, files.file_aspect_ratio, files.file_orientation, files.file_main_color,   files.file_colors, files.file_luminance, files.file_chroma, files.file_projection,   files.file_diff, files.file_video, files.file_duration, files.file_size,   cameras.camera_make, cameras.camera_model,   lenses.lens_make, lenses.lens_model,   places.place_label, places.place_city, places.place_state, places.place_country FROM `photos` JOIN files ON photos.id = files.photo_id AND files.file_missing = 0 AND files.deleted_at IS NULL JOIN cameras ON photos.camera_id = cameras.id JOIN lenses ON photos.lens_id = lenses.id JOIN places ON photos.place_id = places.id WHERE (files.file_type = 'jpg' OR files.file_video = 1) AND (files.file_error = '') AND (photos.deleted_at IS NULL) AND (photos.photo_private = 0) AND (photos.photo_quality >= 3) AND (photos.photo_type IN ('image','raw','live')) ORDER BY photos.id DESC, files.file_primary DESC LIMIT 360 OFFSET 0;

360 rows in set (2.366 sec)
+------+-------------+---------+------------+--------------------------------------------------------------------------+----------------------------------------------+---------+----------------------------+-----------+--------------------------------------------------------+
| id   | select_type | table   | type       | possible_keys                                                            | key                                          | key_len | ref                        | rows      | Extra                                                  |
+------+-------------+---------+------------+--------------------------------------------------------------------------+----------------------------------------------+---------+----------------------------+-----------+--------------------------------------------------------+
|    1 | SIMPLE      | cameras | ALL        | PRIMARY                                                                  | NULL                                         | NULL    | NULL                       | 44        | Using temporary; Using filesort                        |
|    1 | SIMPLE      | photos  | ref|filter | PRIMARY,idx_photos_place_id,idx_photos_deleted_at,idx_photos_camera_lens | idx_photos_camera_lens|idx_photos_deleted_at | 5|6     | photoprism.cameras.id      | 229 (50%) | Using index condition; Using where; Using rowid filter |
|    1 | SIMPLE      | places  | eq_ref     | PRIMARY                                                                  | PRIMARY                                      | 44      | photoprism.photos.place_id | 1         |                                                        |
|    1 | SIMPLE      | lenses  | eq_ref     | PRIMARY                                                                  | PRIMARY                                      | 4       | photoprism.photos.lens_id  | 1         |                                                        |
|    1 | SIMPLE      | files   | ref|filter | idx_files_deleted_at,idx_files_photo_id                                  | idx_files_photo_id|idx_files_deleted_at      | 5|6     | photoprism.photos.id       | 1 (50%)   | Using where; Using rowid filter                        |
+------+-------------+---------+------------+--------------------------------------------------------------------------+----------------------------------------------+---------+----------------------------+-----------+--------------------------------------------------------+
```

Default JOIN in MySQL in INNER JOIN. In this request INNER JOIN equals to LEFT JOIN for cameras, places and lenses tables  because photos table has no null links to theese tables. I tried replace JOIN with LEFT JOIN and gоt a significant speedup (0.4s vs 2.4s in my case).
Request with LEFT JOINs and its plan:
```
SELECT photos.*,   files.id AS file_id, files.file_uid, files.instance_id, files.file_primary, files.file_missing, files.file_name,   files.file_root, files.file_hash, files.file_codec, files.file_type, files.file_mime, files.file_width,   files.file_height, files.file_portrait, files.file_aspect_ratio, files.file_orientation, files.file_main_color,   files.file_colors, files.file_luminance, files.file_chroma, files.file_projection,   files.file_diff, files.file_video, files.file_duration, files.file_size,   cameras.camera_make, cameras.camera_model,   lenses.lens_make, lenses.lens_model,   places.place_label, places.place_city, places.place_state, places.place_country FROM `photos` JOIN files ON photos.id = files.photo_id AND files.file_missing = 0 AND files.deleted_at IS NULL LEFT JOIN cameras ON photos.camera_id = cameras.id LEFT JOIN lenses ON photos.lens_id = lenses.id LEFT JOIN places ON photos.place_id = places.id WHERE (files.file_type = 'jpg' OR files.file_video = 1) AND (files.file_error = '') AND (photos.deleted_at IS NULL) AND (photos.photo_private = 0) AND (photos.photo_quality >= 3) AND (photos.photo_type IN ('image','raw','live')) ORDER BY photos.id DESC, files.file_primary DESC LIMIT 360 OFFSET 0;

360 rows in set (0.397 sec)
+------+-------------+---------+--------+-----------------------------------------+--------------------+---------+-----------------------------+-------+----------------------------------------------------+
| id   | select_type | table   | type   | possible_keys                           | key                | key_len | ref                         | rows  | Extra                                              |
+------+-------------+---------+--------+-----------------------------------------+--------------------+---------+-----------------------------+-------+----------------------------------------------------+
|    1 | SIMPLE      | files   | range  | idx_files_deleted_at,idx_files_photo_id | idx_files_photo_id | 5       | NULL                        | 10802 | Using index condition; Using where; Using filesort |
|    1 | SIMPLE      | photos  | eq_ref | PRIMARY,idx_photos_deleted_at           | PRIMARY            | 4       | photoprism.files.photo_id   | 1     | Using where                                        |
|    1 | SIMPLE      | cameras | eq_ref | PRIMARY                                 | PRIMARY            | 4       | photoprism.photos.camera_id | 1     | Using where                                        |
|    1 | SIMPLE      | lenses  | eq_ref | PRIMARY                                 | PRIMARY            | 4       | photoprism.photos.lens_id   | 1     | Using where                                        |
|    1 | SIMPLE      | places  | eq_ref | PRIMARY                                 | PRIMARY            | 44      | photoprism.photos.place_id  | 1     | Using where                                        |
+------+-------------+---------+--------+-----------------------------------------+--------------------+---------+-----------------------------+-------+----------------------------------------------------+
```
This plan looks logical: mysql chooses and filters records from photos and files tables, and in the end joins data from cameras, lenses and places tables. 