### PR TITLE
Fix Card border-radius and mosaic selected box-shadow

### DIFF
--- a/frontend/src/component/photo/cards.vue
+++ b/frontend/src/component/photo/cards.vue
@@ -28,7 +28,7 @@
           :data-index="index"
           class="flex xs12 sm6 md4 lg3 xlg2 xxxl1 d-flex"
       >
-        <div :class="photo.classes()" class="result card-background accent lighten-3">
+        <div class="result card-background accent lighten-3">
           <div v-if="index < firstVisibleElementIndex || index > lastVisibileElementIndex" class="placeholder">
             <div class="accent lighten-2 image"/>
             <div v-if="photo.Quality < 3 && context === 'review'" style="width: 100%; height: 34px"/>
@@ -70,6 +70,7 @@
                 :data-id="photo.ID"
                 :data-uid="photo.UID"
                 class="accent lighten-3"
+                :class="photo.classes()"
                 @contextmenu.stop="onContextMenu($event, index)">
             <div :key="photo.Hash"
                   :alt="photo.Title"

--- a/frontend/src/component/photo/cards.vue
+++ b/frontend/src/component/photo/cards.vue
@@ -20,7 +20,7 @@
         </p>
       </v-alert>
     </template>
-    <v-layout row wrap class="search-results photo-results cards-view" :class="{'select-results': selectMode}">
+    <div class="layout row wrap search-results photo-results cards-view" :class="{'select-results': selectMode}">
       <div
           v-for="(photo, index) in photos"
           ref="items"
@@ -28,205 +28,205 @@
           :data-index="index"
           class="flex xs12 sm6 md4 lg3 xlg2 xxxl1 d-flex"
       >
-        <div v-if="index < firstVisibleElementIndex || index > lastVisibileElementIndex" class="accent lighten-3 result placeholder">
-          <div class="accent lighten-2 image"/>
-          <div v-if="photo.Quality < 3 && context === 'review'" style="width: 100%; height: 34px"/>
-          <div class="pa-3 card-details">
-            <div>
-              <h3 class="body-2 mb-2" :title="photo.Title">
-                {{ photo.Title | truncate(80) }}
-              </h3>
-              <div v-if="photo.Description" class="caption mb-2">
-                {{ photo.Description }}
-              </div>
-              <div class="caption">
-                  <i/>
-                  {{ photo.getDateString(true) }}
-                <br>
-                <i/>
-                <template v-if="photo.Type === 'video' || photo.Type === 'animated'">
-                  {{ photo.getVideoInfo() }}
-                </template>
-                <template v-else>
-                  {{ photo.getPhotoInfo() }}
-                </template>
-                <template v-if="filter.order === 'name' && $config.feature('download')">
+        <div :class="photo.classes()" class="result card-background accent lighten-3">
+          <div v-if="index < firstVisibleElementIndex || index > lastVisibileElementIndex" class="placeholder">
+            <div class="accent lighten-2 image"/>
+            <div v-if="photo.Quality < 3 && context === 'review'" style="width: 100%; height: 34px"/>
+            <div class="pa-3 card-details">
+              <div>
+                <h3 class="body-2 mb-2" :title="photo.Title">
+                  {{ photo.Title | truncate(80) }}
+                </h3>
+                <div v-if="photo.Description" class="caption mb-2">
+                  {{ photo.Description }}
+                </div>
+                <div class="caption">
+                    <i/>
+                    {{ photo.getDateString(true) }}
                   <br>
                   <i/>
-                  {{ photo.baseName() }}
-                </template>
-                <template v-if="featPlaces && photo.Country !== 'zz'">
-                  <br>
-                  <i/>
-                  {{ photo.locationInfo() }}
-                </template>
+                  <template v-if="photo.Type === 'video' || photo.Type === 'animated'">
+                    {{ photo.getVideoInfo() }}
+                  </template>
+                  <template v-else>
+                    {{ photo.getPhotoInfo() }}
+                  </template>
+                  <template v-if="filter.order === 'name' && $config.feature('download')">
+                    <br>
+                    <i/>
+                    {{ photo.baseName() }}
+                  </template>
+                  <template v-if="featPlaces && photo.Country !== 'zz'">
+                    <br>
+                    <i/>
+                    {{ photo.locationInfo() }}
+                  </template>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        <div v-else
-              tile
-              :data-id="photo.ID"
-              :data-uid="photo.UID"
-              class="result accent lighten-3"
-              :class="photo.classes()"
-              @contextmenu.stop="onContextMenu($event, index)">
-          <div class="card-background accent lighten-3"></div>
-          <div :key="photo.Hash"
-                :alt="photo.Title"
-                :title="photo.Title"
-                class="accent lighten-2 clickable image"
-                :style="`background-image: url(${photo.thumbnailUrl('tile_500')})`"
-                @touchstart.passive="input.touchStart($event, index)"
-                @touchend.stop.prevent="onClick($event, index)"
-                @mousedown.stop.prevent="input.mouseDown($event, index)"
-                @click.stop.prevent="onClick($event, index)"
-                @mouseover="playLive(photo)"
-                @mouseleave="pauseLive(photo)"
-          >
-            <v-layout v-if="photo.Type === 'live' || photo.Type === 'animated'" class="live-player">
-              <video :id="'live-player-' + photo.ID" :key="photo.ID" width="500" height="500" preload="none"
-                    loop muted playsinline>
-                <source :src="photo.videoUrl()">
-              </video>
-            </v-layout>
-
-            <button v-if="photo.Type !== 'image' || photo.Files.length > 1"
-                  class="input-open"
-                  @touchstart.stop.prevent="input.touchStart($event, index)"
-                  @touchend.stop.prevent="onOpen($event, index, true)"
-                  @touchmove.stop.prevent
-                  @click.stop.prevent="onOpen($event, index, true)">
-                <i v-if="photo.Type === 'raw'" class="action-raw" :title="$gettext('RAW')">photo_camera</i>
-                <i v-if="photo.Type === 'live'" class="action-live" :title="$gettext('Live')"><icon-live-photo/></i>
-                <i v-if="photo.Type === 'animated'" class="action-animated" :title="$gettext('Animated')">gif</i>
-                <i v-if="photo.Type === 'video'" class="action-play" :title="$gettext('Video')">play_arrow</i>
-                <i v-if="photo.Type === 'image'" class="action-stack" :title="$gettext('Stack')">burst_mode</i>
-            </button>
-
-            <button v-if="photo.Type === 'image' && selectMode"
-                  class="input-view"
-                  :title="$gettext('View')"
-                  @touchstart.stop.prevent="input.touchStart($event, index)"
-                  @touchend.stop.prevent="onOpen($event, index, false)"
-                  @touchmove.stop.prevent
-                  @click.stop.prevent="onOpen($event, index, false)">
-              <i class="action-fullscreen">zoom_in</i>
-            </button>
-
-            <button v-if="featPrivate && photo.Private" class="input-private">
-              <i class="select-on">lock</i>
-            </button>
-
-            <!--
-              We'd usually use v-if here to only render the button if needed.
-              Because the button is supposed to be visible when the result is
-              being hovered over, implementing the v-if would require the use of
-              a <v-hover> element around the result.
-
-              Because rendering the plain HTML-Button is faster than rendering
-              the v-hover component we instead hide the button by default and
-              use css to show it when it is being hovered.
-            -->
-            <button
-                  class="input-select"
-                  @touchstart.stop.prevent="input.touchStart($event, index)"
-                  @touchend.stop.prevent="onSelect($event, index)"
-                  @touchmove.stop.prevent
-                  @click.stop.prevent="onSelect($event, index)">
-              <i class="select-on">check_circle</i>
-              <i class="select-off">radio_button_off</i>
-            </button>
-
-            <button
-                  class="input-favorite"
-                  @touchstart.stop.prevent="input.touchStart($event, index)"
-                  @touchend.stop.prevent="toggleLike($event, index)"
-                  @touchmove.stop.prevent
-                  @click.stop.prevent="toggleLike($event, index)">
-              <i v-if="photo.Favorite">favorite</i>
-              <i v-else>favorite_border</i>
-            </button>
-          </div>
-
-          <v-card-actions v-if="photo.Quality < 3 && context === 'review'" class="card-details pa-0">
-            <v-layout row wrap align-center>
-              <v-flex xs6 class="text-xs-center pa-1">
-                <v-btn color="accent lighten-2"
-                      small depressed dark block :round="false"
-                      class="action-archive text-xs-center"
-                      :title="$gettext('Archive')" @click.stop="photo.archive()">
-                  <v-icon dark>clear</v-icon>
-                </v-btn>
-              </v-flex>
-              <v-flex xs6 class="text-xs-center pa-1">
-                <v-btn color="accent lighten-2"
-                      small depressed dark block :round="false"
-                      class="action-approve text-xs-center"
-                      :title="$gettext('Approve')" @click.stop="photo.approve()">
-                  <v-icon dark>check</v-icon>
-                </v-btn>
-              </v-flex>
-            </v-layout>
-          </v-card-actions>
-
-          <div class="pa-3 card-details">
-            <div>
-              <h3 class="body-2 mb-2" :title="photo.Title">
-                <button class="action-title-edit" :data-uid="photo.UID"
-                        @click.exact="editPhoto(index)">
-                  {{ photo.Title | truncate(80) }}
-                </button>
-              </h3>
-              <div v-if="photo.Description" class="caption mb-2" :title="$gettext('Description')">
-                <button @click.exact="editPhoto(index)">
-                  {{ photo.Description }}
-                </button>
+          <div v-else
+                tile
+                :data-id="photo.ID"
+                :data-uid="photo.UID"
+                class="accent lighten-3"
+                @contextmenu.stop="onContextMenu($event, index)">
+            <div :key="photo.Hash"
+                  :alt="photo.Title"
+                  :title="photo.Title"
+                  class="accent lighten-2 clickable image"
+                  :style="`background-image: url(${photo.thumbnailUrl('tile_500')})`"
+                  @touchstart.passive="input.touchStart($event, index)"
+                  @touchend.stop.prevent="onClick($event, index)"
+                  @mousedown.stop.prevent="input.mouseDown($event, index)"
+                  @click.stop.prevent="onClick($event, index)"
+                  @mouseover="playLive(photo)"
+                  @mouseleave="pauseLive(photo)"
+            >
+              <div v-if="photo.Type === 'live' || photo.Type === 'animated'" class="layout live-player">
+                <video :id="'live-player-' + photo.ID" :key="photo.ID" width="500" height="500" preload="none"
+                      loop muted playsinline>
+                  <source :src="photo.videoUrl()">
+                </video>
               </div>
-              <div class="caption">
-                <button class="action-date-edit" :data-uid="photo.UID"
-                        @click.exact="editPhoto(index)">
-                  <i :title="$gettext('Taken')">date_range</i>
-                  {{ photo.getDateString(true) }}
-                </button>
-                <br>
-                <button v-if="photo.Type === 'video'" :title="$gettext('Video')"
-                        @click.exact="openPhoto(index, true)">
-                  <i>movie</i>
-                  {{ photo.getVideoInfo() }}
-                </button>
-                <button v-else-if="photo.Type === 'animated'" :title="$gettext('Animated')+' GIF'"
-                        @click.exact="openPhoto(index, true)">
-                  <i>gif_box</i>
-                  {{ photo.getVideoInfo() }}
-                </button>
-                <button v-else :title="$gettext('Camera')" class="action-camera-edit"
-                        :data-uid="photo.UID" @click.exact="editPhoto(index)">
-                  <i>photo_camera</i>
-                  {{ photo.getPhotoInfo() }}
-                </button>
-                <template v-if="filter.order === 'name' && $config.feature('download')">
-                  <br>
-                  <button :title="$gettext('Name')"
-                          @click.exact="downloadFile(index)">
-                    <i>insert_drive_file</i>
-                    {{ photo.baseName() }}
+
+              <button v-if="photo.Type !== 'image' || photo.Files.length > 1"
+                    class="input-open"
+                    @touchstart.stop.prevent="input.touchStart($event, index)"
+                    @touchend.stop.prevent="onOpen($event, index, true)"
+                    @touchmove.stop.prevent
+                    @click.stop.prevent="onOpen($event, index, true)">
+                  <i v-if="photo.Type === 'raw'" class="action-raw" :title="$gettext('RAW')">photo_camera</i>
+                  <i v-if="photo.Type === 'live'" class="action-live" :title="$gettext('Live')"><icon-live-photo/></i>
+                  <i v-if="photo.Type === 'animated'" class="action-animated" :title="$gettext('Animated')">gif</i>
+                  <i v-if="photo.Type === 'video'" class="action-play" :title="$gettext('Video')">play_arrow</i>
+                  <i v-if="photo.Type === 'image'" class="action-stack" :title="$gettext('Stack')">burst_mode</i>
+              </button>
+
+              <button v-if="photo.Type === 'image' && selectMode"
+                    class="input-view"
+                    :title="$gettext('View')"
+                    @touchstart.stop.prevent="input.touchStart($event, index)"
+                    @touchend.stop.prevent="onOpen($event, index, false)"
+                    @touchmove.stop.prevent
+                    @click.stop.prevent="onOpen($event, index, false)">
+                <i class="action-fullscreen">zoom_in</i>
+              </button>
+
+              <button v-if="featPrivate && photo.Private" class="input-private">
+                <i class="select-on">lock</i>
+              </button>
+
+              <!--
+                We'd usually use v-if here to only render the button if needed.
+                Because the button is supposed to be visible when the result is
+                being hovered over, implementing the v-if would require the use of
+                a <v-hover> element around the result.
+
+                Because rendering the plain HTML-Button is faster than rendering
+                the v-hover component we instead hide the button by default and
+                use css to show it when it is being hovered.
+              -->
+              <button
+                    class="input-select"
+                    @touchstart.stop.prevent="input.touchStart($event, index)"
+                    @touchend.stop.prevent="onSelect($event, index)"
+                    @touchmove.stop.prevent
+                    @click.stop.prevent="onSelect($event, index)">
+                <i class="select-on">check_circle</i>
+                <i class="select-off">radio_button_off</i>
+              </button>
+
+              <button
+                    class="input-favorite"
+                    @touchstart.stop.prevent="input.touchStart($event, index)"
+                    @touchend.stop.prevent="toggleLike($event, index)"
+                    @touchmove.stop.prevent
+                    @click.stop.prevent="toggleLike($event, index)">
+                <i v-if="photo.Favorite">favorite</i>
+                <i v-else>favorite_border</i>
+              </button>
+            </div>
+
+            <v-card-actions v-if="photo.Quality < 3 && context === 'review'" class="card-details pa-0">
+              <div class="layout row wrap align-center">
+                <v-flex xs6 class="text-xs-center pa-1">
+                  <v-btn color="accent lighten-2"
+                        small depressed dark block :round="false"
+                        class="action-archive text-xs-center"
+                        :title="$gettext('Archive')" @click.stop="photo.archive()">
+                    <v-icon dark>clear</v-icon>
+                  </v-btn>
+                </v-flex>
+                <v-flex xs6 class="text-xs-center pa-1">
+                  <v-btn color="accent lighten-2"
+                        small depressed dark block :round="false"
+                        class="action-approve text-xs-center"
+                        :title="$gettext('Approve')" @click.stop="photo.approve()">
+                    <v-icon dark>check</v-icon>
+                  </v-btn>
+                </v-flex>
+              </div>
+            </v-card-actions>
+
+            <div class="pa-3 card-details">
+              <div>
+                <h3 class="body-2 mb-2" :title="photo.Title">
+                  <button class="action-title-edit" :data-uid="photo.UID"
+                          @click.exact="editPhoto(index)">
+                    {{ photo.Title | truncate(80) }}
                   </button>
-                </template>
-                <template v-if="featPlaces && photo.Country !== 'zz'">
-                  <br>
-                  <button :title="$gettext('Location')" class="action-location"
-                          :data-uid="photo.UID" @click.exact="openLocation(index)">
-                    <i>location_on</i>
-                    {{ photo.locationInfo() }}
+                </h3>
+                <div v-if="photo.Description" class="caption mb-2" :title="$gettext('Description')">
+                  <button @click.exact="editPhoto(index)">
+                    {{ photo.Description }}
                   </button>
-                </template>
+                </div>
+                <div class="caption">
+                  <button class="action-date-edit" :data-uid="photo.UID"
+                          @click.exact="editPhoto(index)">
+                    <i :title="$gettext('Taken')">date_range</i>
+                    {{ photo.getDateString(true) }}
+                  </button>
+                  <br>
+                  <button v-if="photo.Type === 'video'" :title="$gettext('Video')"
+                          @click.exact="openPhoto(index, true)">
+                    <i>movie</i>
+                    {{ photo.getVideoInfo() }}
+                  </button>
+                  <button v-else-if="photo.Type === 'animated'" :title="$gettext('Animated')+' GIF'"
+                          @click.exact="openPhoto(index, true)">
+                    <i>gif_box</i>
+                    {{ photo.getVideoInfo() }}
+                  </button>
+                  <button v-else :title="$gettext('Camera')" class="action-camera-edit"
+                          :data-uid="photo.UID" @click.exact="editPhoto(index)">
+                    <i>photo_camera</i>
+                    {{ photo.getPhotoInfo() }}
+                  </button>
+                  <template v-if="filter.order === 'name' && $config.feature('download')">
+                    <br>
+                    <button :title="$gettext('Name')"
+                            @click.exact="downloadFile(index)">
+                      <i>insert_drive_file</i>
+                      {{ photo.baseName() }}
+                    </button>
+                  </template>
+                  <template v-if="featPlaces && photo.Country !== 'zz'">
+                    <br>
+                    <button :title="$gettext('Location')" class="action-location"
+                            :data-uid="photo.UID" @click.exact="openLocation(index)">
+                      <i>location_on</i>
+                      {{ photo.locationInfo() }}
+                    </button>
+                  </template>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </v-layout>
+    </div>
   </v-container>
 </template>
 <script>

--- a/frontend/src/component/photo/mosaic.vue
+++ b/frontend/src/component/photo/mosaic.vue
@@ -30,16 +30,25 @@
       >
        <!--
          The following div is the layout + size container. It makes the browser not
-         re-layout all elements in the list when the children of one of them changes
+         re-layout all elements in the list when the children of one of them changes.
+         We'd usually put the result-class and photo-classes on this, but that hurts
+         performance, because
+         1. photos would need to get accessed for placehoders (accessing large reactive array is slow)
+         2. the image-container could change size on selection, resulting in huge re-layout
+
+         We therefore put result- and photo classes in the actual rendered in-view node
+
+         We still add the result-class here aswell, because
         -->
-        <div :class="photo.classes()" class="image-container result accent lighten-2">
+        <div class="image-container result accent lighten-2">
           <div  v-if="index >= firstVisibleElementIndex && index <= lastVisibileElementIndex"
                 :key="photo.Hash"
                 tile
                 :data-id="photo.ID"
                 :data-uid="photo.UID"
                 :style="`background-image: url(${photo.thumbnailUrl('tile_224')})`"
-                class="accent lighten-2 clickable image"
+                :class="photo.classes()"
+                class="result accent lighten-2 clickable image"
                 :alt="photo.Title"
                 :title="photo.Title"
                 @contextmenu.stop="onContextMenu($event, index)"

--- a/frontend/src/component/photo/mosaic.vue
+++ b/frontend/src/component/photo/mosaic.vue
@@ -20,7 +20,7 @@
         </p>
       </v-alert>
     </template>
-    <v-layout row wrap class="search-results photo-results mosaic-view" :class="{'select-results': selectMode}">
+    <div class="layout row wrap search-results photo-results mosaic-view" :class="{'select-results': selectMode}">
       <div
           v-for="(photo, index) in photos"
           ref="items"
@@ -32,15 +32,14 @@
          The following div is the layout + size container. It makes the browser not
          re-layout all elements in the list when the children of one of them changes
         -->
-        <div class="image-container">
-          <div v-if="index < firstVisibleElementIndex || index > lastVisibileElementIndex" class="accent lighten-2 result image" />
-          <div  v-else
+        <div :class="photo.classes()" class="image-container result accent lighten-2">
+          <div  v-if="index >= firstVisibleElementIndex && index <= lastVisibileElementIndex"
                 :key="photo.Hash"
                 tile
                 :data-id="photo.ID"
                 :data-uid="photo.UID"
                 :style="`background-image: url(${photo.thumbnailUrl('tile_224')})`"
-                :class="photo.classes().join(' ') + ' accent lighten-2 result clickable image'"
+                class="accent lighten-2 clickable image"
                 :alt="photo.Title"
                 :title="photo.Title"
                 @contextmenu.stop="onContextMenu($event, index)"
@@ -50,12 +49,12 @@
                 @click.stop.prevent="onClick($event, index)"
                 @mouseover="playLive(photo)"
                 @mouseleave="pauseLive(photo)">
-            <v-layout v-if="photo.Type === 'live' || photo.Type === 'animated'" class="live-player">
+            <div v-if="photo.Type === 'live' || photo.Type === 'animated'" class="layout live-player">
               <video :id="'live-player-' + photo.ID" :key="photo.ID" width="224" height="224" preload="none"
                     loop muted playsinline>
                 <source :src="photo.videoUrl()">
               </video>
-            </v-layout>
+            </div>
 
             <button v-if="photo.Type !== 'image' || photo.Files.length > 1"
                   class="input-open"
@@ -118,7 +117,7 @@
           </div>
         </div>
       </div>
-    </v-layout>
+    </div>
   </v-container>
 </template>
 <script>

--- a/frontend/src/component/photo/mosaic.vue
+++ b/frontend/src/component/photo/mosaic.vue
@@ -30,18 +30,11 @@
       >
        <!--
          The following div is the layout + size container. It makes the browser not
-         re-layout all elements in the list when the children of one of them changes.
-         We'd usually put the result-class and photo-classes on this, but that hurts
-         performance, because
-         1. photos would need to get accessed for placehoders (accessing large reactive array is slow)
-         2. the image-container could change size on selection, resulting in huge re-layout
-
-         We therefore put result- and photo classes in the actual rendered in-view node
-
-         We still add the result-class here aswell, because
+         re-layout all elements in the list when the children of one of them changes
         -->
-        <div class="image-container result accent lighten-2">
-          <div  v-if="index >= firstVisibleElementIndex && index <= lastVisibileElementIndex"
+        <div class="image-container">
+          <div v-if="index < firstVisibleElementIndex || index > lastVisibileElementIndex" class="accent lighten-2 result image"/>
+          <div v-else
                 :key="photo.Hash"
                 tile
                 :data-id="photo.ID"

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -184,7 +184,7 @@ body.chrome #photoprism .search-results .result {
 }
 
 #photoprism .list-view {
-    box-shadow: 0 0 0 0 rgba(0,0,0,.2),0 0 0 0 rgba(0,0,0,.14),0 0 0 0 rgba(0,0,0,.12) !important;
+    box-shadow: none !important;
 }
 
 #photoprism .cards-view .result,
@@ -194,8 +194,10 @@ body.chrome #photoprism .search-results .result {
     -moz-transition-duration: 15ms !important;
     -o-transition-duration: 15ms !important;
     transition-duration: 15ms !important;
-    margin: 4px !important;
-    box-shadow: 0 0 0 0 rgba(0, 0, 0, .2), 0 0 0 0 rgba(0, 0, 0, .14), 0 0 0 0 rgba(0, 0, 0, .12) !important;
+    margin: 4px;
+    border-radius: 3px;
+    overflow: hidden;
+    box-shadow: none;
 }
 
 #photoprism .search-results .image-container {
@@ -205,7 +207,7 @@ body.chrome #photoprism .search-results .result {
 
 #photoprism .cards-view .result .image,
 #photoprism .list-view .result .image,
-#photoprism .mosaic-view .result.image
+#photoprism .mosaic-view .result .image
 {
   position: relative;
   user-select: none;
@@ -213,13 +215,11 @@ body.chrome #photoprism .search-results .result {
   background-position: center center;
   background-size: cover;
   background-repeat: no-repeat;
-  border-radius: 3px;
-  overflow: hidden;
 }
 
 #photoprism .cards-view .result .image button,
 #photoprism .list-view .result .image button,
-#photoprism .mosaic-view .result.image button {
+#photoprism .mosaic-view .result .image button {
   position: absolute;
   display: flex;
   justify-content: center;
@@ -242,11 +242,11 @@ body.chrome #photoprism .search-results .result {
 }
 #photoprism .cards-view .result .image button:hover,
 #photoprism .list-view .result .image button:hover,
-#photoprism .mosaic-view .result.image button:hover {
+#photoprism .mosaic-view .result .image button:hover {
   background-color: rgba(255, 255, 255, 0.12);
 }
 
-#photoprism .mosaic-view .result.image i,
+#photoprism .mosaic-view .result .image i,
 #photoprism .list-view .result .image i,
 #photoprism .cards-view .result .image i {
   color: white;
@@ -279,7 +279,7 @@ body.chrome #photoprism .search-results .result {
 }
 
 
-#photoprism .cards-view .result.placeholder .card-details i {
+#photoprism .cards-view .result .placeholder .card-details i {
   width: 14px;
 }
 

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -200,6 +200,10 @@ body.chrome #photoprism .search-results .result {
     box-shadow: none;
 }
 
+#photoprism .list-view .result .image {
+    border-radius: 3px;
+}
+
 #photoprism .search-results .image-container {
   aspect-ratio: 1;
   contain: layout paint style size;

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -206,12 +206,12 @@ body.chrome #photoprism .search-results .result {
 
 #photoprism .search-results .image-container {
   aspect-ratio: 1;
-  contain: layout paint style size !important;
+  contain: layout style size;
 }
 
 #photoprism .cards-view .result .image,
 #photoprism .list-view .result .image,
-#photoprism .mosaic-view .result .image
+#photoprism .mosaic-view .result.image
 {
   position: relative;
   user-select: none;
@@ -223,7 +223,7 @@ body.chrome #photoprism .search-results .result {
 
 #photoprism .cards-view .result .image button,
 #photoprism .list-view .result .image button,
-#photoprism .mosaic-view .result .image button {
+#photoprism .mosaic-view .result.image button {
   position: absolute;
   display: flex;
   justify-content: center;
@@ -246,11 +246,11 @@ body.chrome #photoprism .search-results .result {
 }
 #photoprism .cards-view .result .image button:hover,
 #photoprism .list-view .result .image button:hover,
-#photoprism .mosaic-view .result .image button:hover {
+#photoprism .mosaic-view .result.image button:hover {
   background-color: rgba(255, 255, 255, 0.12);
 }
 
-#photoprism .mosaic-view .result .image i,
+#photoprism .mosaic-view .result.image i,
 #photoprism .list-view .result .image i,
 #photoprism .cards-view .result .image i {
   color: white;

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -206,7 +206,7 @@ body.chrome #photoprism .search-results .result {
 
 #photoprism .search-results .image-container {
   aspect-ratio: 1;
-  contain: layout paint style size;
+  contain: layout paint style size !important;
 }
 
 #photoprism .cards-view .result .image,


### PR DESCRIPTION
### DO NO MERGE YET.
- Performance has gotten worse in mosaic view, because the photos-array is accessed for placeholders now
- It is not yet tested on more browsers

---

- The selected mosaic-entries currently have no box-shadow, even though they should
- The Elements in the cards-view have no border-radius at the bottom, even though they should
- The Images in the elements in the cards view have a border-radius at the bottom, even though they shouldn't

This PR fixes thexe things.
It also implements two other cleanups
- make sure the element that has the `result`-class is a parent-element of the one that has the `image`-class in the mosaic view. cards- and list-view were already implemented that way, and to reduce special-cases, i adjusted mosaic-view to work the same.
- remove now unnecessary placeholder-element in mosaic-view by making the container that holds the whole element anyway look like the placeholder
- replace `box-shadow: 0 0 0 0 ....` with `box-shadow: none`, because a `0 0 0 0`-box-shadow is not visible

| before | after |
| --- | --- |
| <img width="338" alt="card-before" src="https://user-images.githubusercontent.com/20770029/174463020-ccb09870-cc3c-47c8-b0d6-03940b3f2a2b.png"> | <img width="337" alt="card-after" src="https://user-images.githubusercontent.com/20770029/174463161-3c9d4cef-d13c-4359-b958-e72d42f969ef.png"> |
| <img width="466" alt="mosaic-selected-before" src="https://user-images.githubusercontent.com/20770029/174463030-7b355951-3e49-4734-a12d-f733f6e5788f.png"> | <img width="455" alt="mosaic-selected-after" src="https://user-images.githubusercontent.com/20770029/174463033-32404d1b-7099-4134-ae6d-08a675df0614.png"> |

Acceptance Criteria:

- [ ] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [x] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

