### PR TITLE
Metadata: When parsing dates from exiftool, remap year 0 to 1

### DIFF
--- a/pkg/txt/datetime.go
+++ b/pkg/txt/datetime.go
@@ -132,8 +132,15 @@ func DateTime(s, timeZone string) (t time.Time) {
 	}
 
 	// Create rounded timestamp from parsed input values.
+	// Year 0 is treated separately as it has a special meaning in exiftool. Golang
+	// does not seem to accept value 0 for the year, but considers a date to be
+	// "zero" when year is 1.
+	year := IntVal(m[v["year"]], 0, YearMax, time.Now().Year())
+	if year == 0 {
+		year = 1
+	}
 	t = time.Date(
-		IntVal(m[v["year"]], 1, YearMax, time.Now().Year()),
+		year,
 		time.Month(IntVal(m[v["month"]], 1, 12, 1)),
 		IntVal(m[v["day"]], 1, 31, 1),
 		IntVal(m[v["h"]], 0, 23, 0),

--- a/pkg/txt/datetime_test.go
+++ b/pkg/txt/datetime_test.go
@@ -119,6 +119,9 @@ func TestDateTime(t *testing.T) {
 		assert.Equal(t, "2020-10-17 17:48:24.9508123 +0000 UTC", result.UTC().String())
 		assert.Equal(t, "2020-10-17 17:48:24.9508123", result.Format("2006-01-02 15:04:05.999999999"))
 	})
+	t.Run("UTC/0000:00:00 00:00:00", func(t *testing.T) {
+		assert.True(t, DateTime("0000:00:00 00:00:00", "UTC").IsZero())
+	})
 	t.Run("2022-09-03T17:48:26-07:00", func(t *testing.T) {
 		result := DateTime("2022-09-03T17:48:26-07:00", "")
 		assert.Equal(t, "2022-09-04 00:48:26 +0000 UTC", result.UTC().String())


### PR DESCRIPTION
Year 0 is frequently used in exiftool but is not accepted in the Go time
package. time package uses year 1 for "zero" dates instead. Therefore,
remap year 0 from exiftool to year 1.

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [x] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] Contributor License Agreement (CLA) has been signed