### PR TITLE
UX: Fix portrait video preview when hovering over live photos

### DIFF
--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -76,7 +76,6 @@ body.chrome #photoprism .search-results .result {
     width: auto;
     height: 100%;
     position: absolute;
-    top: 0;
     overflow: hidden;
 }
 
@@ -504,5 +503,9 @@ body.chrome #photoprism .search-results .result {
        margins into consideration
     */
     padding-bottom: calc(100% - 8px)
+  }
+
+  #photoprism .live-player video {
+    margin-top: 100%;
   }
 }


### PR DESCRIPTION
This fixes that on hover of live-images that have more height than width, the preview is not centered.

That `top: 0` that is removed here was added in https://github.com/photoprism/photoprism/pull/2448 and is only required for browsers that don't support aspect-ratio.
With this PR It is no longer required, because of the new `margin-top: 100%` that is added if no aspect-ratio-support is present.
That `top: 0` is what made the preview be NOT centered, when aspect-ratio IS supported and the image has more height than width

**Before:**

https://user-images.githubusercontent.com/20770029/176174984-b753d480-e4ec-4cd6-9a6a-d1444d918725.mp4

**After:**

https://user-images.githubusercontent.com/20770029/176175504-1fb4f477-1f9e-4d44-ad1e-db5efcd44c3b.mp4

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [x] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [x] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed