### PR TITLE
update browser support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,5 +123,5 @@
     "npm": ">= 8.0.0",
     "yarn": "please use npm"
   },
-  "browserslist": ">0.25% and last 2 year"
+  "browserslist": ">0.25% and last 2 years"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,5 +123,5 @@
     "npm": ">= 8.0.0",
     "yarn": "please use npm"
   },
-  "browserslist": ">0.25% and last 1 year"
+  "browserslist": ">0.25% and last 2 year"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,9 +123,5 @@
     "npm": ">= 8.0.0",
     "yarn": "please use npm"
   },
-  "browserslist": [
-    "> 1%",
-    "not ie <= 9",
-    "last 3 versions"
-  ]
+  "browserslist": ">0.25% and last 1 year"
 }


### PR DESCRIPTION
The JavaScript we write is not the JavaScript that the browser executes.

We use modern language features that are not yet available in all browsers. To make photoprism work in those browser anyway, babel transpiles the code so that the newer language-features are replaced by older ones.

Babel uses the browserlist configured in the `package.json` to determine the lowest featureset / oldest browser that we still want to support. This browserlist ist currently configured in a way that forces babel to support some very old and or obsucre browsers like Blackberry 7, Kaios and QQ Browser (see [browserlist.dev: `> 1%, not ie <= 9, last 3 versions`](https://browserslist.dev/?q=PiAxJSwgbm90IGllIDw9IDksIGxhc3QgMyB2ZXJzaW9ucw%3D%3D))

Because of that the resulting bundle doesn't even include ES6 code, which is now a 7 year old standard.
Preventing the use of newer, natively supported language features increases bundlesize and makes the application slower (because the browser can't make use of optimizations in newer language features).

This PR updates the list of supported browsers to something more reasonable. See [browserlist.dev: `>0.25% and last 2 years`](https://browserslist.dev/?q=PjAuMjUlIGFuZCBsYXN0IDIgeWVhcnM%3D)


PS: I assume the old browserlist was misconfigured because of a misunderstanding. Defining an array of queries means a browser needs to pass **any** of these queries, not **all** of them.

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [x] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed