### PR TITLE
Albums: Preload more items for auto-completion in "Add to album" dialog

### DIFF
--- a/frontend/src/dialog/photo/album.vue
+++ b/frontend/src/dialog/photo/album.vue
@@ -105,9 +105,13 @@ export default {
 
       this.loading = true;
 
+      // todo: either introduce infinite flag or
+      // make count parameter optional for REST API
+      const MAX_COUNT = 10000;
+
       const params = {
         q: q,
-        count: 1000,
+        count: MAX_COUNT,
         offset: 0,
         type: "album"
       };


### PR DESCRIPTION
<!--
Please describe your pull request:
- What does it implement / fix / improve?
- Is it related to an existing issue?
-->

This is a small hotfix to the "Add photos to album" dialog.

If there are more than 1000 albums in photoprism, a problem arises in the user interface:
- you cannot add photos to existing albums that are not included in the range
- worse, it looks like there is no such album yet, leading to duplicate albums with same name when pressing add button

This pull requests increases the max album fetch `count` to 10000 as quickfix and removes the magic number, declaring `MAX_COUNT` as explicit constant.

Future improvements of REST API may one of the following:
- include an "infinite count" flag, as the intention is always to provide *all* albums in autocomplete dialog
- make `count` query parameter optional

Background:
I have a bunch of auto-generated albums (> 1000) from external sources and found it very confusing, that only one half of albums have been displayed in the autocomplete.

---

<!--
After submitting your first pull request, you will automatically be asked to accept our Contributor License Agreement (CLA):

https://github.com/photoprism/photoprism/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla

Because we want to create the best possible product for our users, we have a set of guidelines to ensure that all submissions are acceptable.
Please check the following items by replacing "[ ]" with "[x]".
You can also do this when viewing the pull request after it was created:
-->

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work

This is a small change (projects with < 1000 albums not affected in any way), hence following points are neglected:
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [ ] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

