### PR TITLE
Frontend: Copy to clipboard without HTTPS

### DIFF
--- a/frontend/src/common/util.js
+++ b/frontend/src/common/util.js
@@ -179,7 +179,7 @@ export default class Util {
       document.body.removeChild(clipboardElement);
 
       // Validate operation succeed
-      if(!succeed){
+      if (!succeed) {
         throw new Error('Failed copying to clipboard');
       }
     } else {

--- a/frontend/src/common/util.js
+++ b/frontend/src/common/util.js
@@ -147,9 +147,9 @@ export default class Util {
   }
 
   static async copyToMachineClipboard(text) {
-    if(window.navigator.clipboard) {
+    if (window.navigator.clipboard) {
       await window.navigator.clipboard.writeText(text);
-    } else if(document.execCommand) { 
+    } else if (document.execCommand) { 
       // Clipboard is available only in HTTPS pages. see https://web.dev/async-clipboard/
       // So if the the official 'clipboard' doesn't supported and the 'document.execCommand' is supported.
       // copy by a work-around by creating a textarea in the DOM and execute copy command from him.
@@ -173,7 +173,7 @@ export default class Util {
       clipboardElement.select();
       
       // Copy the selected textarea content
-      const succeed = document.execCommand('copy')
+      const succeed = document.execCommand('copy');
 
       // Remove the textarea from DOM
       document.body.removeChild(clipboardElement);

--- a/frontend/src/common/util.js
+++ b/frontend/src/common/util.js
@@ -150,7 +150,7 @@ export default class Util {
     if(window.navigator.clipboard) {
       await window.navigator.clipboard.writeText(text);
     } else { 
-      // Clapboard is available only in HTTPS pages. see https://web.dev/async-clipboard/
+      // Clipboard is available only in HTTPS pages. see https://web.dev/async-clipboard/
       // So if the the official 'clipboard' doesn't supported, copy by a work-around 
       // - try to create a textarea in the DOM and execute copy command from him.
       

--- a/frontend/src/common/util.js
+++ b/frontend/src/common/util.js
@@ -149,10 +149,10 @@ export default class Util {
   static async copyToMachineClipboard(text) {
     if(window.navigator.clipboard) {
       await window.navigator.clipboard.writeText(text);
-    } else { 
+    } else if(document.execCommand) { 
       // Clipboard is available only in HTTPS pages. see https://web.dev/async-clipboard/
-      // So if the the official 'clipboard' doesn't supported, copy by a work-around 
-      // - try to create a textarea in the DOM and execute copy command from him.
+      // So if the the official 'clipboard' doesn't supported and the 'document.execCommand' is supported.
+      // copy by a work-around by creating a textarea in the DOM and execute copy command from him.
       
       // Create the text area element (to copy from)
       const clipboardElement = document.createElement("textarea");
@@ -180,8 +180,10 @@ export default class Util {
 
       // Validate operation succeed
       if(!succeed){
-        throw new Error('Failed copying to clipboard')
+        throw new Error('Failed copying to clipboard');
       }
-    } 
+    } else {
+      throw new Error('Copy to clipboard does not support in your browser');
+    }
   }
 }

--- a/frontend/src/common/util.js
+++ b/frontend/src/common/util.js
@@ -145,4 +145,43 @@ export default class Util {
     console.log(`${label}: ${now.getTime() - start.getTime()}ms`);
     start = now;
   }
+
+  static async copyToMachineClipboard(text) {
+    if(window.navigator.clipboard) {
+      await window.navigator.clipboard.writeText(text);
+    } else { 
+      // Clapboard is available only in HTTPS pages. see https://web.dev/async-clipboard/
+      // So if the the official 'clipboard' doesn't supported, copy by a work-around 
+      // - try to create a textarea in the DOM and execute copy command from him.
+      
+      // Create the text area element (to copy from)
+      const clipboardElement = document.createElement("textarea");
+
+      // Set the text content to copy
+      clipboardElement.value = text;
+
+      // Avoid scrolling to bottom
+      clipboardElement.style.top = "0";
+      clipboardElement.style.left = "0";
+      clipboardElement.style.position = "fixed";
+
+      // Add element to DOM
+      document.body.appendChild(clipboardElement);
+
+      // "Select" the new textarea
+      clipboardElement.focus();
+      clipboardElement.select();
+      
+      // Copy the selected textarea content
+      const succeed = document.execCommand('copy')
+
+      // Remove the textarea from DOM
+      document.body.removeChild(clipboardElement);
+
+      // Validate operation succeed
+      if(!succeed){
+        throw new Error('Failed copying to clipboard')
+      }
+    } 
+  }
 }

--- a/frontend/src/dialog/share.vue
+++ b/frontend/src/dialog/share.vue
@@ -128,6 +128,7 @@
 </template>
 <script>
 import * as options from "options/options";
+import Util from "../common/util";
 
 export default {
   name: 'PShareDialog',
@@ -175,9 +176,14 @@ export default {
 
       ev.target.select();
     },
-    copyUrl(link) {
-      window.navigator.clipboard.writeText(link.url())
-        .then(() => this.$notify.success(this.$gettext("Copied to clipboard")), () => this.$notify.error(this.$gettext("Failed copying to clipboard")));
+    async copyUrl(link) {
+      try {
+        const url = link.url();
+        await Util.copyToMachineClipboard(url);
+        this.$notify.success(this.$gettext("Copied to clipboard"))
+      } catch (error) {
+        this.$notify.error(this.$gettext("Failed copying to clipboard"))
+      }
     },
     expires(link) {
       let result = this.$gettext('Expires');

--- a/frontend/src/dialog/webdav.vue
+++ b/frontend/src/dialog/webdav.vue
@@ -49,6 +49,8 @@
 </template>
 
 <script>
+import Util from "../common/util";
+
 export default {
   name: 'PDialogWebdav',
   props: {
@@ -79,9 +81,13 @@ export default {
 
       this.copyUrl();
     },
-    copyUrl() {
-      window.navigator.clipboard.writeText(this.webdavUrl())
-        .then(() => this.$notify.success(this.$gettext("Copied to clipboard")), () => this.$notify.error(this.$gettext("Failed copying to clipboard")));
+    async copyUrl() {
+      try {
+        await Util.copyToMachineClipboard(this.webdavUrl());
+        this.$notify.success(this.$gettext("Copied to clipboard"));
+      } catch (error) {
+        this.$notify.error(this.$gettext("Failed copying to clipboard"))
+      }
     },
     webdavUrl() {
       return `${window.location.protocol}//admin@${window.location.host}/originals/`;


### PR DESCRIPTION
Allow copy content to the clipboard even if the "window.navigator.clipboard" doesn't support