### PR TITLE
Retrieve missing state data from Overpass

### DIFF
--- a/internal/hub/overpass/overpass.go
+++ b/internal/hub/overpass/overpass.go
@@ -1,0 +1,114 @@
+package overpass
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	log "github.com/dsoprea/go-logging"
+	"github.com/photoprism/photoprism/pkg/s2"
+)
+
+const OverpassStateQuery = `
+is_in(%f,%f);
+area._[admin_level="4"];
+out meta;
+`
+
+const OverpassUrl = "https://overpass-api.de/api/interpreter"
+
+// OverpassResponse represents the response from the Overpass API.
+type OverpassResponse struct {
+	Version   float32           `json:"version"`
+	Generator string            `json:"generator"`
+	Elements  []OverpassElement `json:"elements"`
+}
+
+// OverpassElement represents a generic Overpass element.
+type OverpassElement struct {
+	ID   int               `json:"id"`
+	Type string            `json:"type"`
+	Tags map[string]string `json:"tags"`
+}
+
+// Name returns the native name of the Overpass element.
+func (e OverpassElement) Name() string {
+	return e.Tags["name"]
+}
+
+// InternationalName returns the international name of the Overpass element.
+func (e OverpassElement) InternationalName() string {
+	return e.Tags["int_name"]
+}
+
+// LocalizedNames returns a mapping of the available localized names (language ISO code -> name).
+func (e OverpassElement) LocalizedNames() map[string]string {
+	names := make(map[string]string)
+
+	for name, value := range e.Tags {
+		if strings.HasPrefix(name, "name:") {
+			country_code := name[len("name:"):]
+			names[country_code] = value
+		}
+	}
+
+	return names
+}
+
+// AdministrativeLevel returns the administrative level of the Overpass element if available.
+func (e OverpassElement) AdministrativeLevel() string {
+	return e.Tags["admin_level"]
+}
+
+// FindState queries the Overpass API to retrieve the state name in the native language for the given s2 cell.
+func FindState(token string) (state string, err error) {
+	lat, lng := s2.LatLng(token)
+	query := fmt.Sprintf(OverpassStateQuery, lat, lng)
+
+	r, err := queryOverpass(query)
+	if err != nil {
+		return state, err
+	}
+
+	if len(r.Elements) == 0 {
+		return state, fmt.Errorf("overpass: token %s does not have state data", token)
+	}
+
+	// TODO Should we return the "native" name or the international?
+	state = r.Elements[0].Name()
+
+	return state, nil
+}
+
+// queryOverpass sends the given query to the Overpass API and unmarshals the response.
+func queryOverpass(query string) (result OverpassResponse, err error) {
+	reader := strings.NewReader(fmt.Sprintf("data=[out:json];%s", query))
+	req, err := http.NewRequest(http.MethodPost, OverpassUrl, reader)
+
+	if err != nil {
+		log.Errorf("overpass: %s", err.Error())
+		return result, err
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	r, err := client.Do(req)
+
+	if err != nil {
+		log.Errorf("overpass: %s (http request)", err.Error())
+		return result, err
+	} else if r.StatusCode >= 400 {
+		err = fmt.Errorf("overpass: request failed with code %d", r.StatusCode)
+		return result, err
+	}
+
+	err = json.NewDecoder(r.Body).Decode(&result)
+
+	if err != nil {
+		log.Errorf("overpass: %s (decode json)", err.Error())
+		return result, err
+	}
+
+	return result, nil
+}

--- a/internal/hub/overpass/overpass_test.go
+++ b/internal/hub/overpass/overpass_test.go
@@ -1,0 +1,94 @@
+package overpass
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOverpassJson(t *testing.T) {
+	t.Run("Nepal", func(t *testing.T) {
+		overpassJson := `
+		{
+			"version": 0.6,
+			"generator": "Overpass API 0.7.57.1 74a55df1",
+			"osm3s": {
+				"timestamp_osm_base": "2021-11-21T08:51:55Z",
+				"timestamp_areas_base": "2021-11-21T08:27:30Z",
+				"copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+			},
+			"elements": [{
+				"type": "area",
+				"id": 3604583291,
+				"tags": {
+					"ISO3166-2": "NP-4",
+					"admin_level": "4",
+					"boundary": "historic",
+					"int_name": "Eastern Development Region",
+					"is_in:continent": "Asia",
+					"is_in:country": "Nepal",
+					"is_in:country_code": "NP",
+					"name": "पुर्वाञ्चल विकास क्षेत्र",
+					"name:ar": "المنطقة التنموية الشرقية",
+					"name:de": "Entwicklungsregion Ost",
+					"name:en": "Eastern Development Region",
+					"name:es": "Región de desarrollo Este",
+					"name:fr": "Région de développement Est",
+					"name:ja": "東部開発区域",
+					"name:ne": "पुर्वाञ्चल विकास क्षेत्र",
+					"name:pl": "Eastern Development Region",
+					"name:ru": "Восточный регион",
+					"name:ur": "مشرقی ترقیاتی علاقہ",
+					"name:zh": "东部经济发展区",
+					"note": "outdated",
+					"type": "boundary",
+					"wikidata": "Q28576",
+					"wikipedia": "en:Eastern Development Region, Nepal"
+				}
+			}]
+		}`
+
+		expectedLocalizedNames := map[string]string{
+			"ar": "المنطقة التنموية الشرقية",
+			"de": "Entwicklungsregion Ost",
+			"en": "Eastern Development Region",
+			"es": "Región de desarrollo Este",
+			"fr": "Région de développement Est",
+			"ja": "東部開発区域",
+			"ne": "पुर्वाञ्चल विकास क्षेत्र",
+			"pl": "Eastern Development Region",
+			"ru": "Восточный регион",
+			"ur": "مشرقی ترقیاتی علاقہ",
+			"zh": "东部经济发展区",
+		}
+
+		var r OverpassResponse
+
+		if err := json.Unmarshal([]byte(overpassJson), &r); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotNil(t, r)
+		assert.Len(t, r.Elements, 1)
+
+		overpassArea := r.Elements[0]
+		assert.Equal(t, "area", overpassArea.Type)
+		assert.Equal(t, "4", overpassArea.AdministrativeLevel())
+		assert.Equal(t, "पुर्वाञ्चल विकास क्षेत्र", overpassArea.Name())
+		assert.Equal(t, "Eastern Development Region", overpassArea.InternationalName())
+		assert.Equal(t, expectedLocalizedNames, overpassArea.LocalizedNames())
+	})
+}
+
+func TestFindState(t *testing.T) {
+	t.Run("Khumjung", func(t *testing.T) {
+		state, err := FindState("39e9ac0d2c4c")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, "पुर्वाञ्चल विकास क्षेत्र", state)
+	})
+}

--- a/internal/maps/location.go
+++ b/internal/maps/location.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/photoprism/photoprism/internal/hub/overpass"
 	"github.com/photoprism/photoprism/internal/hub/places"
 	"github.com/photoprism/photoprism/pkg/s2"
 	"github.com/photoprism/photoprism/pkg/txt"
@@ -69,6 +70,15 @@ func (l *Location) QueryPlaces() error {
 	l.LocState = s.State()
 	l.LocCountry = s.CountryCode()
 	l.LocKeywords = s.Keywords()
+
+	if l.LocState == "" {
+		state, err := overpass.FindState(l.ID)
+		if err != nil {
+			return err
+		}
+
+		l.LocState = state
+	}
 
 	return nil
 }


### PR DESCRIPTION
In case the places API does not provide state information for a given s2 cell, use the Overpass API to retrieve it.

Related to #1664 