### PR TITLE
fix icons on old chromium (e.g. 86) being tall and not displayed

### DIFF
--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -259,6 +259,7 @@ body.chrome #photoprism .search-results .result {
   font-weight: 400;
   text-transform: none;
   line-height: 1;
+  white-space: nowrap;
 }
 
 #photoprism .cards-view .result .caption {
@@ -277,6 +278,7 @@ body.chrome #photoprism .search-results .result {
   text-transform: none;
   line-height: 1;
   vertical-align: text-bottom;
+  white-space: nowrap;
 }
 
 


### PR DESCRIPTION
This fixes the issue mentioned here: https://github.com/photoprism/photoprism/pull/2448#issuecomment-1161672998

This bug was introduced in https://github.com/photoprism/photoprism/pull/2433

> In older Edge versions (Screenshot is from Windows 10 Edge 86) the card view looks weird. I am not sure if it is related to your changes or looked like this before. For me it is not a MUST to support this as in newer versions it looks good.
> 
> ![windows-10-edge-86](https://github.com/assets/15210372/05845e97-1a75-4c10-bfde-8fdb9dd3c342)



Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [x] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [x] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed