### PR TITLE
Translations: Update Polish

### DIFF
--- a/assets/locales/pl/default.po
+++ b/assets/locales/pl/default.po
@@ -144,7 +144,7 @@ msgstr "Nie udało się utworzyć pliku zip"
 
 #: messages.go:112
 msgid "Invalid credentials"
-msgstr "Nieprawidłowe poświadczenia"
+msgstr "Nieprawidłowe dane logowania"
 
 #: messages.go:113
 msgid "Invalid link"
@@ -290,7 +290,7 @@ msgstr "Przedmiot usunięty"
 
 #: messages.go:147
 msgid "Person saved"
-msgstr "Osoba uratowana"
+msgstr "Osoba zapisana"
 
 #: messages.go:148
 msgid "Person deleted"


### PR DESCRIPTION
I found  translations that look weird for native speaker

- credentials could be translated as _poświadczenie_ but it's quite official term and mean something like a certificate not login data (_`dane logowania`_). 
- To save somebody means to rescue so _`Person saved`_ translated to _`Osoba uratowana`_ means `Person rescued`. We should have _`Osoba zapisana`_ like with other _`<Object> saved`_ items.