### PR TITLE
Added VAAPI encoder support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,12 +85,13 @@ services:
       ## Run/install on first startup (options: update gpu tensorflow davfs clitools clean):
       # PHOTOPRISM_INIT: "gpu tensorflow"
       ## Hardware Video Transcoding (optional):
-      # PHOTOPRISM_FFMPEG_ENCODER: "nvidia"          # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry")
-      # PHOTOPRISM_FFMPEG_ENCODER: "intel"           # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry")
+      # PHOTOPRISM_FFMPEG_ENCODER: "nvidia"          # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry", "vaapi") Intel: "intel" for Broadwell or later and "vaapi" for Haswell or earlier
+      # PHOTOPRISM_FFMPEG_ENCODER: "intel"           # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry", "vaapi") Intel: "intel" for Broadwell or later and "vaapi" for Haswell or earlier`
       # PHOTOPRISM_FFMPEG_BITRATE: "32"              # FFmpeg encoding bitrate limit in Mbit/s (default: 50)
+      # LIBVA_DRIVER_NAME: "i965"                    # For Intel architectures Haswell and older which do not support QSV yet but use VAAPI instead
     ## Share hardware devices with FFmpeg and TensorFlow (optional):
     # devices:
-    #  - "/dev/dri:/dev/dri"                         # Intel QSV
+    #  - "/dev/dri:/dev/dri"                         # Intel QSV (Broadwell and later) or VAAPI (Haswell and earlier)
     #  - "/dev/nvidia0:/dev/nvidia0"                 # Nvidia CUDA
     #  - "/dev/nvidiactl:/dev/nvidiactl"
     #  - "/dev/nvidia-modeset:/dev/nvidia-modeset"

--- a/internal/ffmpeg/convert.go
+++ b/internal/ffmpeg/convert.go
@@ -78,6 +78,23 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 			avcName,
 		)
 
+	case VAAPIEncoder:
+		format := "format=nv12,hwupload"
+		result = exec.Command(
+			ffmpegBin,
+			"-hwaccel", "vaapi",
+			"-i", fileName,
+			"-c:a", "aac",
+			"-vf", format,
+			"-c:v", string(encoder),
+			"-vsync", "vfr",
+			"-r", "30",
+			"-b:v", bitrate,
+			"-f", "mp4",
+			"-y",
+			avcName,
+		)
+
 	case NvidiaEncoder:
 		// ffmpeg -hide_banner -h encoder=h264_nvenc
 		result = exec.Command(


### PR DESCRIPTION
Added VAAPI encoder support for ffmpeg which is necessary for Intel architectures like Haswell and older.

Topic was discussed here: https://github.com/photoprism/photoprism/discussions/2450

<!--
After submitting your first pull request, you will automatically be asked to accept our Contributor License Agreement (CLA):

https://github.com/photoprism/photoprism/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla

Because we want to create the best possible product for our users, we have a set of guidelines to ensure that all submissions are acceptable.
Please check the following items by replacing "[ ]" with "[x]".
You can also do this when viewing the pull request after it was created:
-->

Acceptance Criteria:

- [x] **Features and enhancements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [ ] Translations have been / will be updated (specify if needed)
- [ ] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

