### PR TITLE
Reduce memory usage in indexer and importer

### DIFF
--- a/internal/photoprism/import_worker.go
+++ b/internal/photoprism/import_worker.go
@@ -152,7 +152,7 @@ func ImportWorker(jobs <-chan ImportJob) {
 				continue
 			}
 
-			done := make(map[string]bool)
+			done := make(map[string]*struct{})
 			ind := imp.index
 			sizeLimit := ind.conf.OriginalsLimit()
 
@@ -168,7 +168,7 @@ func ImportWorker(jobs <-chan ImportJob) {
 				res := ind.MediaFile(f, indexOpt, originalName)
 
 				log.Infof("import: %s main %s file %s", res, f.FileType(), txt.Quote(f.RelName(ind.originalsPath())))
-				done[f.FileName()] = true
+				done[f.FileName()] = &struct{}{}
 
 				if res.Success() {
 					if err := entity.AddPhotoToAlbums(res.PhotoUID, opt.Albums); err != nil {
@@ -186,11 +186,11 @@ func ImportWorker(jobs <-chan ImportJob) {
 					continue
 				}
 
-				if done[f.FileName()] {
+				if done[f.FileName()] != nil {
 					continue
 				}
 
-				done[f.FileName()] = true
+				done[f.FileName()] = &struct{}{}
 
 				// Enforce file size limit for originals.
 				if sizeLimit > 0 && f.FileSize() > sizeLimit {

--- a/internal/photoprism/index_related.go
+++ b/internal/photoprism/index_related.go
@@ -71,7 +71,7 @@ func IndexMain(related *RelatedFiles, ind *Index, opt IndexOptions) (result Inde
 
 // IndexMain indexes a group of related files and returns the result.
 func IndexRelated(related RelatedFiles, ind *Index, opt IndexOptions) (result IndexResult) {
-	done := make(map[string]bool)
+	done := make(map[string]*struct{})
 	sizeLimit := ind.conf.OriginalsLimit()
 
 	result = IndexMain(&related, ind, opt)
@@ -84,7 +84,7 @@ func IndexRelated(related RelatedFiles, ind *Index, opt IndexOptions) (result In
 		return result
 	}
 
-	done[related.Main.FileName()] = true
+	done[related.Main.FileName()] = &struct{}{}
 
 	i := 0
 
@@ -96,11 +96,11 @@ func IndexRelated(related RelatedFiles, ind *Index, opt IndexOptions) (result In
 			continue
 		}
 
-		if done[f.FileName()] {
+		if done[f.FileName()] != nil {
 			continue
 		}
 
-		done[f.FileName()] = true
+		done[f.FileName()] = &struct{}{}
 
 		// Enforce file size limit for originals.
 		if sizeLimit > 0 && f.FileSize() > sizeLimit {


### PR DESCRIPTION
The empty struct type uses no storage. Correct me if I'm wrong but these areas seemed like a bit of a hot path, so thought it'd help to reduce some memory pressure here.