### PR TITLE
Fix unhandled error in Config.DecodeSession

### DIFF
--- a/internal/hub/config.go
+++ b/internal/hub/config.go
@@ -93,7 +93,9 @@ func (c *Config) DecodeSession() (Session, error) {
 	}
 
 	hash := sha256.New()
-	hash.Write([]byte(c.Secret))
+	if _, err := hash.Write([]byte(c.Secret)); err != nil {
+		return result, err
+	}
 
 	var b []byte
 


### PR DESCRIPTION
Looking at the [source implementation of sha256.Write](https://golang.org/src/crypto/sha256/sha256.go), it's currently not possible for an error to be thrown by the function. However, I still think it's good form to handle this err here in case this changes in the future. 