### PR TITLE
Index: Delay RAW file format check to improve performance

### DIFF
--- a/internal/photoprism/index.go
+++ b/internal/photoprism/index.go
@@ -187,7 +187,15 @@ func (ind *Index) Start(o IndexOptions) fs.Done {
 				return nil
 			}
 
-			mf, err := NewMediaFile(fileName)
+			var mf *MediaFile
+			var err error
+			if isSymlink {
+				mf, err = NewMediaFile(fileName)
+			} else {
+				// If the file found while scanning is not a symlink we can
+				// skip resolving the fileName, which is resource intensive.
+				mf, err = NewMediaFileSkipResolve(fileName, fileName)
+			}
 
 			// Check if file exists and is not empty.
 			if err != nil {


### PR DESCRIPTION
Scanning is unnecesserily slow because the code does extra processing for files that are unchanged and skipped later.

With a bit of reshuffeling I was able to achieve a 100x scan speedup (from about 900s down to 9s) for my library of 33000 photos (see specs below) if I trigger a rescan without any changes to any of the files.

Discovered using strace and noticing how during index each file is opened and exactly 261 ones bytes are read and many stat calls for the same file:
```
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism", {st_mode=S_IFDIR|0755, st_size=5, ...}, AT_SYMLINK_NOFOLLOW) = 0                                             
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals", {st_mode=S_IFDIR|0755, st_size=8, ...}, AT_SYMLINK_NOFOLLOW) = 0                                   
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals/XXX", {st_mode=S_IFDIR|0755, st_size=3045, ...}, AT_SYMLINK_NOFOLLOW) = 0                        
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX", {st_mode=S_IFDIR|0755, st_size=10, ...}, AT_SYMLINK_NOFOLLOW) = 0                  
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX/XXX.jpg", {st_mode=S_IFREG|0644, st_size=156377, ...}, AT_SYMLINK_NOFOLLOW) = 0                                                   
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX/XXX.jpg", {st_mode=S_IFREG|0644, st_size=156377, ...}, 0) = 0                                                                                                                                                     
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism", {st_mode=S_IFDIR|0755, st_size=5, ...}, AT_SYMLINK_NOFOLLOW) = 0          
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals", {st_mode=S_IFDIR|0755, st_size=8, ...}, AT_SYMLINK_NOFOLLOW) = 0                                   
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals/XXX", {st_mode=S_IFDIR|0755, st_size=3045, ...}, AT_SYMLINK_NOFOLLOW) = 0             
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX", {st_mode=S_IFDIR|0755, st_size=10, ...}, AT_SYMLINK_NOFOLLOW) = 0                  
[pid 3359850] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX/XXX.jpg", {st_mode=S_IFREG|0644, st_size=156377, ...}, AT_SYMLINK_NOFOLLOW) = 0                                                                                                                                   
[pid 3359850] openat(AT_FDCWD, "/photoprism/originals/XXX/XXX/XXX.jpg", O_RDONLY|O_CLOEXEC) = 10                                                                         
[pid 3359850] read(10, "\377\330\377\340\0\20JFIF\0\1\1\0\0\1\0\1\0\0\377\341\vjhttp://n"..., 261) = 261                               
[pid 3359850] close(10 <unfinished ...>                                                                                              
```

After the changes each file is only stat'ed once (which we need to get the modification time for the isIndexed check):
```
[pid 1410222] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX/1.jpg", {st_mode=S_IFREG|0644, st_size=1706545, ...}, 0) = 0
[pid 1410222] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX/2.jpg", {st_mode=S_IFREG|0644, st_size=971489, ...}, 0) = 0
[pid 1410222] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX/3.jpg", {st_mode=S_IFREG|0644, st_size=1722545, ...}, 0) = 0
[pid 1410222] newfstatat(AT_FDCWD, "/photoprism/originals/XXX/XXX/4.jpg", {st_mode=S_IFREG|0644, st_size=980666, ...}, 0) = 0
```

"Benchmarked" using around 33000 images stored on a HDD backed ZFS pool on a Ryzen 3900X, 64G RAM, SQLite/Cache/sidecar/... on a SSD backed ZFS pool
- Before: around 850s for a scan of originals (not complete rescan)
- After: around 9s for a scan of originals (not complete rescan)

Acceptance Criteria:

- [X] **Features and enhancements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [X] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

