### PR TITLE
Add -overwrite_original option to exiftool

### DIFF
--- a/docker/scripts/heif-convert.sh
+++ b/docker/scripts/heif-convert.sh
@@ -12,4 +12,4 @@ fi
 
 # Remove Exif orientation flag as JPEG is rotated already:
 
-/usr/bin/exiftool -n -Orientation=1 "$2"
+/usr/bin/exiftool -overwrite_original -P -n -Orientation=1 "$2"


### PR DESCRIPTION
Fixes #1200

Add -overwrite_original option to exiftool to avoid creating a copy of
the image file.
Adds -P option to preserve file modification time