### PR TITLE
Config: Add regexp option to remove file sequence suffixes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,6 +161,9 @@ func (c *Config) Propagate() {
 	face.ClusterDist = c.FaceClusterDist()
 	face.MatchDist = c.FaceMatchDist()
 
+	// Set file system parameters
+	fs.StripSequenceRegex = c.StripSequenceRegex()
+
 	c.Settings().Propagate()
 	c.Hub().Propagate()
 }

--- a/internal/config/config_fs.go
+++ b/internal/config/config_fs.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"github.com/photoprism/photoprism/pkg/fs"
+	"regexp"
+)
+
+func (c *Config) StripSequenceRegex() *regexp.Regexp {
+	if c.options.StripSequenceRegex == "" {
+		return fs.StripSequenceRegex
+	}
+
+	exp, err := regexp.Compile(c.options.StripSequenceRegex)
+	if err != nil {
+		log.Errorf("config: can't parse StripSequenceRegex: %v", err)
+		return fs.StripSequenceRegex
+	}
+
+	return exp
+}

--- a/internal/config/config_fs_test.go
+++ b/internal/config/config_fs_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"github.com/photoprism/photoprism/pkg/fs"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConfig_StripSequenceRegex(t *testing.T) {
+	c := NewConfig(CliTestContext())
+
+	assert.Equal(t, fs.StripSequenceRegex, c.StripSequenceRegex())
+
+	c.options.StripSequenceRegex = `\invalid`
+	assert.Equal(t, fs.StripSequenceRegex, c.StripSequenceRegex())
+
+	c.options.StripSequenceRegex = `\.\d{5,}$| copy.*$|\(.*$|-[a-zA-Z\d]*$`
+	assert.Equal(t, `\.\d{5,}$| copy.*$|\(.*$|-[a-zA-Z\d]*$`, c.StripSequenceRegex().String())
+}

--- a/internal/config/config_report.go
+++ b/internal/config/config_report.go
@@ -165,6 +165,9 @@ func (c *Config) Report() (rows [][]string, cols []string) {
 		// Daemon Mode.
 		{"pid-filename", c.PIDFilename()},
 		{"log-filename", c.LogFilename()},
+
+		// File System.
+		{"strip-sequence-regex", c.StripSequenceRegex().String()},
 	}
 
 	if p := c.CustomAssetsPath(); p != "" {

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -130,6 +130,7 @@ type Options struct {
 	FaceMatchDist         float64       `yaml:"-" json:"-" flag:"face-match-dist"`
 	PIDFilename           string        `yaml:"PIDFilename" json:"-" flag:"pid-filename"`
 	LogFilename           string        `yaml:"LogFilename" json:"-" flag:"log-filename"`
+	StripSequenceRegex    string        `yaml:"StripSequenceRegex" json:"StripSequenceRegex" flag:"strip-sequence-regex"`
 }
 
 // NewOptions creates a new configuration entity by using two methods:

--- a/internal/config/options_cli.go
+++ b/internal/config/options_cli.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/klauspost/cpuid/v2"
+	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/urfave/cli"
 
 	"github.com/photoprism/photoprism/internal/face"
@@ -730,5 +731,12 @@ var Flags = CliFlags{
 			Usage:  "server log `FILE` *daemon-mode only*",
 			EnvVar: "PHOTOPRISM_LOG_FILENAME",
 			Value:  "",
+		}},
+	CliFlag{
+		Flag: cli.StringFlag{
+			Name:   "strip-sequence-regex",
+			Usage:  "regex for strip sequence",
+			Value:  fs.StripSequenceRegex.String(),
+			EnvVar: "PHOTOPRISM_STRIP_SEQUENCE_REGEX",
 		}},
 }


### PR DESCRIPTION
This allows users to stack images that have uncommon naming extensions like IMG_1234-123

related issues: #2566, #2241

If changes are accepted, i will also update the documentation

<!--
Please describe your pull request:
- What does it implement / fix / improve?
- Is it related to an existing issue?
-->

<!--
After submitting your first pull request, you will automatically be asked to accept our Contributor License Agreement (CLA):

https://github.com/photoprism/photoprism/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla

Because we want to create the best possible product for our users, we have a set of guidelines to ensure that all submissions are acceptable.
Please check the following items by replacing "[ ]" with "[x]".
You can also do this when viewing the pull request after it was created:
-->

Acceptance Criteria:

- [x] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [x] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

