### PR TITLE
HEIF: Add Sony .HIF file extension

### DIFF
--- a/pkg/fs/file_exts.go
+++ b/pkg/fs/file_exts.go
@@ -18,6 +18,7 @@ var Extensions = FileExtensions{
 	".jfi":      ImageJPEG,
 	".thm":      ImageJPEG,
 	".heif":     ImageHEIF,
+	".hif":      ImageHEIF,
 	".heic":     ImageHEIF,
 	".heifs":    ImageHEIF,
 	".heics":    ImageHEIF,


### PR DESCRIPTION
Add file extension ".HIF" for Sony HEIF images.
Currently, change ".HIF" to ".HEIF" can import into PhotoPrism without problems for 4:2:2 10bit images.

<!--
Please describe your pull request:
- What does it implement / fix / improve?
- Is it related to an existing issue?
-->

<!--
After submitting your first pull request, you will automatically be asked to accept our Contributor License Agreement (CLA):

https://github.com/photoprism/photoprism/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla

Because we want to create the best possible product for our users, we have a set of guidelines to ensure that all submissions are acceptable.
Please check the following items by replacing "[ ]" with "[x]".
You can also do this when viewing the pull request after it was created:
-->

Acceptance Criteria:

- [x] **Features and enhancements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

