### PR TITLE
Docker: Fix tensorflow Dockerfile

### DIFF
--- a/docker/tensorflow/Dockerfile
+++ b/docker/tensorflow/Dockerfile
@@ -58,6 +58,5 @@ RUN mv bazel-0.24.1-linux-x86_64 /usr/local/bin/bazel && chmod 755 /usr/local/bi
 # Configure TensorFlow
 WORKDIR "/home/tensorflow/tensorflow-1.15.2"
 COPY ./*.sh ./
-COPY ./*.diff ./
 COPY ./.tf_configure.bazelrc .tf_configure.bazelrc
 COPY ./Makefile Makefile


### PR DESCRIPTION
There are no more *.diff files as of 4f05fde794c so the COPY
command makes building the container fail. The deleted diff
file was for TF 1.14.x which has long been dropped.