### PR TITLE
Add the GeocodingApi option to allow switching between places and osm for reverse location lookups.

### DIFF
--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -128,5 +128,8 @@ func configAction(ctx *cli.Context) error {
 	fmt.Printf("%-25s %d\n", "jpeg-size", conf.JpegSize())
 	fmt.Printf("%-25s %d\n", "jpeg-quality", conf.JpegQuality())
 
+	// Geocoding
+	fmt.Printf("%-25s %s\n", "geocoding-api", conf.GeoApi())
+
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -408,7 +408,16 @@ func (c *Config) GeoApi() string {
 		return ""
 	}
 
-	return "places"
+	switch strings.ToLower(c.options.GeocodingApi) {
+	case "places":
+		return "places"
+	case "osm":
+		return "osm"
+	case "none":
+		return ""
+	default:
+		return "places"
+	}
 }
 
 // OriginalsLimit returns the file size limit for originals.

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -104,6 +104,7 @@ type Options struct {
 	ThumbSizeUncached int    `yaml:"ThumbSizeUncached" json:"ThumbSizeUncached" flag:"thumb-size-uncached"`
 	JpegSize          int    `yaml:"JpegSize" json:"JpegSize" flag:"jpeg-size"`
 	JpegQuality       int    `yaml:"JpegQuality" json:"JpegQuality" flag:"jpeg-quality"`
+	GeocodingApi      string `yaml:"GeocodingApi" json:"GeocodingApi" flag:"geocoding-api"`
 }
 
 // NewOptions creates a new configuration entity by using two methods:


### PR DESCRIPTION
- `GeocodingApi: places` configures the app to use the photoprism places api.
- `GeocodingApi: places` configures the app to use the Open Street Map api.