### PR TITLE
Docker: Fix docker-local make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,8 +334,13 @@ docker-release-impish:
 	docker pull --platform=amd64 ubuntu:impish
 	docker pull --platform=arm64 ubuntu:impish
 	scripts/docker/buildx-multi.sh photoprism linux/amd64,linux/arm64 impish /impish
-docker-local:
-	scripts/docker/build.sh photoprism
+docker-local: docker-local-bookworm
+docker-local-bullseye:
+	docker pull photoprism/develop:bullseye
+	scripts/docker/build.sh photoprism bullseye /bullseye
+docker-local-bookworm:
+	docker pull photoprism/develop:bookworm
+	scripts/docker/build.sh photoprism bookworm /bookworm
 docker-pull:
 	docker pull photoprism/photoprism:preview photoprism/photoprism:latest
 docker-ddns:


### PR DESCRIPTION
With the adaptation to Debian Bullseye/Bookworm based images, the
docker-local make target got broken with below error.

```
rrs@lenovo:~/photoprism-repo (rickysarraf-develop)$ make docker-local
scripts/docker/build.sh photoprism
Usage: build.sh [name] [tag] [/subimage]
make: *** [Makefile:338: docker-local] Error 1
```

This PR fixes it by introducing the 2 new local targets for Bullseye and
Bookworm

Signed-off-by: Ritesh Raj Sarraf <rrs@researchut.com>

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

