### PR TITLE
Config: Allow bypassing low memory suggestion

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,11 @@ func init() {
 	TotalMem = memory.TotalMemory()
 	LowMem = TotalMem < MinMem
 
+	if (os.Getenv("UNSAFE_IGNORE_LOW_MEM") == "true") {
+		LowMem = false
+		log.Warnf("Ignoring memory requirements, because UNSAFE_IGNORE_LOW_MEM is set to true")
+	}
+
 	// Init public thumb sizes for use in client apps.
 	for i := len(thumb.DefaultSizes) - 1; i >= 0; i-- {
 		name := thumb.DefaultSizes[i]


### PR DESCRIPTION
After one of the recent releases I found out that tensorflow is disabled on my device (with 1.7 GiB of memory as reported by `free`). I understand the concern, but I wanted to try to run tensorflow anyway and see how bad it is. So I added a way to bypass this check with an environment variable. I named it `unsafe_` to emphasize that it's not stable.

It turned out that my device still can run image recognition with these resources, so I would really like to have a way to disable low memory check. I'm not very familiar with Go, so if my change is not properly implemented or can be enhanced, I'll be happy to do it.

Another note, when tensorflow is disabled because of low mem, a checkbox 'Disable tensorflow' on frontend is checked and cannot be unchecked.