### PR TITLE
Docker: Don't update permissions of originals on startup

### DIFF
--- a/scripts/dist/entrypoint-init.sh
+++ b/scripts/dist/entrypoint-init.sh
@@ -17,15 +17,18 @@ case $DOCKER_ENV in
   prod)
     export PATH="/usr/local/sbin:/usr/sbin:/sbin:/bin:/usr/local/bin:/usr/bin:/scripts:/opt/photoprism/bin";
     INIT_SCRIPTS="/scripts"
-    CHOWN_DIRS=("/photoprism" "/opt/photoprism")
+    CHOWN_DIRS=("/photoprism/storage" "/photoprism/import" "/opt/photoprism")
     CHMOD_DIRS=("/opt/photoprism")
+    CHOWN_ORIGINALS=("/photoprism/originals")
     ;;
 
   develop)
     export PATH="/usr/local/sbin:/usr/sbin:/sbin:/bin:/usr/local/bin:/usr/bin:/scripts:/usr/local/go/bin:/go/bin:/opt/photoprism/bin";
     INIT_SCRIPTS="/go/src/github.com/photoprism/photoprism/scripts/dist"
-    CHOWN_DIRS=("/photoprism" "/opt/photoprism" "/go" "/tmp/photoprism")
+    CHOWN_DIRS=("/photoprism/storage" "/photoprism/import" "/opt/photoprism" "/go" "/tmp/photoprism")
     CHMOD_DIRS=("/opt/photoprism" "/tmp/photoprism")
+    CHOWN_ORIGINALS=("/photoprism/originals")
+
     ;;
 
   *)
@@ -47,6 +50,14 @@ if [[ ${PHOTOPRISM_UID} =~ $re ]] && [[ ${PHOTOPRISM_UID} != "0" ]]; then
     chown --preserve-root --silent -R "${CHOWN}" "${CHOWN_DIRS[@]}"
     chmod --preserve-root --silent -R u+rwX "${CHMOD_DIRS[@]}"
   fi
+
+  if [[ -z ${PHOTOPRISM_DISABLE_CHOWN_ORIGINALS} ]] || [[ ${PHOTOPRISM_DISABLE_CHOWN_ORIGINALS} == "false" ]]; then
+    echo "init: updating originals permissions"
+    echo "PHOTOPRISM_DISABLE_CHOWN_ORIGINALS=\"true\" disables permission updates"
+    echo "You may need to adjust your Originals owners/permission to allow the container to read originals if PHOTOPRISM_DISABLE_CHOWN_ORIGINALS=true"
+    chown --preserve-root --silent -R "${CHOWN}" "${CHOWN_ORIGINALS[@]}"
+  fi
+
 fi
 
 # do nothing if PHOTOPRISM_INIT was not set


### PR DESCRIPTION
Separating Originals path from Storage and Imports path for CHOWN purposes.  This will allow users with specific ownership on Originals to retain those owners while allowing the rest of the pathing to be owned by the UID/GID in the container.

Photoprism states that it does NOT modify the Originals directory.  This is untrue.  A power user who controls the permissions of the Originals directory should be able to exclude it from being owned by container UID/GID.

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

