### PR TITLE
Give the photoprism service the standard name photoprism 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
   photoprism:
     build: .
     image: photoprism/photoprism:develop
+    container_name: photoprism
     security_opt:
       - seccomp:unconfined
       - apparmor:unconfined


### PR DESCRIPTION
Add container_name to the docker-compose file, making it easier to setup other services who rely on the container name and making it easier for things like docker restart, docker log ,...