### PR TITLE
Sharing: Fix app navigation layout on small screens

### DIFF
--- a/frontend/src/share/routes.js
+++ b/frontend/src/share/routes.js
@@ -15,14 +15,14 @@ export default [
     name: "albums",
     path: "/s/:token",
     component: Albums,
-    meta: { title: shareTitle, auth: true },
+    meta: { title: shareTitle, auth: true, hideNav: true },
     props: { view: "album", staticFilter: { type: "" } },
   },
   {
     name: "album",
     path: "/s/:token/:uid",
     component: AlbumPhotos,
-    meta: { title: shareTitle, auth: true },
+    meta: { title: shareTitle, auth: true, hideNav: true },
   },
   {
     path: "*",


### PR DESCRIPTION
[There](https://github.com/photoprism/photoprism/blob/develop/frontend/src/css/navigation.css#L80-L82) exists a css-class to make sure that on small screens, there is space above the content for the nav-bar.
This is only relevant for small screens, because on wide screens the navigation is on the left side.

wether a nav-bar is shown or not can be configured in the `routes.js` on a per-route basis by either providing or not providing `meta: {hideNav: true}`.
This setting controls wether the `show-nav`-class (and therefore the 48px padding on small screens) gets applied or not.

Or in short: routes that don't have a navigation must have `meta: {hideNav: true}` set, otherwise there is blank space above the content on small screens, that looks like this:

| without fix | with fix |
| --- | --- |
| <img width="544" alt="Screenshot 2022-06-16 at 20 11 07" src="https://user-images.githubusercontent.com/20770029/174137768-39dad92b-f991-4f40-b738-2371aae2ca13.png"> | <img width="544" alt="Screenshot 2022-06-16 at 20 08 48" src="https://user-images.githubusercontent.com/20770029/174137790-6e5f8ec8-0601-429b-9897-b27d0db13c68.png"> |

The shared album views do not have a navigation, and therefore require this config. They are currently not configured correctly, resulting in the bug displayed above. This PR fixes that.

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [x] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

