### PR TITLE
Fix Mapbox map RTL support - Fix #1391

### DIFF
--- a/frontend/src/pages/places.vue
+++ b/frontend/src/pages/places.vue
@@ -272,6 +272,14 @@ export default {
       }).catch(() => this.loading = false);
     },
     renderMap() {
+      // In case of facing RTL language on the map, this plugin will be fetched (only by lazy!) and will set RTL properly support.
+      // See mapbox documentation here https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-rtl-text/
+      mapboxgl.setRTLTextPlugin(
+        'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js',
+        null,
+        true // Lazy load the plugin
+      );
+      
       this.map = new mapboxgl.Map(this.options);
 
       this.map.addControl(new mapboxgl.NavigationControl({showCompass: true}, 'top-right'));


### PR DESCRIPTION
Load Mapbox RTL plugin when facing RTL language on the map.
Load the plugin lazy, so it will not affect current other languages' performance.