### PR TITLE
Config: Add Apple Video Toolbox hardware transcoding support for macOS

### DIFF
--- a/internal/photoprism/convert.go
+++ b/internal/photoprism/convert.go
@@ -26,6 +26,7 @@ import (
 
 const DefaultAvcEncoder = "libx264" // Default FFmpeg AVC software encoder.
 const IntelQsvEncoder = "h264_qsv"
+const AppleVideoToolbox = "h264_videotoolbox"
 
 // Convert represents a converter that can convert RAW/HEIF images to JPEG.
 type Convert struct {
@@ -379,6 +380,24 @@ func (c *Convert) AvcConvertCommand(f *MediaFile, avcName, codecName string) (re
 				"-maxrate", c.AvcBitrate(f),
 				"-f", "mp4",
 				"-y",
+				avcName,
+			)
+		} else if codecName == AppleVideoToolbox {
+			format := "format=yuv420p"
+
+			result = exec.Command(
+				c.conf.FFmpegBin(),
+				"-i", f.FileName(),
+				"-c:v", codecName,
+				"-c:a", "aac",
+				"-vf", format,
+				"-profile", "high",
+				"-level", "51",
+				"-vsync", "vfr",
+				"-r", "30",
+				"-b:v", c.AvcBitrate(f),
+				"-f", "mp4",
+				 "-y",
 				avcName,
 			)
 		} else {


### PR DESCRIPTION
I know Docker installation is the priority right now, and binaries for macOS or other platforms may or may not come in the future. Perhaps these modifications will be useful in the future if/when that comes. 

For my use case, I prefer to run Photoprism on macOS without Docker, due to disk I/O performance of Docker on Mac. Photoprism compiles and runs smoothly already. Thank you. 

What did not work was `ffmpeg` transcoding using `libx264`. `ffmpeg` threw an error of `Unrecognized option 'num_output_buffers'.` This got me digging further, and for macOS, `ffmpeg` can use Video Toolbox for hardware accelerated video encoding/transcoding. 

These proposed changes to the code are to recognize when `PHOTOPRISM_FFMPEG_ENCODER` is set to `h264_videotoolbox` and then to provide `ffmpeg` the appropriate option string.  The same options as `libx264` are not available for `h264_videotoolbox`. The proposed code is trying to mimic how Intel QuickSync is recognized and used. 

It's been running very well for me over the past week, and the transcoding is fast (500ms on an old machine) for Live Photos. The hover functionality to trigger the Live Photo feels instantaneous. 

My coding experience is limited, and I'm new to this excellent project. I hope this helps give back, is useful, and is not too much hassle to review. Given most devices can decode H.264 High Profile Level 5.1, it is hard coded as such, and this can be made to be set by new environment variables too.

One could also modify this to add an option to transcode to HEVC, using the `hevc_videotoolbox`, and while that may save bandwidth, not every client device is compatible with HEVC. I see there is another pull to use HEVC when the client can play it. https://github.com/photoprism/photoprism/pull/513

Unit test: `make test` had 310 tests pass, with one exception, which is unrelated to this pull request, as it occurred when testing a build without the code changes in this pull request. 

Acceptance test: Most of these worked. There were some errors They also are unrelated to the pull request, as the same ones occurred when testing a build without the code changes in this pull request. 

Thanks again for an excellent project. 