### PR TITLE
Places: Add Normalization Mappings for NDS (Germany) #1664

### DIFF
--- a/pkg/txt/states.go
+++ b/pkg/txt/states.go
@@ -94,6 +94,7 @@ var StatesDE = LookupTable{
 	"HH":                     "Hamburg",
 	"HE":                     "Hessen",
 	"NI":                     "Niedersachsen",
+	"NDS":                    "Niedersachsen",
 	"Lower Saxony":           "Niedersachsen",
 	"Lower-Saxony":           "Niedersachsen",
 	"MV":                     "Mecklenburg-Vorpommern",


### PR DESCRIPTION
NDS is commonly used as an abbreviation for Niedersachsen.
See [Wikipedia](https://de.wikipedia.org/wiki/Niedersachsen) or in [the title of this Website of the local government](https://www.mi.niedersachsen.de/startseite/).