### PR TITLE
Removed orientation from web app manifest

### DIFF
--- a/assets/static/manifest.json
+++ b/assets/static/manifest.json
@@ -82,7 +82,6 @@
   "scope": "/",
   "start_url": "/",
   "display": "standalone",
-  "orientation": "any",
   "theme_color": "#333333",
   "background_color": "#333333",
   "permissions": [


### PR DESCRIPTION
When using photoprism as an app after installing it with _Add to Home Screen_ on Android, the app ignores the screen orientation lock and rotates to landscape/portrait when it shouldn't. This appears to be caused by `orientation` being set to `any` in the web app manifest. Removing the property solves this issue. The app can still rotate when the screen orientation is unlocked but behaves correctly when it's locked.

I have tested this on the latest Chrome, Edge and Samsung Internet on Android 11.