### PR TITLE
Docker compose has been rolled into the main CLI, so the hyphen is deprecated.

### DIFF
--- a/docker/examples/macos/docker-compose.yml
+++ b/docker/examples/macos/docker-compose.yml
@@ -11,19 +11,19 @@ version: '3.5'
 # ------------------------------------------------------------------
 # DOCKER COMPOSE COMMAND REFERENCE
 # ------------------------------------------------------------------
-# Start    | docker-compose up -d
-# Stop     | docker-compose stop
-# Update   | docker-compose pull
-# Logs     | docker-compose logs --tail=25 -f
-# Terminal | docker-compose exec photoprism bash
-# Help     | docker-compose exec photoprism photoprism help
-# Config   | docker-compose exec photoprism photoprism config
-# Reset    | docker-compose exec photoprism photoprism reset
-# Backup   | docker-compose exec photoprism photoprism backup -a -i
-# Restore  | docker-compose exec photoprism photoprism restore -a -i
-# Index    | docker-compose exec photoprism photoprism index
-# Reindex  | docker-compose exec photoprism photoprism index -a
-# Import   | docker-compose exec photoprism photoprism import
+# Start    | docker compose up -d
+# Stop     | docker compose stop
+# Update   | docker compose pull
+# Logs     | docker compose logs --tail=25 -f
+# Terminal | docker compose exec photoprism bash
+# Help     | docker compose exec photoprism photoprism help
+# Config   | docker compose exec photoprism photoprism config
+# Reset    | docker compose exec photoprism photoprism reset
+# Backup   | docker compose exec photoprism photoprism backup -a -i
+# Restore  | docker compose exec photoprism photoprism restore -a -i
+# Index    | docker compose exec photoprism photoprism index
+# Reindex  | docker compose exec photoprism photoprism index -a
+# Import   | docker compose exec photoprism photoprism import
 # -------------------------------------------------------------------
 
 services:


### PR DESCRIPTION

```% docker-compose up -d
Docker Compose is now in the Docker CLI, try `docker compose up`
```

This should probably be propagated to all docker-compose files, but I can only test on Mac, so I only edited this one.