### PR TITLE
Import: Index original filenames of related files

### DIFF
--- a/internal/photoprism/import_worker.go
+++ b/internal/photoprism/import_worker.go
@@ -23,6 +23,7 @@ type ImportJob struct {
 func ImportWorker(jobs <-chan ImportJob) {
 	for job := range jobs {
 		var destMainFileName string
+		relatedOriginalNames := make(map[string]string)
 
 		o := job.IndexOpt
 		imp := job.Imp
@@ -59,6 +60,9 @@ func ImportWorker(jobs <-chan ImportJob) {
 
 			if destFileName, err := imp.DestinationFilename(related.Main, f); err == nil {
 				destDir := filepath.Dir(destFileName)
+
+				// Keep original name of related files after they are renamed, so they are indexed with the original name.
+				relatedOriginalNames[destFileName] = relFileName
 
 				if fs.PathExists(destDir) {
 					// Do nothing.
@@ -232,7 +236,7 @@ func ImportWorker(jobs <-chan ImportJob) {
 				}
 
 				// Index related MediaFile.
-				res := ind.MediaFile(f, o, "", photoUID)
+				res := ind.MediaFile(f, o, relatedOriginalNames[f.FileName()], photoUID)
 
 				// Save file error.
 				if fileUid, err := res.FileError(); err != nil {

--- a/internal/photoprism/import_worker_test.go
+++ b/internal/photoprism/import_worker_test.go
@@ -1,0 +1,79 @@
+package photoprism
+
+import (
+	"github.com/photoprism/photoprism/internal/classify"
+	"github.com/photoprism/photoprism/internal/config"
+	"github.com/photoprism/photoprism/internal/entity"
+	"github.com/photoprism/photoprism/internal/face"
+	"github.com/photoprism/photoprism/internal/nsfw"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestImportWorker_OriginalFileNames(t *testing.T) {
+	conf := config.TestConfig()
+
+	conf.InitializeTestData(t)
+
+	tf := classify.New(conf.AssetsPath(), conf.DisableTensorFlow())
+	nd := nsfw.New(conf.NSFWModelPath())
+	fn := face.NewNet(conf.FaceNetModelPath(), "", conf.DisableTensorFlow())
+	convert := NewConvert(conf)
+	ind := NewIndex(conf, tf, nd, fn, convert, NewFiles(), NewPhotos())
+	imp := &Import{conf, ind, convert}
+
+	mediaFileName := conf.ExamplesPath() + "/beach_sand.jpg"
+	mediaFile, err := NewMediaFile(mediaFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mediaFileName2 := conf.ExamplesPath() + "/beach_wood.jpg"
+	mediaFile2, err2 := NewMediaFile(mediaFileName2)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	mediaFileName3 := conf.ExamplesPath() + "/beach_colorfilter.jpg"
+	mediaFile3, err3 := NewMediaFile(mediaFileName3)
+	if err3 != nil {
+		t.Fatal(err3)
+	}
+	relatedFiles := RelatedFiles{
+		Files: MediaFiles{mediaFile, mediaFile2, mediaFile3},
+		Main:  mediaFile,
+	}
+
+	jobs := make(chan ImportJob)
+	done := make(chan bool)
+
+	go func() {
+		ImportWorker(jobs)
+		done <- true
+	}()
+
+	jobs <- ImportJob{
+		FileName:  mediaFile.FileName(),
+		Related:   relatedFiles,
+		IndexOpt:  IndexOptionsAll(),
+		ImportOpt: ImportOptionsCopy(conf.ImportPath()),
+		Imp:       imp,
+	}
+
+	// Wait for job to finish.
+	close(jobs)
+	<-done
+
+	var file entity.File
+	res := entity.UnscopedDb().First(&file, "original_name = ?", mediaFileName)
+	assert.Nil(t, res.Error)
+	assert.Equal(t, file.OriginalName, mediaFileName)
+
+	var file2 entity.File
+	res = entity.UnscopedDb().First(&file2, "original_name = ?", mediaFileName2)
+	assert.Nil(t, res.Error)
+	assert.Equal(t, file2.OriginalName, mediaFileName2)
+
+	var file3 entity.File
+	res = entity.UnscopedDb().First(&file3, "original_name = ?", mediaFileName3)
+	assert.Nil(t, res.Error)
+	assert.Equal(t, file3.OriginalName, mediaFileName3)
+}


### PR DESCRIPTION
When uploading multiple related/stackable files, the non-primary files are missing the `Original Name` attribute. This PR ensures they are also assigned with their original file name.

<!--
After submitting your first pull request, you will automatically be asked to accept our Contributor License Agreement (CLA):

https://github.com/photoprism/photoprism/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla

Because we want to create the best possible product for our users, we have a set of guidelines to ensure that all submissions are acceptable.
Please check the following items by replacing "[ ]" with "[x]".
You can also do this when viewing the pull request after it was created:
-->

Acceptance Criteria:

- [ ] **Features and improvements are fully implemented** so that they can be released at any time without additional work
- [X] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

