### PR TITLE
Enable module graph pruning and deprecate io/ioutil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/studio-b12/gowebdav v0.0.0-20210917133250-a3a86976a1df
 	github.com/tensorflow/tensorflow v1.15.2
 	github.com/tidwall/gjson v1.9.1
-	github.com/ugorji/go v1.2.6 // indirect
 	github.com/ulule/deepcopier v0.0.0-20200430083143-45decc6639b6
 	github.com/urfave/cli v1.22.5
 	go4.org v0.0.0-20201209231011-d4a079459e60 // indirect
@@ -69,4 +68,26 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-go 1.16
+require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dsoprea/go-logging v0.0.0-20200710184922-b02d349568dd // indirect
+	github.com/dsoprea/go-utility/v2 v2.0.0-20200717064901-2fccff4aa15e // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.14.0 // indirect
+	github.com/go-playground/universal-translator v0.18.0 // indirect
+	github.com/go-sql-driver/mysql v1.5.0 // indirect
+	github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b // indirect
+	github.com/gosimple/unidecode v1.0.0 // indirect
+	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/tidwall/match v1.0.3 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/ugorji/go/codec v1.2.6 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+)
+
+go 1.17

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -81,7 +80,7 @@ func SaveConfigOptions(router *gin.RouterGroup) {
 		v := make(valueMap)
 
 		if fs.FileExists(fileName) {
-			yamlData, err := ioutil.ReadFile(fileName)
+			yamlData, err := os.ReadFile(fileName)
 
 			if err != nil {
 				log.Errorf("options: %s", err)
@@ -118,7 +117,7 @@ func SaveConfigOptions(router *gin.RouterGroup) {
 		}
 
 		// Write YAML data to file.
-		if err := ioutil.WriteFile(fileName, yamlData, os.ModePerm); err != nil {
+		if err := os.WriteFile(fileName, yamlData, os.ModePerm); err != nil {
 			log.Errorf("options: %s", err)
 			c.AbortWithStatusJSON(http.StatusInternalServerError, err)
 			return

--- a/internal/classify/gen.go
+++ b/internal/classify/gen.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ func main() {
 		log.Panicf("classify: found no label rules in %s", txt.Quote(filepath.Base(fileName)))
 	}
 
-	yamlConfig, err := ioutil.ReadFile(fileName)
+	yamlConfig, err := os.ReadFile(fileName)
 
 	if err != nil {
 		panic(err)

--- a/internal/classify/tensorflow.go
+++ b/internal/classify/tensorflow.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"image"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -49,7 +48,7 @@ func (t *TensorFlow) File(filename string) (result Labels, err error) {
 		return result, nil
 	}
 
-	imageBuffer, err := ioutil.ReadFile(filename)
+	imageBuffer, err := os.ReadFile(filename)
 
 	if err != nil {
 		return nil, err

--- a/internal/classify/tensorflow_test.go
+++ b/internal/classify/tensorflow_test.go
@@ -1,7 +1,7 @@
 package classify
 
 import (
-	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 
@@ -84,7 +84,7 @@ func TestTensorFlow_Labels(t *testing.T) {
 	t.Run("chameleon_lime.jpg", func(t *testing.T) {
 		tensorFlow := NewTest(t)
 
-		if imageBuffer, err := ioutil.ReadFile(examplesPath + "/chameleon_lime.jpg"); err != nil {
+		if imageBuffer, err := os.ReadFile(examplesPath + "/chameleon_lime.jpg"); err != nil {
 			t.Error(err)
 		} else {
 			result, err := tensorFlow.Labels(imageBuffer)
@@ -108,7 +108,7 @@ func TestTensorFlow_Labels(t *testing.T) {
 	t.Run("dog_orange.jpg", func(t *testing.T) {
 		tensorFlow := NewTest(t)
 
-		if imageBuffer, err := ioutil.ReadFile(examplesPath + "/dog_orange.jpg"); err != nil {
+		if imageBuffer, err := os.ReadFile(examplesPath + "/dog_orange.jpg"); err != nil {
 			t.Error(err)
 		} else {
 			result, err := tensorFlow.Labels(imageBuffer)
@@ -132,7 +132,7 @@ func TestTensorFlow_Labels(t *testing.T) {
 	t.Run("Random.docx", func(t *testing.T) {
 		tensorFlow := NewTest(t)
 
-		if imageBuffer, err := ioutil.ReadFile(examplesPath + "/Random.docx"); err != nil {
+		if imageBuffer, err := os.ReadFile(examplesPath + "/Random.docx"); err != nil {
 			t.Error(err)
 		} else {
 			result, err := tensorFlow.Labels(imageBuffer)
@@ -143,7 +143,7 @@ func TestTensorFlow_Labels(t *testing.T) {
 	t.Run("6720px_white.jpg", func(t *testing.T) {
 		tensorFlow := NewTest(t)
 
-		if imageBuffer, err := ioutil.ReadFile(examplesPath + "/6720px_white.jpg"); err != nil {
+		if imageBuffer, err := os.ReadFile(examplesPath + "/6720px_white.jpg"); err != nil {
 			t.Error(err)
 		} else {
 			result, err := tensorFlow.Labels(imageBuffer)
@@ -158,7 +158,7 @@ func TestTensorFlow_Labels(t *testing.T) {
 	t.Run("disabled true", func(t *testing.T) {
 		tensorFlow := New(assetsPath, true)
 
-		if imageBuffer, err := ioutil.ReadFile(examplesPath + "/dog_orange.jpg"); err != nil {
+		if imageBuffer, err := os.ReadFile(examplesPath + "/dog_orange.jpg"); err != nil {
 			t.Error(err)
 		} else {
 			result, err := tensorFlow.Labels(imageBuffer)
@@ -224,7 +224,7 @@ func TestTensorFlow_MakeTensor(t *testing.T) {
 	t.Run("cat_brown.jpg", func(t *testing.T) {
 		tensorFlow := NewTest(t)
 
-		imageBuffer, err := ioutil.ReadFile(examplesPath + "/cat_brown.jpg")
+		imageBuffer, err := os.ReadFile(examplesPath + "/cat_brown.jpg")
 
 		if err != nil {
 			t.Fatal(err)
@@ -238,7 +238,7 @@ func TestTensorFlow_MakeTensor(t *testing.T) {
 	t.Run("Random.docx", func(t *testing.T) {
 		tensorFlow := NewTest(t)
 
-		imageBuffer, err := ioutil.ReadFile(examplesPath + "/Random.docx")
+		imageBuffer, err := os.ReadFile(examplesPath + "/Random.docx")
 		assert.Nil(t, err)
 		result, err := tensorFlow.createTensor(imageBuffer, "jpeg")
 

--- a/internal/commands/backup.go
+++ b/internal/commands/backup.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -157,7 +156,7 @@ func backupAction(ctx *cli.Context) error {
 			fmt.Println(out.String())
 		} else {
 			// Write output to file.
-			if err := ioutil.WriteFile(indexFileName, []byte(out.String()), os.ModePerm); err != nil {
+			if err := os.WriteFile(indexFileName, []byte(out.String()), os.ModePerm); err != nil {
 				return err
 			}
 		}

--- a/internal/commands/restore.go
+++ b/internal/commands/restore.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -124,7 +124,7 @@ func restoreAction(ctx *cli.Context) error {
 
 		log.Infof("restoring index from %s", txt.Quote(indexFileName))
 
-		sqlBackup, err := ioutil.ReadFile(indexFileName)
+		sqlBackup, err := os.ReadFile(indexFileName)
 
 		if err != nil {
 			return err

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -38,7 +38,7 @@ func statusAction(ctx *cli.Context) error {
 		return fmt.Errorf("can't connect to %s:%d", conf.HttpHost(), conf.HttpPort())
 	} else if resp.StatusCode != 200 {
 		return fmt.Errorf("server running at %s:%d, bad status %d\n", conf.HttpHost(), conf.HttpPort(), resp.StatusCode)
-	} else if body, err := ioutil.ReadAll(resp.Body); err != nil {
+	} else if body, err := io.ReadAll(resp.Body); err != nil {
 		return err
 	} else {
 		status = string(body)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -210,13 +209,13 @@ func (c *Config) initStorage() error {
 	storageName := filepath.Join(c.StoragePath(), serialName)
 	backupName := filepath.Join(c.BackupPath(), serialName)
 
-	if data, err := ioutil.ReadFile(storageName); err == nil {
+	if data, err := os.ReadFile(storageName); err == nil {
 		c.serial = string(data)
-	} else if data, err := ioutil.ReadFile(backupName); err == nil {
+	} else if data, err := os.ReadFile(backupName); err == nil {
 		c.serial = string(data)
-	} else if err := ioutil.WriteFile(storageName, []byte(c.serial), os.ModePerm); err != nil {
+	} else if err := os.WriteFile(storageName, []byte(c.serial), os.ModePerm); err != nil {
 		return fmt.Errorf("failed creating %s: %s", storageName, err)
-	} else if err := ioutil.WriteFile(backupName, []byte(c.serial), os.ModePerm); err != nil {
+	} else if err := os.WriteFile(backupName, []byte(c.serial), os.ModePerm); err != nil {
 		return fmt.Errorf("failed creating %s: %s", backupName, err)
 	}
 

--- a/internal/config/db.go
+++ b/internal/config/db.go
@@ -3,7 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -301,7 +301,7 @@ func (c *Config) connectDb() error {
 
 // ImportSQL imports a file to the currently configured database.
 func (c *Config) ImportSQL(filename string) {
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 
 	if err != nil {
 		log.Error(err)

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -3,7 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 
 	_ "github.com/jinzhu/gorm/dialects/mysql"
@@ -177,7 +177,7 @@ func (c *Options) Load(fileName string) error {
 		return errors.New(fmt.Sprintf("config: %s not found", fileName))
 	}
 
-	yamlConfig, err := ioutil.ReadFile(fileName)
+	yamlConfig, err := os.ReadFile(fileName)
 
 	if err != nil {
 		return err

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/photoprism/photoprism/internal/entity"
@@ -185,7 +184,7 @@ func (s *Settings) Load(fileName string) error {
 		return fmt.Errorf("settings file not found: %s", txt.Quote(fileName))
 	}
 
-	yamlConfig, err := ioutil.ReadFile(fileName)
+	yamlConfig, err := os.ReadFile(fileName)
 
 	if err != nil {
 		return err
@@ -210,7 +209,7 @@ func (s *Settings) Save(fileName string) error {
 
 	s.Propagate()
 
-	if err := ioutil.WriteFile(fileName, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(fileName, data, os.ModePerm); err != nil {
 		return err
 	}
 

--- a/internal/crop/image.go
+++ b/internal/crop/image.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"image"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -162,7 +162,7 @@ func findIdealThumbFileName(hash string, width int, filePath string) (fileName s
 func openIdealThumbFile(fileName, hash string, area Area, size Size) (image.Image, error) {
 	if len(hash) != 40 || area.W <= 0 || size.Width <= 0 {
 		// Not a standard thumb name with sha1 hash prefix.
-		if imageBuffer, err := ioutil.ReadFile(fileName); err != nil {
+		if imageBuffer, err := os.ReadFile(fileName); err != nil {
 			return nil, err
 		} else {
 			return imaging.Decode(bytes.NewReader(imageBuffer), imaging.AutoOrientation(true))
@@ -173,7 +173,7 @@ func openIdealThumbFile(fileName, hash string, area Area, size Size) (image.Imag
 		fileName = name
 	}
 
-	if imageBuffer, err := ioutil.ReadFile(fileName); err != nil {
+	if imageBuffer, err := os.ReadFile(fileName); err != nil {
 		return nil, err
 	} else {
 		return imaging.Decode(bytes.NewReader(imageBuffer))

--- a/internal/crop/request.go
+++ b/internal/crop/request.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"image"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/disintegration/imaging"
@@ -30,7 +30,7 @@ func FromRequest(hash, area string, size Size, thumbPath string) (fileName strin
 	cropBase := fmt.Sprintf("%s_%dx%d_crop_%s%s", hash, size.Width, size.Height, area, fs.JpegExt)
 	cropName := filepath.Join(filepath.Dir(thumbName), cropBase)
 
-	imageBuffer, err := ioutil.ReadFile(thumbName)
+	imageBuffer, err := os.ReadFile(thumbName)
 
 	if err != nil {
 		return "", err

--- a/internal/entity/album_yaml.go
+++ b/internal/entity/album_yaml.go
@@ -1,7 +1,6 @@
 package entity
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -39,7 +38,7 @@ func (m *Album) SaveAsYaml(fileName string) error {
 	defer albumYamlMutex.Unlock()
 
 	// Write YAML data to file.
-	if err := ioutil.WriteFile(fileName, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(fileName, data, os.ModePerm); err != nil {
 		return err
 	}
 
@@ -48,7 +47,7 @@ func (m *Album) SaveAsYaml(fileName string) error {
 
 // LoadFromYaml photo data from a YAML file.
 func (m *Album) LoadFromYaml(fileName string) error {
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 
 	if err != nil {
 		return err

--- a/internal/entity/album_yaml_test.go
+++ b/internal/entity/album_yaml_test.go
@@ -1,7 +1,6 @@
 package entity
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -85,7 +84,7 @@ func TestAlbum_LoadFromYaml(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if existingYaml, err := ioutil.ReadFile(fileName); err != nil {
+		if existingYaml, err := os.ReadFile(fileName); err != nil {
 			t.Fatal(err)
 		} else if newYaml, err := a.Yaml(); err != nil {
 			t.Fatal(err)

--- a/internal/entity/photo_yaml.go
+++ b/internal/entity/photo_yaml.go
@@ -1,7 +1,6 @@
 package entity
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -43,7 +42,7 @@ func (m *Photo) SaveAsYaml(fileName string) error {
 	defer photoYamlMutex.Unlock()
 
 	// Write YAML data to file.
-	if err := ioutil.WriteFile(fileName, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(fileName, data, os.ModePerm); err != nil {
 		return err
 	}
 
@@ -52,7 +51,7 @@ func (m *Photo) SaveAsYaml(fileName string) error {
 
 // LoadFromYaml photo data from a YAML file.
 func (m *Photo) LoadFromYaml(fileName string) error {
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 
 	if err != nil {
 		return err

--- a/internal/hub/config.go
+++ b/internal/hub/config.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -187,7 +186,7 @@ func (c *Config) Load() error {
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	yamlConfig, err := ioutil.ReadFile(c.FileName)
+	yamlConfig, err := os.ReadFile(c.FileName)
 
 	if err != nil {
 		return err
@@ -228,7 +227,7 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(c.FileName, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(c.FileName, data, os.ModePerm); err != nil {
 		return err
 	}
 

--- a/internal/maps/gen.go
+++ b/internal/maps/gen.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -20,7 +19,7 @@ type Country struct {
 var countries []Country
 
 func main() {
-	rawData, err := ioutil.ReadFile("./countries.json")
+	rawData, err := os.ReadFile("./countries.json")
 
 	if err != nil {
 		panic(err)

--- a/internal/meta/json.go
+++ b/internal/meta/json.go
@@ -3,7 +3,7 @@ package meta
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime/debug"
 
@@ -37,7 +37,7 @@ func (data *Data) JSON(jsonName, originalName string) (err error) {
 		return fmt.Errorf("metadata: %s not found", quotedName)
 	}
 
-	jsonData, err := ioutil.ReadFile(jsonName)
+	jsonData, err := os.ReadFile(jsonName)
 
 	if err != nil {
 		return fmt.Errorf("can't read json file %s", quotedName)

--- a/internal/meta/xmp_document.go
+++ b/internal/meta/xmp_document.go
@@ -2,7 +2,7 @@ package meta
 
 import (
 	"encoding/xml"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 )
@@ -200,7 +200,7 @@ type XmpDocument struct {
 
 // Load parses an XMP file and populates document values with its contents.
 func (doc *XmpDocument) Load(filename string) error {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 
 	if err != nil {
 		return err

--- a/internal/nsfw/detector.go
+++ b/internal/nsfw/detector.go
@@ -3,7 +3,6 @@ package nsfw
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -34,7 +33,7 @@ func (t *Detector) File(filename string) (result Labels, err error) {
 		return result, fmt.Errorf("nsfw: %s is not a jpeg file", txt.Quote(filepath.Base(filename)))
 	}
 
-	imageBuffer, err := ioutil.ReadFile(filename)
+	imageBuffer, err := os.ReadFile(filename)
 
 	if err != nil {
 		return result, err

--- a/internal/photoprism/convert.go
+++ b/internal/photoprism/convert.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/exec"
@@ -172,7 +171,7 @@ func (c *Convert) ToJson(f *MediaFile) (jsonName string, err error) {
 	}
 
 	// Write output to file.
-	if err := ioutil.WriteFile(jsonName, []byte(out.String()), os.ModePerm); err != nil {
+	if err := os.WriteFile(jsonName, []byte(out.String()), os.ModePerm); err != nil {
 		return "", err
 	}
 

--- a/internal/photoprism/mediafile_test.go
+++ b/internal/photoprism/mediafile_test.go
@@ -1,7 +1,6 @@
 package photoprism
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2145,7 +2144,7 @@ func TestMediaFile_RenameSidecars(t *testing.T) {
 		srcName := filepath.Join(conf.SidecarPath(), "foo/bar.jpg.json")
 		dstName := filepath.Join(conf.SidecarPath(), "2020/12/foobar.jpg.json")
 
-		if err := ioutil.WriteFile(srcName, []byte("{}"), 0666); err != nil {
+		if err := os.WriteFile(srcName, []byte("{}"), 0666); err != nil {
 			t.Fatal(err)
 		}
 
@@ -2190,7 +2189,7 @@ func TestMediaFile_RemoveSidecars(t *testing.T) {
 
 		sidecarName := filepath.Join(conf.SidecarPath(), "2020/12/foobar.jpg.json")
 
-		if err := ioutil.WriteFile(sidecarName, []byte("{}"), 0666); err != nil {
+		if err := os.WriteFile(sidecarName, []byte("{}"), 0666); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/remote/webdav/webdav.go
+++ b/internal/remote/webdav/webdav.go
@@ -33,7 +33,6 @@ package webdav
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -166,7 +165,7 @@ func (c Client) Download(from, to string, force bool) error {
 		return err
 	}
 
-	return ioutil.WriteFile(to, bytes, 0644)
+	return os.WriteFile(to, bytes, 0644)
 }
 
 // DownloadDir downloads all files from a remote to a local directory.

--- a/internal/server/recovery.go
+++ b/internal/server/recovery.go
@@ -3,9 +3,9 @@ package server
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"runtime"
 
 	"github.com/gin-gonic/gin"
@@ -48,7 +48,7 @@ func stack(skip int) []byte {
 		// Print this much at least.  If we can't find the source, it won't show.
 		fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
 		if file != lastFile {
-			data, err := ioutil.ReadFile(file)
+			data, err := os.ReadFile(file)
 			if err != nil {
 				continue
 			}

--- a/internal/server/webdav.go
+++ b/internal/server/webdav.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -37,7 +36,7 @@ func MarkUploadAsFavorite(fileName string) {
 	}
 
 	// Write YAML data to file.
-	if err := ioutil.WriteFile(yamlName, []byte("Favorite: true\n"), os.ModePerm); err != nil {
+	if err := os.WriteFile(yamlName, []byte("Favorite: true\n"), os.ModePerm); err != nil {
 		log.Errorf("webdav: %s", err.Error())
 		return
 	}

--- a/internal/session/save.go
+++ b/internal/session/save.go
@@ -2,7 +2,7 @@ package session
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path"
 	"sync"
 	"time"
@@ -30,7 +30,7 @@ func New(expiration time.Duration, cachePath string) *Session {
 		items := make(map[string]gc.Item)
 		s.cacheFile = path.Join(cachePath, cacheFileName)
 
-		if cached, err := ioutil.ReadFile(s.cacheFile); err != nil {
+		if cached, err := os.ReadFile(s.cacheFile); err != nil {
 			log.Debugf("session: %s", err)
 		} else if err := json.Unmarshal(cached, &savedItems); err != nil {
 			log.Errorf("session: %s", err)
@@ -92,7 +92,7 @@ func (s *Session) Save() error {
 
 	if serialized, err := json.MarshalIndent(savedItems, "", " "); err != nil {
 		return err
-	} else if err = ioutil.WriteFile(s.cacheFile, serialized, 0600); err != nil {
+	} else if err = os.WriteFile(s.cacheFile, serialized, 0600); err != nil {
 		return err
 	}
 

--- a/pkg/clusters/json_importer.go
+++ b/pkg/clusters/json_importer.go
@@ -2,7 +2,7 @@ package clusters
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 type jsonImporter struct {
@@ -17,7 +17,7 @@ func (i *jsonImporter) Import(file string, start, end int) ([][]float64, error) 
 		return [][]float64{}, errInvalidRange
 	}
 
-	f, err := ioutil.ReadFile(file)
+	f, err := os.ReadFile(file)
 	if err != nil {
 		return [][]float64{}, err
 	}

--- a/pkg/fastwalk/fastwalk_portable.go
+++ b/pkg/fastwalk/fastwalk_portable.go
@@ -8,7 +8,6 @@
 package fastwalk
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -17,16 +16,16 @@ import (
 // If fn returns a non-nil error, readDir returns with that error
 // immediately.
 func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) error) error {
-	fis, err := ioutil.ReadDir(dirName)
+	dirEntries, err := os.ReadDir(dirName)
 	if err != nil {
 		return err
 	}
 	skipFiles := false
-	for _, fi := range fis {
-		if fi.Mode().IsRegular() && skipFiles {
+	for _, entry := range dirEntries {
+		if entry.Type().IsRegular() && skipFiles {
 			continue
 		}
-		if err := fn(dirName, fi.Name(), fi.Mode()&os.ModeType); err != nil {
+		if err := fn(dirName, entry.Name(), entry.Type()&os.ModeType); err != nil {
 			if err == ErrSkipFiles {
 				skipFiles = true
 				continue

--- a/pkg/fastwalk/fastwalk_test.go
+++ b/pkg/fastwalk/fastwalk_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -35,7 +34,7 @@ func formatFileModes(m map[string]os.FileMode) string {
 }
 
 func testFastWalk(t *testing.T, files map[string]string, callback func(path string, typ os.FileMode) error, want map[string]os.FileMode) {
-	tempdir, err := ioutil.TempDir("", "test-fast-walk")
+	tempdir, err := os.MkdirTemp("", "test-fast-walk")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +48,7 @@ func testFastWalk(t *testing.T, files map[string]string, callback func(path stri
 		if strings.HasPrefix(contents, "LINK:") {
 			err = os.Symlink(strings.TrimPrefix(contents, "LINK:"), file)
 		} else {
-			err = ioutil.WriteFile(file, []byte(contents), 0644)
+			err = os.WriteFile(file, []byte(contents), 0644)
 		}
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/fs/case.go
+++ b/pkg/fs/case.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -11,7 +10,7 @@ import (
 func CaseInsensitive(storagePath string) (result bool, err error) {
 	tmpName := filepath.Join(storagePath, "caseTest.tmp")
 
-	if err := ioutil.WriteFile(tmpName, []byte("{}"), 0666); err != nil {
+	if err := os.WriteFile(tmpName, []byte("{}"), 0666); err != nil {
 		return false, fmt.Errorf("%s not writable", filepath.Base(storagePath))
 	}
 

--- a/pkg/fs/fileinfo_test.go
+++ b/pkg/fs/fileinfo_test.go
@@ -1,7 +1,6 @@
 package fs
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -26,10 +25,20 @@ func TestNewFileInfo(t *testing.T) {
 }
 
 func TestNewFileInfos(t *testing.T) {
-	infos, err := ioutil.ReadDir("testdata")
+	dirEntries, err := os.ReadDir("testdata")
 
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	infos := make([]os.FileInfo, 0, len(dirEntries))
+
+	for _, entry := range dirEntries {
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		infos = append(infos, info)
 	}
 
 	result := NewFileInfos(infos, PathSeparator)


### PR DESCRIPTION
This pull request introduces two small changes

1. Enable [module graph pruning and lazy module loading](https://golang.org/ref/mod#graph-pruning) supported by Go 1.17 or higher. 

1. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since photoprism has upgraded to Go 1.17 (feb0c557c1c12ec8fac62e9d409adb2499b082df), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.