### PR TITLE
Add dependabot config for automatic gomod/npm update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/frontend/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Merging this opens update PRs like they can be seen here https://github.com/dbast/photoprism/pulls

Proposed updates can be merged if CI is green or closed to be ignored.

There are also commands to tell dependabot e.g. to ignore specific major versions @dependabot ignore this major version as described in the PRs.
