### PR TITLE
Fail entire build script if any command fails

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 PHOTOPRISM_DATE=`date -u +%y%m%d`
 PHOTOPRISM_VERSION=`git describe --always`
 


### PR DESCRIPTION
At the moment, the build script exits with 0 even if any of the commands fail.
Setting `-e` fixes this.