### PR TITLE
Videos: Fix incorrect FFMPEG option order when using NVENC

### DIFF
--- a/internal/ffmpeg/convert.go
+++ b/internal/ffmpeg/convert.go
@@ -82,7 +82,6 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 		// ffmpeg -hide_banner -h encoder=h264_nvenc
 		result = exec.Command(
 			ffmpegBin,
-			"-r", "30",
 			"-i", fileName,
 			"-pix_fmt", "yuv420p",
 			"-c:v", string(encoder),
@@ -94,6 +93,7 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 			"-rc:v", "constqp",
 			"-cq", "0",
 			"-tune", "2",
+			"-r", "30",
 			"-b:v", bitrate,
 			"-profile:v", "1",
 			"-level:v", "41",


### PR DESCRIPTION
Fixes issue #2442, by moving the framerate option when NVENC is used to immediately before bitrate (and after input file), in line with the other encoder cases.

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

