### PR TITLE
Dockerfile: reduce number of layers

### DIFF
--- a/docker/photoprism/Dockerfile
+++ b/docker/photoprism/Dockerfile
@@ -14,11 +14,11 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND noninteractive
 
 # Configure apt-get
-RUN echo 'Acquire::Retries "10";' > /etc/apt/apt.conf.d/80retry
-RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/80recommends
-RUN echo 'APT::Install-Suggests "false";' > /etc/apt/apt.conf.d/80suggests
-RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/80forceyes
-RUN echo 'APT::Get::Fix-Missing "true";' > /etc/apt/apt.conf.d/80fixmissin
+RUN echo 'Acquire::Retries "10";' > /etc/apt/apt.conf.d/80retry && \
+    echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/80recommends && \
+    echo 'APT::Install-Suggests "false";' > /etc/apt/apt.conf.d/80suggests && \
+    echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/80forceyes && \
+    echo 'APT::Get::Fix-Missing "true";' > /etc/apt/apt.conf.d/80fixmissin
 
 # Install additional distribution packages
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
We can use one Docker layer instead of 5:

```
7 /bin/sh -c echo 'Acquire::Retries "10";' 204 B
8 /bin/sh -c echo 'APT::Install-Recommends "false";' 217 B
9 /bin/sh -c echo 'APT::Install-Suggests "false";' 213 B
10 /bin/sh -c echo 'APT::Get::Assume-Yes "true";' 216 B
11 /bin/sh -c echo 'APT::Get::Fix-Missing "true";' 216 B
```

See the layers here:https://hub.docker.com/layers/photoprism/photoprism/20210111/images/sha256-1b5c2e4e618dcef9a50c29cf14f6197c1864d5626fea713fb37edd95ff9ac101?context=explore