### PR TITLE
fix scrolling in cards-view lagging regularly on small screens

### DIFF
--- a/frontend/src/component/photo/cards.vue
+++ b/frontend/src/component/photo/cards.vue
@@ -317,13 +317,11 @@ export default {
       }
 
       /**
-       * observing only every 5th item reduces the amount of time
-       * spent computing intersection by 80%. me might render up to
-       * 8 items more than required, but the time saved computing
-       * intersections is far greater than the time lost rendering
-       * a couple more items
+       * observing only every 5th item doesn't work here, because on small
+       * screens there aren't >= 5 elements in the viewport at all times.
+       * observing every second element should work.
        */
-      for (let i = 0; i < this.$refs.items.length; i += 5) {
+      for (let i = 0; i < this.$refs.items.length; i += 2) {
         this.intersectionObserver.observe(this.$refs.items[i]);
       }
     },


### PR DESCRIPTION
On small screens in card view, there might only be 2 or 3 elements in the rendered area (screen area + 50% height in both directions).

For performance reasons, only the visibility of every 5th item is **currently** observed.

To determine the first- and last element to render, at least one observed item has to be in the rendered area at all times.
If that is not the case:
- the first- and last visible element index to render become `NaN`
- Therefore all loaded Elements get rendered
- As soon as an observed element enters the visible area the first- and last visible element become correct numbers again
- Therefore everything outside the viewport gets replaced with placeholders again

This "Render everything, then remove everything" is obviously slow, resulting in very noticable lag when scrolling.

This PR fixes that by having every 2nd element observed in the cards view, instead of every 5th.
I don't think there is a screen whose rendered area (screen area + 50% height in both directions) would contain < 2 cards, as that would mean that even a single card wouldn't fit that screen.

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

