### PR TITLE
Update package-lock.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1687,39 +1687,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@vue/reactivity": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.11.tgz",
-      "integrity": "sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vue/shared": "3.0.11"
-      }
-    },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.11.tgz",
-      "integrity": "sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vue/reactivity": "3.0.11",
-        "@vue/shared": "3.0.11"
-      }
-    },
-    "node_modules/@vue/runtime-dom": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz",
-      "integrity": "sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vue/runtime-core": "3.0.11",
-        "@vue/shared": "3.0.11",
-        "csstype": "^2.6.8"
-      }
-    },
     "node_modules/@vue/shared": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.11.tgz",
@@ -4135,13 +4102,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/csstype": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
@@ -4655,18 +4615,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/easygettext/node_modules/vue": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.11.tgz",
-      "integrity": "sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.0.11",
-        "@vue/runtime-dom": "3.0.11",
-        "@vue/shared": "3.0.11"
       }
     },
     "node_modules/easygettext/node_modules/yallist": {
@@ -16178,8 +16126,7 @@
     "@mapbox/mapbox-gl-supported": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
-      "requires": {}
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -16367,39 +16314,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
-      }
-    },
-    "@vue/reactivity": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.11.tgz",
-      "integrity": "sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@vue/shared": "3.0.11"
-      }
-    },
-    "@vue/runtime-core": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.11.tgz",
-      "integrity": "sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@vue/reactivity": "3.0.11",
-        "@vue/shared": "3.0.11"
-      }
-    },
-    "@vue/runtime-dom": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz",
-      "integrity": "sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@vue/runtime-core": "3.0.11",
-        "@vue/shared": "3.0.11",
-        "csstype": "^2.6.8"
       }
     },
     "@vue/shared": {
@@ -16615,14 +16529,12 @@
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "requires": {}
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
     },
     "acorn-private-class-elements": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.7.tgz",
-      "integrity": "sha512-+GZH2wOKNZOBI4OOPmzpo4cs6mW297sn6fgIk1dUI08jGjhAaEwvC39mN2gJAg2lmAQJ1rBkFqKWonL3Zz6PVA==",
-      "requires": {}
+      "integrity": "sha512-+GZH2wOKNZOBI4OOPmzpo4cs6mW297sn6fgIk1dUI08jGjhAaEwvC39mN2gJAg2lmAQJ1rBkFqKWonL3Zz6PVA=="
     },
     "acorn-private-methods": {
       "version": "0.3.3",
@@ -16690,14 +16602,12 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "requires": {}
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -18338,13 +18248,6 @@
         }
       }
     },
-    "csstype": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
-      "optional": true,
-      "peer": true
-    },
     "cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
@@ -18637,8 +18540,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "optional": true,
-          "requires": {}
+          "optional": true
         },
         "lru-cache": {
           "version": "5.1.1",
@@ -18686,8 +18588,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "optional": true,
-          "requires": {}
+          "optional": true
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -18729,18 +18630,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "optional": true
-        },
-        "vue": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.11.tgz",
-          "integrity": "sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@vue/compiler-dom": "3.0.11",
-            "@vue/runtime-dom": "3.0.11",
-            "@vue/shared": "3.0.11"
-          }
         },
         "yallist": {
           "version": "3.1.1",
@@ -19131,14 +19020,12 @@
     "eslint-config-prettier": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
-      "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-      "requires": {}
+      "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg=="
     },
     "eslint-config-standard": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-      "requires": {}
+      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg=="
     },
     "eslint-formatter-pretty": {
       "version": "4.0.0",
@@ -19510,8 +19397,7 @@
     "eslint-plugin-standard": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
-      "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-      "requires": {}
+      "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ=="
     },
     "eslint-plugin-vue": {
       "version": "7.10.0",
@@ -26264,8 +26150,7 @@
     "vuetify": {
       "version": "1.5.24",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.5.24.tgz",
-      "integrity": "sha512-guFOgEgZ8VpSgNXOv1QL2fOliaJBoiyNnf+bBqcXsnIppJGRlW1wyT6Ux7ZlQyphSHs+UK1aJNUjcyAtoOiHWg==",
-      "requires": {}
+      "integrity": "sha512-guFOgEgZ8VpSgNXOv1QL2fOliaJBoiyNnf+bBqcXsnIppJGRlW1wyT6Ux7ZlQyphSHs+UK1aJNUjcyAtoOiHWg=="
     },
     "watchpack": {
       "version": "1.7.5",
@@ -26825,8 +26710,7 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "requires": {}
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     },
     "xmlbuilder": {
       "version": "10.1.1",


### PR DESCRIPTION
When I run `npm install` it removes several packages that look to be unnecessary. I'm using npm 7.11.1. Perhaps this file was generated with an older version? Or the `package.json` was updated and the `package-lock.json` wasn't regenerated?