### PR TITLE
Videos: Exclude streaming from gzip compression

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,6 +64,7 @@ func Start(ctx context.Context, conf *config.Config) {
 				conf.BaseUri(config.ApiUri + "/zip"),
 				conf.BaseUri(config.ApiUri + "/albums"),
 				conf.BaseUri(config.ApiUri + "/labels"),
+				conf.BaseUri(config.ApiUri + "/videos"),
 			})))
 	}
 


### PR DESCRIPTION
Noticed that videos didn't start playing until fully downloaded when I used Firefox (OSX and Android). Started to investigate and found that the videos API path wasn't excluded from gzipping. When I turned off gzipping Firefox worked as expected.

This isn't a problem for Chrome and Safari because they don't seem to set `gzip` in the `Accept-Encoding` header for video resources but Firefox does.

The result is that, for Firefox, the server returns a gzipped stream and the browser seem to need to wait for all the data before start playing the video. And I guess gzipping compressed video cause unnecessary CPU usage as well.