### PR TITLE
Exif: Extract creation time from DateTimeCreated, if available

### DIFF
--- a/internal/meta/exif.go
+++ b/internal/meta/exif.go
@@ -25,7 +25,7 @@ import (
 var exifIfdMapping *exifcommon.IfdMapping
 var exifTagIndex = exif.NewTagIndex()
 var exifMutex = sync.Mutex{}
-var exifDateTimeTags = []string{"DateTimeOriginal", "DateTimeDigitized", "CreateDate", "DateTime"}
+var exifDateTimeTags = []string{"DateTimeOriginal", "DateTimeDigitized", "CreateDate", "DateTime", "DateTimeCreated"}
 var exifSubSecTags = []string{"SubSecTimeOriginal", "SubSecTimeDigitized", "SubSecTime"}
 
 func init() {


### PR DESCRIPTION
exiftool seems to also be able to extract the composite DateTimeCreated
tag. Adding also that tag may increase the chances of getting a
valid date for the photo.

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [x] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work