### PR TITLE
Use deb.debian.org host for CDN redirection

### DIFF
--- a/docker/develop/bookworm/sources.list
+++ b/docker/develop/bookworm/sources.list
@@ -1,4 +1,4 @@
-deb http://ftp.de.debian.org/debian bookworm contrib non-free
-deb http://ftp.de.debian.org/debian bookworm-updates contrib non-free
-deb http://ftp.de.debian.org/debian bookworm-backports main contrib non-free
+deb http://deb.debian.org/debian bookworm contrib non-free
+deb http://deb.debian.org/debian bookworm-updates contrib non-free
+deb http://deb.debian.org/debian bookworm-backports main contrib non-free
 deb http://security.debian.org/debian-security bookworm-security contrib non-free

--- a/docker/develop/bullseye/sources.list
+++ b/docker/develop/bullseye/sources.list
@@ -1,4 +1,4 @@
-deb http://ftp.de.debian.org/debian bullseye contrib non-free
-deb http://ftp.de.debian.org/debian bullseye-updates contrib non-free
-deb http://ftp.de.debian.org/debian bullseye-backports main contrib non-free
+deb http://deb.debian.org/debian bullseye contrib non-free
+deb http://deb.debian.org/debian bullseye-updates contrib non-free
+deb http://deb.debian.org/debian bullseye-backports main contrib non-free
 deb http://security.debian.org/debian-security bullseye-security contrib non-free


### PR DESCRIPTION
As per http://deb.debian.org/ this host name mapping maps to geolocation
based hosts.

This helps it auto-detecting and redirecting to the fastest available host.

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed
