### PR TITLE
API: Add support for search queries with incremental updates

### DIFF
--- a/internal/api/batch.go
+++ b/internal/api/batch.go
@@ -65,7 +65,7 @@ func BatchPhotosArchive(router *gin.RouterGroup) {
 			log.Errorf("archive: %s", err)
 			AbortSaveFailed(c)
 			return
-		} else if err := entity.Db().Model(&entity.PhotoAlbum{}).Where("photo_uid IN (?)", f.Photos).UpdateColumn("hidden", true).Error; err != nil {
+		} else if err := entity.Db().Model(&entity.PhotoAlbum{}).Where("photo_uid IN (?)", f.Photos).Update("hidden", true).Error; err != nil {
 			log.Errorf("archive: %s", err)
 		}
 
@@ -125,7 +125,7 @@ func BatchPhotosRestore(router *gin.RouterGroup) {
 				}
 			}
 		} else if err := entity.Db().Unscoped().Model(&entity.Photo{}).Where("photo_uid IN (?)", f.Photos).
-			UpdateColumn("deleted_at", gorm.Expr("NULL")).Error; err != nil {
+			Update("deleted_at", gorm.Expr("NULL")).Error; err != nil {
 			log.Errorf("restore: %s", err)
 			AbortSaveFailed(c)
 			return
@@ -263,7 +263,7 @@ func BatchPhotosPrivate(router *gin.RouterGroup) {
 
 		log.Infof("photos: updating private flag for %s", clean.Log(f.String()))
 
-		if err := entity.Db().Model(entity.Photo{}).Where("photo_uid IN (?)", f.Photos).UpdateColumn("photo_private",
+		if err := entity.Db().Model(entity.Photo{}).Where("photo_uid IN (?)", f.Photos).Update("photo_private",
 			gorm.Expr("CASE WHEN photo_private > 0 THEN 0 ELSE 1 END")).Error; err != nil {
 			log.Errorf("private: %s", err)
 			AbortSaveFailed(c)

--- a/internal/api/db.go
+++ b/internal/api/db.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/photoprism/photoprism/internal/acl"
+	"github.com/photoprism/photoprism/internal/form"
+	"github.com/photoprism/photoprism/internal/query"
+)
+
+// GET /api/v1/db
+func GetTable(router *gin.RouterGroup) {
+	router.GET("/db", func(c *gin.Context) {
+		s := Auth(c, acl.ResourceDefault, acl.ActionView)
+
+		if s.Invalid() {
+			AbortUnauthorized(c)
+			return
+		}
+
+		var f form.DbSearch
+
+		err := c.MustBindWith(&f, binding.Form)
+
+		if err != nil {
+			AbortBadRequest(c)
+			return
+		}
+
+		if f.Table == "photos" {
+			result, err := query.TablePhotos(f)
+			if err != nil {
+				AbortEntityNotFound(c)
+				return
+			}
+			c.JSON(http.StatusOK, result)
+		} else if f.Table == "files" {
+			result, err := query.TableFiles(f)
+			if err != nil {
+				AbortEntityNotFound(c)
+				return
+			}
+			c.JSON(http.StatusOK, result)
+		} else if f.Table == "albums" {
+			result, err := query.TableAlbums(f)
+			if err != nil {
+				AbortEntityNotFound(c)
+				return
+			}
+			c.JSON(http.StatusOK, result)
+		} else if f.Table == "photos_albums" {
+			result, err := query.TablePhotosAlbums(f)
+			if err != nil {
+				AbortEntityNotFound(c)
+				return
+			}
+			c.JSON(http.StatusOK, result)
+		} else {
+
+			AbortEntityNotFound(c)
+		}
+	})
+}

--- a/internal/api/db.go
+++ b/internal/api/db.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -9,6 +10,11 @@ import (
 	"github.com/photoprism/photoprism/internal/form"
 	"github.com/photoprism/photoprism/internal/query"
 )
+
+type dbResult struct {
+	QueryTimestamp time.Time
+	Results        interface{}
+}
 
 // GET /api/v1/db
 func GetTable(router *gin.RouterGroup) {
@@ -29,37 +35,37 @@ func GetTable(router *gin.RouterGroup) {
 			return
 		}
 
-		if f.Table == "photos" {
-			result, err := query.TablePhotos(f)
-			if err != nil {
-				AbortEntityNotFound(c)
-				return
-			}
-			c.JSON(http.StatusOK, result)
-		} else if f.Table == "files" {
-			result, err := query.TableFiles(f)
-			if err != nil {
-				AbortEntityNotFound(c)
-				return
-			}
-			c.JSON(http.StatusOK, result)
-		} else if f.Table == "albums" {
-			result, err := query.TableAlbums(f)
-			if err != nil {
-				AbortEntityNotFound(c)
-				return
-			}
-			c.JSON(http.StatusOK, result)
-		} else if f.Table == "photos_albums" {
-			result, err := query.TablePhotosAlbums(f)
-			if err != nil {
-				AbortEntityNotFound(c)
-				return
-			}
-			c.JSON(http.StatusOK, result)
-		} else {
+		var result dbResult
+		result.QueryTimestamp = time.Now()
 
+		if f.Table == "photos" {
+			result.Results, err = query.TablePhotos(f)
+			if err != nil {
+				AbortEntityNotFound(c)
+				return
+			}
+		} else if f.Table == "files" {
+			result.Results, err = query.TableFiles(f)
+			if err != nil {
+				AbortEntityNotFound(c)
+				return
+			}
+		} else if f.Table == "albums" {
+			result.Results, err = query.TableAlbums(f)
+			if err != nil {
+				AbortEntityNotFound(c)
+				return
+			}
+		} else if f.Table == "photos_albums" {
+			result.Results, err = query.TablePhotosAlbums(f)
+			if err != nil {
+				AbortEntityNotFound(c)
+				return
+			}
+		} else {
 			AbortEntityNotFound(c)
+			return
 		}
+		c.JSON(http.StatusOK, result)
 	})
 }

--- a/internal/entity/auth_session.go
+++ b/internal/entity/auth_session.go
@@ -487,7 +487,7 @@ func (m *Session) UpdateLastActive() *Session {
 
 	m.LastActive = UnixTime()
 
-	if err := Db().Model(m).UpdateColumn("LastActive", m.LastActive).Error; err != nil {
+	if err := Db().Model(m).Update("LastActive", m.LastActive).Error; err != nil {
 		event.AuditWarn([]string{m.IP(), "session %s", "failed to update last active time", "%s"}, m.RefID, err)
 	}
 

--- a/internal/entity/cell.go
+++ b/internal/entity/cell.go
@@ -123,7 +123,7 @@ func (m *Cell) Refresh(api string) (err error) {
 		log.Tracef("index: cell %s keeps place_id %s", m.ID, m.PlaceID)
 	} else if err := UnscopedDb().Table(Photo{}.TableName()).
 		Where("place_id = ?", oldPlaceID).
-		UpdateColumn("place_id", m.PlaceID).
+		Update("place_id", m.PlaceID).
 		Error; err != nil {
 		log.Warnf("index: %s while changing place_id from %s to %s", err, oldPlaceID, m.PlaceID)
 	}

--- a/internal/entity/entity_counts.go
+++ b/internal/entity/entity_counts.go
@@ -56,7 +56,7 @@ func UpdatePlacesCounts() (err error) {
 
 	// Update places.
 	res := Db().Table("places").
-		UpdateColumn("photo_count", gorm.Expr("(SELECT COUNT(*) FROM photos p "+
+		Update("photo_count", gorm.Expr("(SELECT COUNT(*) FROM photos p "+
 			"WHERE places.id = p.place_id "+
 			"AND p.photo_quality > -1 "+
 			"AND p.photo_private = 0 "+
@@ -99,7 +99,7 @@ func UpdateSubjectCounts() (err error) {
 	case SQLite3:
 		// Update files count.
 		res = Db().Table(subjTable).
-			UpdateColumn("file_count", gorm.Expr("(SELECT COUNT(DISTINCT f.id) FROM files f "+
+			Update("file_count", gorm.Expr("(SELECT COUNT(DISTINCT f.id) FROM files f "+
 				fmt.Sprintf("JOIN %s m ON f.file_uid = m.file_uid AND m.subj_uid = %s.subj_uid ",
 					markerTable, subjTable)+" WHERE m.marker_invalid = 0 AND f.deleted_at IS NULL) WHERE ?", condition))
 
@@ -108,7 +108,7 @@ func UpdateSubjectCounts() (err error) {
 			return res.Error
 		} else {
 			photosRes := Db().Table(subjTable).
-				UpdateColumn("photo_count", gorm.Expr("(SELECT COUNT(DISTINCT f.photo_id) FROM files f "+
+				Update("photo_count", gorm.Expr("(SELECT COUNT(DISTINCT f.photo_id) FROM files f "+
 					fmt.Sprintf("JOIN %s m ON f.file_uid = m.file_uid AND m.subj_uid = %s.subj_uid ",
 						markerTable, subjTable)+" WHERE m.marker_invalid = 0 AND f.deleted_at IS NULL) WHERE ?", condition))
 			res.RowsAffected += photosRes.RowsAffected
@@ -150,7 +150,7 @@ func UpdateLabelCounts() (err error) {
 	} else if IsDialect(SQLite3) {
 		res = Db().
 			Table("labels").
-			UpdateColumn("photo_count",
+			Update("photo_count",
 				gorm.Expr(`(SELECT photo_count FROM (SELECT label_id, SUM(photo_count) AS photo_count FROM (
 				SELECT l.id AS label_id, COUNT(*) AS photo_count FROM labels l
 					JOIN photos_labels pl ON pl.label_id = l.id

--- a/internal/entity/face.go
+++ b/internal/entity/face.go
@@ -109,7 +109,7 @@ func (m *Face) SetEmbeddings(embeddings face.Embeddings) (err error) {
 // Matched updates the match timestamp.
 func (m *Face) Matched() error {
 	m.MatchedAt = TimePointer()
-	return UnscopedDb().Model(m).UpdateColumns(Values{"MatchedAt": m.MatchedAt}).Error
+	return UnscopedDb().Model(m).Updates(Values{"MatchedAt": m.MatchedAt}).Error
 }
 
 // Embedding returns parsed face embedding.
@@ -278,7 +278,7 @@ func (m *Face) SetSubjectUID(subjUid string) (err error) {
 		Where("subj_src = ?", SrcAuto).
 		Where("subj_uid <> ?", m.SubjUID).
 		Where("marker_invalid = 0").
-		UpdateColumns(Values{"subj_uid": m.SubjUID, "marker_review": false}).Error; err != nil {
+		Updates(Values{"subj_uid": m.SubjUID, "marker_review": false}).Error; err != nil {
 		return err
 	}
 
@@ -337,7 +337,7 @@ func (m *Face) Delete() error {
 	// Remove face id from markers before deleting.
 	if err := Db().Model(&Marker{}).
 		Where("face_id = ?", m.ID).
-		UpdateColumns(Values{"face_id": "", "face_dist": -1}).Error; err != nil {
+		Updates(Values{"face_id": "", "face_dist": -1}).Error; err != nil {
 		return err
 	}
 

--- a/internal/entity/file.go
+++ b/internal/entity/file.go
@@ -348,7 +348,7 @@ func (m *File) ReplaceHash(newHash string) error {
 	for name, entity := range entities {
 		start := time.Now()
 
-		if res := UnscopedDb().Model(entity).Where("thumb = ?", oldHash).UpdateColumn("thumb", newHash); res.Error != nil {
+		if res := UnscopedDb().Model(entity).Where("thumb = ?", oldHash).Update("thumb", newHash); res.Error != nil {
 			return res.Error
 		} else if res.RowsAffected > 0 {
 			log.Infof("%s: updated %s [%s]", name, english.Plural(int(res.RowsAffected), "cover", "covers"), time.Since(start))
@@ -470,12 +470,12 @@ func (m *File) UpdateVideoInfos() error {
 
 // Update updates a column in the database.
 func (m *File) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // Updates multiple columns in the database.
 func (m *File) Updates(values interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumns(values).Error
+	return UnscopedDb().Model(m).Updates(values).Error
 }
 
 // Rename updates the name and path of this file.
@@ -759,7 +759,7 @@ func (m *File) UpdatePhotoFaceCount() (c int, err error) {
 
 	err = UnscopedDb().Model(Photo{}).
 		Where("id = ?", m.PhotoID).
-		UpdateColumn("photo_faces", c).Error
+		Update("photo_faces", c).Error
 
 	return c, err
 }

--- a/internal/entity/file_share.go
+++ b/internal/entity/file_share.go
@@ -46,12 +46,12 @@ func NewFileShare(fileID, accountID uint, remoteName string) *FileShare {
 
 // Updates multiple columns in the database.
 func (m *FileShare) Updates(values interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumns(values).Error
+	return UnscopedDb().Model(m).Updates(values).Error
 }
 
 // Update updates a column value in the database.
 func (m *FileShare) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // Save updates the record in the database or inserts a new record if it does not already exist.

--- a/internal/entity/file_sync.go
+++ b/internal/entity/file_sync.go
@@ -46,12 +46,12 @@ func NewFileSync(accountID uint, remoteName string) *FileSync {
 
 // Updates multiple columns in the database.
 func (m *FileSync) Updates(values interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumns(values).Error
+	return UnscopedDb().Model(m).Updates(values).Error
 }
 
 // Update a column in the database.
 func (m *FileSync) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // Save updates the record in the database or inserts a new record if it does not already exist.

--- a/internal/entity/keyword.go
+++ b/internal/entity/keyword.go
@@ -34,12 +34,12 @@ func NewKeyword(keyword string) *Keyword {
 
 // Updates multiple columns in the database.
 func (m *Keyword) Updates(values interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumns(values).Error
+	return UnscopedDb().Model(m).Updates(values).Error
 }
 
 // Update a column in the database.
 func (m *Keyword) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // Save updates the record in the database or inserts a new record if it does not already exist.

--- a/internal/entity/label.go
+++ b/internal/entity/label.go
@@ -124,7 +124,7 @@ func (m *Label) Restore() error {
 
 // Update a label property in the database.
 func (m *Label) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // FirstOrCreateLabel returns the existing label, inserts a new label or nil in case of errors.

--- a/internal/entity/link.go
+++ b/internal/entity/link.go
@@ -82,7 +82,7 @@ func NewUserLink(shareUid, userUid string) Link {
 func (m *Link) Redeem() *Link {
 	m.LinkViews += 1
 
-	if err := Db().Model(m).UpdateColumn("link_views", gorm.Expr("link_views + 1")).Error; err != nil {
+	if err := Db().Model(m).Update("link_views", gorm.Expr("link_views + 1")).Error; err != nil {
 		event.AuditWarn([]string{"link %s", "failed to update view counter"}, clean.Log(m.RefID), err)
 	}
 

--- a/internal/entity/marker.go
+++ b/internal/entity/marker.go
@@ -132,7 +132,7 @@ func (m *Marker) UpdateFile(file *File) (updated bool) {
 
 	if !updated || m.MarkerUID == "" {
 		return false
-	} else if err := UnscopedDb().Model(m).UpdateColumns(Values{"file_uid": m.FileUID, "thumb": m.Thumb}).Error; err != nil {
+	} else if err := UnscopedDb().Model(m).Updates(Values{"file_uid": m.FileUID, "thumb": m.Thumb}).Error; err != nil {
 		log.Errorf("faces: failed assigning marker %s to file %s (%s)", m.MarkerUID, m.FileUID, err)
 		return false
 	} else {
@@ -341,7 +341,7 @@ func (m *Marker) SyncSubject(updateRelated bool) (err error) {
 	// Update related markers?
 	if m.FaceID == "" || m.SubjUID == "" {
 		// Do nothing.
-	} else if res := Db().Model(&Face{}).Where("id = ? AND subj_uid = ''", m.FaceID).UpdateColumn("subj_uid", m.SubjUID); res.Error != nil {
+	} else if res := Db().Model(&Face{}).Where("id = ? AND subj_uid = ''", m.FaceID).Update("subj_uid", m.SubjUID); res.Error != nil {
 		return fmt.Errorf("%s (update known face)", err)
 	} else if !updateRelated {
 		return nil
@@ -350,7 +350,7 @@ func (m *Marker) SyncSubject(updateRelated bool) (err error) {
 		Where("face_id = ?", m.FaceID).
 		Where("subj_src = ?", SrcAuto).
 		Where("subj_uid <> ?", m.SubjUID).
-		UpdateColumns(Values{"subj_uid": m.SubjUID, "subj_src": SrcAuto, "marker_review": false}).Error; err != nil {
+		Updates(Values{"subj_uid": m.SubjUID, "subj_src": SrcAuto, "marker_review": false}).Error; err != nil {
 		return fmt.Errorf("%s (update related markers)", err)
 	} else if res.RowsAffected > 0 && m.face != nil {
 		log.Debugf("markers: matched %s with %s", subj.SubjName, m.FaceID)
@@ -575,7 +575,7 @@ func (m *Marker) RefreshPhotos() error {
 // Matched updates the match timestamp.
 func (m *Marker) Matched() error {
 	m.MatchedAt = TimePointer()
-	return UnscopedDb().Model(m).UpdateColumns(Values{"MatchedAt": m.MatchedAt}).Error
+	return UnscopedDb().Model(m).Updates(Values{"MatchedAt": m.MatchedAt}).Error
 }
 
 // Top returns the top Y coordinate as float64.

--- a/internal/entity/photo.go
+++ b/internal/entity/photo.go
@@ -719,7 +719,7 @@ func (m *Photo) AllFiles() (files Files) {
 func (m *Photo) Archive() error {
 	deletedAt := TimeStamp()
 
-	if err := Db().Model(&PhotoAlbum{}).Where("photo_uid = ?", m.PhotoUID).UpdateColumn("hidden", true).Error; err != nil {
+	if err := Db().Model(&PhotoAlbum{}).Where("photo_uid = ?", m.PhotoUID).Update("hidden", true).Error; err != nil {
 		return err
 	} else if err := m.Update("deleted_at", deletedAt); err != nil {
 		return err
@@ -802,12 +802,12 @@ func (m *Photo) NoDescription() bool {
 
 // Update a column in the database.
 func (m *Photo) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // Updates multiple columns in the database.
 func (m *Photo) Updates(values interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumns(values).Error
+	return UnscopedDb().Model(m).Updates(values).Error
 }
 
 // React adds or updates a user reaction.
@@ -934,10 +934,10 @@ func (m *Photo) SetPrimary(fileUid string) (err error) {
 
 	if err = Db().Model(File{}).
 		Where("photo_uid = ? AND file_uid <> ?", m.PhotoUID, fileUid).
-		UpdateColumn("file_primary", 0).Error; err != nil {
+		Update("file_primary", 0).Error; err != nil {
 		return err
 	} else if err = Db().Model(File{}).Where("photo_uid = ? AND file_uid = ?", m.PhotoUID, fileUid).
-		UpdateColumn("file_primary", 1).Error; err != nil {
+		Update("file_primary", 1).Error; err != nil {
 		return err
 	} else if m.PhotoQuality < 0 {
 		m.PhotoQuality = 0

--- a/internal/entity/photo_label.go
+++ b/internal/entity/photo_label.go
@@ -36,12 +36,12 @@ func NewPhotoLabel(photoID, labelID uint, uncertainty int, source string) *Photo
 
 // Updates multiple columns in the database.
 func (m *PhotoLabel) Updates(values interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumns(values).Error
+	return UnscopedDb().Model(m).Updates(values).Error
 }
 
 // Update a column in the database.
 func (m *PhotoLabel) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // Save updates the record in the database or inserts a new record if it does not already exist.

--- a/internal/entity/reaction.go
+++ b/internal/entity/reaction.go
@@ -93,7 +93,7 @@ func (m *Reaction) Save() (err error) {
 
 	if err = Db().Model(Reaction{}).
 		Where("uid = ? AND user_uid = ?", m.UID, m.UserUID).
-		UpdateColumns(values).Error; err == nil {
+		Updates(values).Error; err == nil {
 		m.Reacted += 1
 		m.ReactedAt = reactedAt
 	}

--- a/internal/entity/service.go
+++ b/internal/entity/service.go
@@ -210,12 +210,12 @@ func (m *Service) Directories() (result fs.FileInfos, err error) {
 
 // Updates multiple columns in the database.
 func (m *Service) Updates(values interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumns(values).Error
+	return UnscopedDb().Model(m).Updates(values).Error
 }
 
 // Update a column in the database.
 func (m *Service) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // Save updates the record in the database or inserts a new record if it does not already exist.

--- a/internal/entity/subject.go
+++ b/internal/entity/subject.go
@@ -167,7 +167,7 @@ func (m *Subject) Restore() error {
 			})
 		}
 
-		return UnscopedDb().Model(m).UpdateColumn("DeletedAt", nil).Error
+		return UnscopedDb().Model(m).Update("DeletedAt", nil).Error
 	}
 
 	return nil
@@ -175,7 +175,7 @@ func (m *Subject) Restore() error {
 
 // Update updates an entity value in the database.
 func (m *Subject) Update(attr string, value interface{}) error {
-	return UnscopedDb().Model(m).UpdateColumn(attr, value).Error
+	return UnscopedDb().Model(m).Update(attr, value).Error
 }
 
 // Updates multiple values in the database.
@@ -403,7 +403,7 @@ func (m *Subject) UpdateMarkerNames() error {
 	if err := Db().Model(&Marker{}).
 		Where("subj_uid = ? AND subj_src <> ?", m.SubjUID, SrcAuto).
 		Where("marker_name <> ?", m.SubjName).
-		UpdateColumn("marker_name", m.SubjName).Error; err != nil {
+		Update("marker_name", m.SubjName).Error; err != nil {
 		return err
 	}
 
@@ -444,11 +444,11 @@ func (m *Subject) MergeWith(other *Subject) error {
 	// Update markers and faces with new SubjUID.
 	if err := Db().Model(&Marker{}).
 		Where("subj_uid = ?", m.SubjUID).
-		UpdateColumn("subj_uid", other.SubjUID).Error; err != nil {
+		Update("subj_uid", other.SubjUID).Error; err != nil {
 		return err
 	} else if err := Db().Model(&Face{}).
 		Where("subj_uid = ?", m.SubjUID).
-		UpdateColumn("subj_uid", other.SubjUID).Error; err != nil {
+		Update("subj_uid", other.SubjUID).Error; err != nil {
 		return err
 	} else if err := other.UpdateMarkerNames(); err != nil {
 		return err

--- a/internal/form/db_search.go
+++ b/internal/form/db_search.go
@@ -1,0 +1,28 @@
+package form
+
+import "time"
+
+// DbSearch represents search form fields for "/api/v1/db".
+type DbSearch struct {
+	Query   string    `form:"q"`
+	Table   string    `form:"table" binding:"required"`
+	Deleted bool      `form:"deleted"`
+	Since   time.Time `form:"since"`
+	Count   uint16    `form:"count" binding:"required"`
+}
+
+func (f *DbSearch) GetQuery() string {
+	return f.Query
+}
+
+func (f *DbSearch) SetQuery(q string) {
+	f.Query = q
+}
+
+func (f *DbSearch) ParseQueryString() error {
+	return ParseQueryString(f)
+}
+
+func NewDbSearch(query string) DbSearch {
+	return DbSearch{Query: query}
+}

--- a/internal/form/db_search.go
+++ b/internal/form/db_search.go
@@ -4,11 +4,11 @@ import "time"
 
 // DbSearch represents search form fields for "/api/v1/db".
 type DbSearch struct {
-	Query   string    `form:"q"`
-	Table   string    `form:"table" binding:"required"`
-	Deleted bool      `form:"deleted"`
-	Since   time.Time `form:"since"`
-	Count   uint16    `form:"count" binding:"required"`
+	Query  string    `form:"q"`
+	Table  string    `form:"table" binding:"required"`
+	Offset uint      `form:"offset"`
+	Since  time.Time `form:"since"`
+	Count  uint16    `form:"count" binding:"required"`
 }
 
 func (f *DbSearch) GetQuery() string {

--- a/internal/query/covers.go
+++ b/internal/query/covers.go
@@ -35,7 +35,7 @@ func UpdateAlbumDefaultCovers() (err error) {
 		SET thumb = b.file_hash WHERE ?`, condition)
 	case SQLite3:
 		res = Db().Table(entity.Album{}.TableName()).
-			UpdateColumn("thumb", gorm.Expr(`(
+			Update("thumb", gorm.Expr(`(
 		SELECT f.file_hash FROM files f 
 			JOIN photos_albums pa ON pa.album_uid = albums.album_uid AND pa.photo_uid = f.photo_uid AND pa.hidden = 0 AND pa.missing = 0
 			JOIN photos p ON p.id = f.photo_id AND p.photo_private = 0 AND p.deleted_at IS NULL AND p.photo_quality > 0
@@ -81,7 +81,7 @@ func UpdateAlbumFolderCovers() (err error) {
 			) b ON b.photo_path = albums.album_path
 		SET thumb = b.file_hash WHERE ?`, condition)
 	case SQLite3:
-		res = Db().Table(entity.Album{}.TableName()).UpdateColumn("thumb", gorm.Expr(`(
+		res = Db().Table(entity.Album{}.TableName()).Update("thumb", gorm.Expr(`(
 		SELECT f.file_hash FROM files f,(
 			SELECT p.photo_path, max(p.id) AS photo_id FROM photos p
 			  WHERE p.photo_quality > 0 AND p.photo_private = 0 AND p.deleted_at IS NULL
@@ -129,7 +129,7 @@ func UpdateAlbumMonthCovers() (err error) {
 			) b ON b.photo_year = albums.album_year AND b.photo_month = albums.album_month
 		SET thumb = b.file_hash WHERE ?`, condition)
 	case SQLite3:
-		res = Db().Table(entity.Album{}.TableName()).UpdateColumn("thumb", gorm.Expr(`(
+		res = Db().Table(entity.Album{}.TableName()).Update("thumb", gorm.Expr(`(
 		SELECT f.file_hash FROM files f,(
 			SELECT p.photo_year, p.photo_month, max(p.id) AS photo_id FROM photos p
 			  WHERE p.photo_quality > 0 AND p.photo_private = 0 AND p.deleted_at IS NULL
@@ -205,7 +205,7 @@ func UpdateLabelCovers() (err error) {
 		) b ON b.label_id = labels.id
 		SET thumb = b.file_hash WHERE ?`, condition)
 	case SQLite3:
-		res = Db().Table(entity.Label{}.TableName()).UpdateColumn("thumb", gorm.Expr(`(
+		res = Db().Table(entity.Label{}.TableName()).Update("thumb", gorm.Expr(`(
 		SELECT f.file_hash FROM files f 
 			JOIN photos_labels pl ON pl.label_id = labels.id AND pl.photo_id = f.photo_id AND pl.uncertainty < 100
 			JOIN photos p ON p.id = f.photo_id AND p.photo_private = 0 AND p.deleted_at IS NULL AND p.photo_quality > 0
@@ -214,7 +214,7 @@ func UpdateLabelCovers() (err error) {
 		) WHERE ?`, condition))
 
 		if res.Error == nil {
-			catRes := Db().Table(entity.Label{}.TableName()).UpdateColumn("thumb", gorm.Expr(`(
+			catRes := Db().Table(entity.Label{}.TableName()).Update("thumb", gorm.Expr(`(
 			SELECT f.file_hash FROM files f 
 			JOIN photos_labels pl ON pl.photo_id = f.photo_id AND pl.uncertainty < 100
 			JOIN categories c ON c.label_id = pl.label_id AND c.category_id = labels.id
@@ -272,7 +272,7 @@ func UpdateSubjectCovers() (err error) {
 		SET thumb = marker_thumb WHERE ?`, gorm.Expr(subjTable), gorm.Expr(markerTable), condition)
 	case SQLite3:
 		from := gorm.Expr(fmt.Sprintf("%s m WHERE m.subj_uid = %s.subj_uid ", markerTable, subjTable))
-		res = Db().Table(entity.Subject{}.TableName()).UpdateColumn("thumb", gorm.Expr(`(
+		res = Db().Table(entity.Subject{}.TableName()).Update("thumb", gorm.Expr(`(
 		SELECT m.thumb FROM ? AND m.thumb <> '' ORDER BY m.subj_src DESC, m.q DESC LIMIT 1
 		) WHERE ?`, from, condition))
 	default:

--- a/internal/query/db.go
+++ b/internal/query/db.go
@@ -1,0 +1,50 @@
+package query
+
+import (
+	"time"
+
+	"github.com/jinzhu/gorm"
+	"github.com/photoprism/photoprism/internal/entity"
+	"github.com/photoprism/photoprism/internal/form"
+)
+
+func filterAndSort(in *gorm.DB, deleted bool, since time.Time, count uint16) (out *gorm.DB) {
+	if deleted {
+		out = in.Where("deleted_at IS NOT NULL AND deleted_at >= ?", since).Order("deleted_at ASC")
+	} else {
+		out = in.Where("updated_at >= ?", since).Order("updated_at ASC")
+	}
+	return out.Limit(count)
+}
+
+// TablePhotos gets all entries from photos table
+func TablePhotos(f form.DbSearch) (photos []entity.Photo, err error) {
+	s := Db().Unscoped().Table("photos")
+	s = filterAndSort(s, f.Deleted, f.Since, f.Count)
+	result := s.Find(&photos)
+	return photos, result.Error
+}
+
+// TableFiles gets all entries from files table
+func TableFiles(f form.DbSearch) (files []entity.File, err error) {
+	s := Db().Unscoped().Table("files")
+	s = filterAndSort(s, f.Deleted, f.Since, f.Count)
+	result := s.Find(&files)
+	return files, result.Error
+}
+
+// TableAlbums gets all entries from albums table
+func TableAlbums(f form.DbSearch) (albums []entity.Album, err error) {
+	s := Db().Unscoped().Table("albums")
+	s = filterAndSort(s, f.Deleted, f.Since, f.Count)
+	result := s.Find(&albums)
+	return albums, result.Error
+}
+
+// TablePhotosAlbums gets all entries from photos_albums table
+func TablePhotosAlbums(f form.DbSearch) (photosAlbums []entity.PhotoAlbum, err error) {
+	s := Db().Unscoped().Table("photos_albums")
+	s = filterAndSort(s, f.Deleted, f.Since, f.Count)
+	result := s.Find(&photosAlbums)
+	return photosAlbums, result.Error
+}

--- a/internal/query/faces.go
+++ b/internal/query/faces.go
@@ -81,7 +81,7 @@ func MatchFaceMarkers() (affected int64, err error) {
 			Where("face_id = ?", f.ID).
 			Where("subj_src = ?", entity.SrcAuto).
 			Where("subj_uid <> ?", f.SubjUID).
-			UpdateColumns(entity.Values{"subj_uid": f.SubjUID, "marker_review": false}); res.Error != nil {
+			Updates(entity.Values{"subj_uid": f.SubjUID, "marker_review": false}); res.Error != nil {
 			return affected, err
 		} else if res.RowsAffected > 0 {
 			affected += res.RowsAffected
@@ -299,7 +299,7 @@ func RemovePeopleAndFaces() (err error) {
 
 	// Reset face counters.
 	if err = UnscopedDb().Model(entity.Photo{}).
-		UpdateColumn("photo_faces", 0).Error; err != nil {
+		Update("photo_faces", 0).Error; err != nil {
 		return err
 	}
 

--- a/internal/query/faces_test.go
+++ b/internal/query/faces_test.go
@@ -89,7 +89,7 @@ func TestMatchFaceMarkers(t *testing.T) {
 	if err := Db().Model(&entity.Marker{}).
 		Where("subj_src = ?", entity.SrcAuto).
 		Where("subj_uid = ?", "jqu0xs11qekk9jx8").
-		UpdateColumn("subj_uid", "").Error; err != nil {
+		Update("subj_uid", "").Error; err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/query/files.go
+++ b/internal/query/files.go
@@ -142,11 +142,11 @@ func SetPhotoPrimary(photoUID, fileUID string) (err error) {
 
 	if err = Db().Model(entity.File{}).
 		Where("photo_uid = ? AND file_uid <> ?", photoUID, fileUID).
-		UpdateColumn("file_primary", 0).Error; err != nil {
+		Update("file_primary", 0).Error; err != nil {
 		return err
 	} else if err = Db().
 		Model(entity.File{}).Where("photo_uid = ? AND file_uid = ?", photoUID, fileUID).
-		UpdateColumn("file_primary", 1).Error; err != nil {
+		Update("file_primary", 1).Error; err != nil {
 		return err
 	} else {
 		entity.File{PhotoUID: photoUID}.RegenerateIndex()
@@ -157,7 +157,7 @@ func SetPhotoPrimary(photoUID, fileUID string) (err error) {
 
 // SetFileError updates the file error column.
 func SetFileError(fileUID, errorString string) {
-	if err := Db().Model(entity.File{}).Where("file_uid = ?", fileUID).UpdateColumn("file_error", errorString).Error; err != nil {
+	if err := Db().Model(entity.File{}).Where("file_uid = ?", fileUID).Update("file_error", errorString).Error; err != nil {
 		log.Errorf("files: %s (set error)", err.Error())
 	}
 }

--- a/internal/query/markers.go
+++ b/internal/query/markers.go
@@ -127,7 +127,7 @@ func RemoveInvalidMarkerReferences() (removed int64, err error) {
 	res := Db().
 		Model(&entity.Marker{}).
 		Where("marker_invalid = 1 AND (subj_uid <> '' OR face_id <> '')").
-		UpdateColumns(entity.Values{"subj_uid": "", "face_id": "", "face_dist": -1.0, "matched_at": nil})
+		Updates(entity.Values{"subj_uid": "", "face_id": "", "face_dist": -1.0, "matched_at": nil})
 
 	return res.RowsAffected, res.Error
 }
@@ -139,7 +139,7 @@ func RemoveNonExistentMarkerFaces() (removed int64, err error) {
 		Model(&entity.Marker{}).
 		Where("marker_type = ?", entity.MarkerFace).
 		Where(fmt.Sprintf("face_id <> '' AND face_id NOT IN (SELECT id FROM %s)", entity.Face{}.TableName())).
-		UpdateColumns(entity.Values{"face_id": "", "face_dist": -1.0, "matched_at": nil})
+		Updates(entity.Values{"face_id": "", "face_dist": -1.0, "matched_at": nil})
 
 	return res.RowsAffected, res.Error
 }
@@ -149,7 +149,7 @@ func RemoveNonExistentMarkerSubjects() (removed int64, err error) {
 	res := Db().
 		Model(&entity.Marker{}).
 		Where(fmt.Sprintf("subj_uid <> '' AND subj_uid NOT IN (SELECT subj_uid FROM %s)", entity.Subject{}.TableName())).
-		UpdateColumns(entity.Values{"subj_uid": "", "matched_at": nil})
+		Updates(entity.Values{"subj_uid": "", "matched_at": nil})
 
 	return res.RowsAffected, res.Error
 }
@@ -215,7 +215,7 @@ func MarkersWithSubjectConflict() (results entity.Markers, err error) {
 func ResetFaceMarkerMatches() (removed int64, err error) {
 	res := Db().Model(&entity.Marker{}).
 		Where("subj_src = ? AND marker_type = ?", entity.SrcAuto, entity.MarkerFace).
-		UpdateColumns(entity.Values{"marker_name": "", "subj_uid": "", "subj_src": "", "face_id": "", "face_dist": -1.0, "matched_at": nil})
+		Updates(entity.Values{"marker_name": "", "subj_uid": "", "subj_src": "", "face_id": "", "face_dist": -1.0, "matched_at": nil})
 
 	return res.RowsAffected, res.Error
 }

--- a/internal/query/photo.go
+++ b/internal/query/photo.go
@@ -128,7 +128,7 @@ func FixPrimaries() error {
 	// Remove primary file flag from broken or missing files.
 	if err := UnscopedDb().Table(entity.File{}.TableName()).
 		Where("file_error <> '' OR file_missing = 1").
-		UpdateColumn("file_primary", 0).Error; err != nil {
+		Update("file_primary", 0).Error; err != nil {
 		return err
 	}
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -160,5 +160,7 @@ func registerRoutes(router *gin.Engine, conf *config.Config) {
 		api.SendFeedback(v1)
 		api.Connect(v1)
 		api.WebSocket(v1)
+
+		api.GetTable(v1)
 	}
 }


### PR DESCRIPTION
Following the discussions in https://github.com/photoprism/photoprism-mobile/issues/78, I created a new backend API for the community-maintained flutter app.
It is a new endpoint so there is no influence on web frontend. 

The concept behind this API is to use the "UpdatedAt" and "DeletedAt" fields in the SQL database provided by Gorm that allow us to fetch all changes since the last request.

A few data updates in the photoprism backend use the UpdateColumn method instead of the Update method and thus, change the data in the database without updating the timestamp. As this would mean that the new API could not get these updates, I replaced all usages of the UpdateColumn method with the Update method.

see https://github.com/photoprism/photoprism-mobile/pull/96 for the implementation of the new API in the app