### PR TITLE
UX: Support older browsers by adding aspect-ratio CSS fallback

### DIFF
--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -199,7 +199,7 @@ body.chrome #photoprism .search-results .result {
 }
 
 #photoprism .search-results .image-container {
-  aspect-ratio: 1;
+  /*aspect-ratio: 1;*/
   contain: layout paint style size;
 }
 
@@ -209,7 +209,7 @@ body.chrome #photoprism .search-results .result {
 {
   position: relative;
   user-select: none;
-  aspect-ratio: 1;
+  /*aspect-ratio: 1;*/
   background-position: center center;
   background-size: cover;
   background-repeat: no-repeat;
@@ -481,14 +481,13 @@ body.chrome #photoprism .search-results .result {
 }
 
 /* old browser support */
-@supports not (aspect-ratio: 1) {
+/*@supports not (aspect-ratio: 1) {*/
   #photoprism .search-results .image-container {
     height: 0;
     padding-bottom: 100%;
   }
 
   #photoprism .cards-view .result .image,
-  #photoprism .list-view .result .image,
   #photoprism .mosaic-view .result.image
   {
     height: 0;
@@ -499,6 +498,7 @@ body.chrome #photoprism .search-results .result {
     padding-bottom: calc(100% - 8px)
   }
 
+  #photoprism .cards-view .result.is-selected,
   #photoprism .mosaic-view .result.is-selected {
     /*
        if it is selected then it has no more margin, so DON't subtract them
@@ -506,4 +506,4 @@ body.chrome #photoprism .search-results .result {
     */
     padding-bottom: 100%
   }
-}
+/*}*/

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -479,3 +479,31 @@ body.chrome #photoprism .search-results .result {
 #photoprism .face-results .is-marker.is-invalid {
     opacity: 0.5;
 }
+
+/* old browser support */
+@supports not (aspect-ratio: 1) {
+  #photoprism .search-results .image-container {
+    height: 0;
+    padding-bottom: 100%;
+  }
+
+  #photoprism .cards-view .result .image,
+  #photoprism .list-view .result .image,
+  #photoprism .mosaic-view .result.image
+  {
+    height: 0;
+    /*
+       8px is required because this aspect-ratio-fallback doesn't take
+       margins into consideration
+    */
+    padding-bottom: calc(100% - 8px)
+  }
+
+  #photoprism .mosaic-view .result.is-selected {
+    /*
+       if it is selected then it has no more margin, so DON't subtract them
+       in that case
+    */
+    padding-bottom: 100%
+  }
+}

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -76,6 +76,7 @@ body.chrome #photoprism .search-results .result {
     width: auto;
     height: 100%;
     position: absolute;
+    top: 0;
     overflow: hidden;
 }
 
@@ -199,7 +200,7 @@ body.chrome #photoprism .search-results .result {
 }
 
 #photoprism .search-results .image-container {
-  /*aspect-ratio: 1;*/
+  aspect-ratio: 1;
   contain: layout paint style size;
 }
 
@@ -209,7 +210,7 @@ body.chrome #photoprism .search-results .result {
 {
   position: relative;
   user-select: none;
-  /*aspect-ratio: 1;*/
+  aspect-ratio: 1;
   background-position: center center;
   background-size: cover;
   background-repeat: no-repeat;
@@ -481,14 +482,19 @@ body.chrome #photoprism .search-results .result {
 }
 
 /* old browser support */
-/*@supports not (aspect-ratio: 1) {*/
-  #photoprism .search-results .image-container {
+@supports not (aspect-ratio: 1) {
+  /* elements with aspect-ratio 1 and without margin */
+  #photoprism .search-results .image-container,
+  #photoprism .cards-view .result .image,
+  #photoprism .list-view .result .image,
+  #photoprism .list-view .result.image,
+  #photoprism .mosaic-view .result.is-selected {
     height: 0;
-    padding-bottom: 100%;
+    padding-bottom: 100%
   }
 
-  #photoprism .cards-view .result .image,
-  #photoprism .mosaic-view .result.image
+  /* elements with aspect-ratio 1 and with margin */
+  #photoprism .mosaic-view .result
   {
     height: 0;
     /*
@@ -497,13 +503,4 @@ body.chrome #photoprism .search-results .result {
     */
     padding-bottom: calc(100% - 8px)
   }
-
-  #photoprism .cards-view .result.is-selected,
-  #photoprism .mosaic-view .result.is-selected {
-    /*
-       if it is selected then it has no more margin, so DON't subtract them
-       in that case
-    */
-    padding-bottom: 100%
-  }
-/*}*/
+}


### PR DESCRIPTION
some not sooo old browsers (Safari on iOS 14.5) do not yet support the aspect-ratio css-property, resulting in images having no height in the search-results.

This adds a fallback for browsers that don't support the aspect-ratio css-property

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [x] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [x] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed
