### PR TITLE
Videos: Skip transcoding of HEVC / HVC1 if supported by the browser #440 #513

### DIFF
--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -449,8 +449,9 @@ export class Photo extends RestModel {
 
   videoUrl() {
     let file = this.videoFile();
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
-    if (file && file.Codec === CodecHvc1 && navigator.userAgent.indexOf("Safari") !== -1) {
+    if (file && file.Codec === CodecHvc1 && isSafari) {
       return `${config.apiUri}/videos/${file.Hash}/${config.previewToken()}/${FormatHvc}`;
     }
 

--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -37,8 +37,10 @@ import download from "common/download";
 import * as src from "common/src";
 
 export const CodecAvc1 = "avc1";
+export const CodecHvc1 = "hvc1";
 export const FormatMp4 = "mp4";
 export const FormatAvc = "avc";
+export const FormatHvc = "hvc";
 export const FormatGif = "gif";
 export const FormatJpeg = "jpg";
 export const MediaImage = "image";
@@ -447,6 +449,10 @@ export class Photo extends RestModel {
 
   videoUrl() {
     let file = this.videoFile();
+
+    if (file && file.Codec === CodecHvc1 && navigator.userAgent.indexOf("Safari") !== -1) {
+      return `${config.apiUri}/videos/${file.Hash}/${config.previewToken()}/${FormatHvc}`;
+    }
 
     if (file) {
       return `${config.apiUri}/videos/${file.Hash}/${config.previewToken()}/${FormatAvc}`;

--- a/internal/api/headers.go
+++ b/internal/api/headers.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	ContentTypeAvc = `video/mp4; codecs="avc1"`
+	ContentTypeHvc = `video/mp4; codecs="hvc1"`
 )
 
 // AddCacheHeader adds a cache control header to the response.

--- a/internal/api/video.go
+++ b/internal/api/video.go
@@ -84,7 +84,11 @@ func GetVideo(router *gin.RouterGroup) {
 			}
 		}
 
-		AddContentTypeHeader(c, ContentTypeAvc)
+		if video.Types[formatName] == video.HEVC {
+			AddContentTypeHeader(c, ContentTypeHvc)
+		} else {
+			AddContentTypeHeader(c, ContentTypeAvc)
+		}
 
 		if c.Query("download") != "" {
 			c.FileAttachment(fileName, f.DownloadName(DownloadName(c), 0))


### PR DESCRIPTION
When using safari and requesting a HVC1 encoded video file, a transcoding to AVC1 is unnecessary, since safari handles HVC1 natively. This pull request removes the unnecessary conversion, thereby loading hvc1 videos faster in Safari and reducing the amount of work done by the server. 

Reference issue: https://github.com/photoprism/photoprism/issues/440
A reimplementation of https://github.com/photoprism/photoprism/pull/513

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed
