### PR TITLE
People: Improve update performance on MariaDB

### DIFF
--- a/internal/entity/marker.go
+++ b/internal/entity/marker.go
@@ -555,9 +555,20 @@ func (m *Marker) RefreshPhotos() error {
 		return fmt.Errorf("empty marker uid")
 	}
 
-	return UnscopedDb().Exec(`UPDATE photos SET checked_at = NULL WHERE id IN
-		(SELECT f.photo_id FROM files f JOIN ? m ON m.file_uid = f.file_uid WHERE m.marker_uid = ? GROUP BY f.photo_id)`,
-		gorm.Expr(Marker{}.TableName()), m.MarkerUID).Error
+	var err error
+	switch DbDialect() {
+	case MySQL:
+		err = UnscopedDb().Exec(`UPDATE photos p JOIN files f ON f.photo_id = p.id
+			JOIN ? m ON m.file_uid = f.file_uid SET p.checked_at = NULL
+			WHERE m.marker_uid = ?`,
+			gorm.Expr(Marker{}.TableName()), m.MarkerUID).Error
+	default:
+		err = UnscopedDb().Exec(`UPDATE photos SET checked_at = NULL WHERE id IN
+			(SELECT f.photo_id FROM files f JOIN ? m ON m.file_uid = f.file_uid
+			WHERE m.marker_uid = ? GROUP BY f.photo_id)`,
+			gorm.Expr(Marker{}.TableName()), m.MarkerUID).Error
+	}
+	return err
 }
 
 // Matched updates the match timestamp.


### PR DESCRIPTION
MariaDB/MySQL traditionally have performance issues for queries of
type UPDATE ... WHERE xxx IN (SELECT ...)

Instead, use JOINs which are much faster.

As discussed in [this thread](https://github.com/photoprism/photoprism/discussions/1768#discussioncomment-1759544), I open this PR after verifying that all tests still pass in the docker compose dev environment, and I've been running these changes on my private collection and nothing blew up so far. This is the first time I touched Go code so I hope it's not too ugly. :-)