### PR TITLE
Add crossorigin="use-credentials" to manifest links

### DIFF
--- a/assets/templates/index.tmpl
+++ b/assets/templates/index.tmpl
@@ -27,7 +27,7 @@
 {{template "favicons.tmpl" .}}
 
   <link rel="stylesheet" href="/static/build/app.css?{{ .config.CSSHash }}">
-  <link rel="manifest" href="/static/manifest.json?{{ .config.ManifestHash }}">
+  <link rel="manifest" href="/static/manifest.json?{{ .config.ManifestHash }}" crossorigin="use-credentials">
 
   <script>
       window.__CONFIG__ = {{ .config }};

--- a/assets/templates/minimal.tmpl
+++ b/assets/templates/minimal.tmpl
@@ -10,7 +10,7 @@
 {{template "favicons.tmpl" .}}
 
   <link rel="stylesheet" href="/static/build/app.css?{{ .config.CSSHash }}">
-  <link rel="manifest" href="/static/manifest.json?{{ .config.ManifestHash }}">
+  <link rel="manifest" href="/static/manifest.json?{{ .config.ManifestHash }}" crossorigin="use-credentials">
 
   <script>
       window.__CONFIG__ = {{ .config }};

--- a/assets/templates/share.tmpl
+++ b/assets/templates/share.tmpl
@@ -24,7 +24,7 @@
 {{template "favicons.tmpl" .}}
 
   <link rel="stylesheet" href="/static/build/share.css?{{ .config.CSSHash }}">
-  <link rel="manifest" href="/static/manifest.json?{{ .config.ManifestHash }}">
+  <link rel="manifest" href="/static/manifest.json?{{ .config.ManifestHash }}" crossorigin="use-credentials">
 
   <script>
       window.__CONFIG__ = {{ .config }};


### PR DESCRIPTION
While setting this up in Docker for the first time behind an [OAuth2-Proxy](https://oauth2-proxy.github.io/oauth2-proxy), I noticed that the PWA fails to offer an installation on latest Android Chrome.

It looks like this is a result of the `manifest.json` [being blocked by CORS](https://stackoverflow.com/questions/6294622/html5-manifest-cache-behind-basic-auth) unless the authentication credentials are passed. Sure enough, if I set an exception for `static/manifest.json`, the installation is offered, similar to what the user found in [this](https://github.com/photoprism/photoprism/issues/374#issuecomment-653042041) issue.

The [fix](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_webmanifest_with_credentials) appears to be to add `crossorigin="use-credentials` to all of the manifest links. I found 3 instances, please correct me if I missed any or was overly zealous.

Also - I could use some guidance on how to test this locally before merging. I didn't see anything in the docs.