### PR TITLE
Docker: Switch from gosu to setpriv in entrypoint.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,6 @@ install:
 	rm -rf --preserve-root $(DESTDIR)/include
 	(cd $(DESTDIR) && mkdir -p bin sbin lib assets config config/examples)
 	./scripts/build.sh prod "$(DESTDIR)/bin/$(BINARY_NAME)"
-	GOBIN="$(DESTDIR)/sbin" go install github.com/tianon/gosu@latest
 	rsync -r -l --safe-links --exclude-from=assets/.buildignore --chmod=a+r,u+rw ./assets/ $(DESTDIR)/assets
 	wget -O $(DESTDIR)/assets/static/img/wallpaper/welcome.jpg https://cdn.photoprism.app/wallpaper/welcome.jpg
 	wget -O $(DESTDIR)/assets/static/img/preview.jpg https://cdn.photoprism.app/img/preview.jpg

--- a/docker/photoprism/armv7/Dockerfile
+++ b/docker/photoprism/armv7/Dockerfile
@@ -101,7 +101,6 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     echo 'APT::Install-Suggests "false";' > /etc/apt/apt.conf.d/80suggests && \
     echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/80forceyes && \
     echo 'APT::Get::Fix-Missing "true";' > /etc/apt/apt.conf.d/80fixmissing && \
-    mv /opt/photoprism/sbin/gosu /usr/local/sbin/gosu && \
     apt-get update && apt-get -qq upgrade && apt-get -qq install --no-install-recommends \
       libc6 ca-certificates sudo bash tzdata \
       gpg zip unzip wget curl rsync make nano \

--- a/docker/photoprism/bookworm/Dockerfile
+++ b/docker/photoprism/bookworm/Dockerfile
@@ -104,7 +104,6 @@ EXPOSE 2342
 
 # copy dist files
 COPY --from=build --chown=root:root --chmod=755 /opt/photoprism/ /opt/photoprism
-RUN mv /opt/photoprism/sbin/gosu /usr/local/sbin/gosu
 
 # Declare container entrypoint script.
 ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/docker/photoprism/bullseye/Dockerfile
+++ b/docker/photoprism/bullseye/Dockerfile
@@ -104,7 +104,6 @@ EXPOSE 2342
 
 # copy dist files
 COPY --from=build --chown=root:root --chmod=755 /opt/photoprism/ /opt/photoprism
-RUN mv /opt/photoprism/sbin/gosu /usr/local/sbin/gosu
 
 # Declare container entrypoint script.
 ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/docker/photoprism/buster/Dockerfile
+++ b/docker/photoprism/buster/Dockerfile
@@ -102,7 +102,6 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     echo 'APT::Install-Suggests "false";' > /etc/apt/apt.conf.d/80suggests && \
     echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/80forceyes && \
     echo 'APT::Get::Fix-Missing "true";' > /etc/apt/apt.conf.d/80fixmissing && \
-    mv /opt/photoprism/sbin/gosu /usr/local/sbin/gosu && \
     apt-get update && apt-get -qq dist-upgrade && apt-get -qq install --no-install-recommends \
       ca-certificates \
       jq \

--- a/docker/photoprism/impish/Dockerfile
+++ b/docker/photoprism/impish/Dockerfile
@@ -101,7 +101,6 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     echo 'APT::Install-Suggests "false";' > /etc/apt/apt.conf.d/80suggests && \
     echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/80forceyes && \
     echo 'APT::Get::Fix-Missing "true";' > /etc/apt/apt.conf.d/80fixmissing && \
-    mv /opt/photoprism/sbin/gosu /usr/local/sbin/gosu && \
     apt-get update && apt-get -qq dist-upgrade && apt-get -qq install --no-install-recommends \
       ca-certificates \
       jq \

--- a/docker/photoprism/jammy/Dockerfile
+++ b/docker/photoprism/jammy/Dockerfile
@@ -105,7 +105,6 @@ EXPOSE 2342
 
 # Copy app files.
 COPY --from=build --chown=root:root --chmod=755 /opt/photoprism/ /opt/photoprism
-RUN mv /opt/photoprism/sbin/gosu /usr/local/sbin/gosu
 
 # Declare container entrypoint script.
 ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/scripts/dist/entrypoint.sh
+++ b/scripts/dist/entrypoint.sh
@@ -96,15 +96,15 @@ if [[ ${INIT_SCRIPT} ]] && [[ $(/usr/bin/id -u) == "0" ]] && [[ ${PHOTOPRISM_UID
     echo "${@}"
 
     # run command as uid:gid
-    ([[ ${DOCKER_ENV} != "prod" ]] || /usr/local/sbin/gosu "${PHOTOPRISM_UID}:${PHOTOPRISM_GID}" "/scripts/audit.sh") \
-     && /usr/local/sbin/gosu "${PHOTOPRISM_UID}:${PHOTOPRISM_GID}" "$@" &
+    ([[ ${DOCKER_ENV} != "prod" ]] || /usr/bin/setpriv --reuid "${PHOTOPRISM_UID}" --regid "${PHOTOPRISM_GID}" --init-groups --inh-caps -all "/scripts/audit.sh") \
+     && /usr/bin/setpriv --reuid "${PHOTOPRISM_UID}" --regid "${PHOTOPRISM_GID}" --init-groups --inh-caps -all "$@" &
   else
     echo "switching to uid ${PHOTOPRISM_UID}"
     echo "${@}"
 
     # run command as uid
-    ([[ ${DOCKER_ENV} != "prod" ]] || /usr/local/sbin/gosu "${PHOTOPRISM_UID}" "/scripts/audit.sh") \
-     && /usr/local/sbin/gosu "${PHOTOPRISM_UID}" "$@" &
+    ([[ ${DOCKER_ENV} != "prod" ]] || /usr/bin/setpriv --reuid "${PHOTOPRISM_UID}" --regid "$(/usr/bin/id -g "${PHOTOPRISM_UID}")" --init-groups --inh-caps -all "/scripts/audit.sh") \
+     && /usr/bin/setpriv --reuid "${PHOTOPRISM_UID}" --regid "$(/usr/bin/id -g "${PHOTOPRISM_UID}")" --init-groups --inh-caps -all "$@" &
   fi
 else
   echo "running as uid $(id -u)"

--- a/scripts/dist/install-go-tools.sh
+++ b/scripts/dist/install-go-tools.sh
@@ -37,12 +37,6 @@ set -e
 
 mkdir -p "$GOPATH/src"
 
-# Install gosu in "/usr/local/sbin".
-echo "Installing gosu in /usr/local/sbin..."
-GOBIN="/usr/local/sbin" go install github.com/tianon/gosu@latest
-chown root:root /usr/local/sbin/gosu
-chmod 755 /usr/local/sbin/gosu
-
 # Install remaining tools in "/usr/local/bin".
 case $DESTARCH in
   arm | ARM | aarch | armv7l | armhf)


### PR DESCRIPTION
## Description
<!--
Please describe your pull request:
- What does it implement / fix / improve?
- Is it related to an existing issue?
-->
This PR switches the su binary in entrypoint.sh from [gosu](https://github.com/tianon/gosu) to [setpriv](https://manpages.debian.org/bullseye/util-linux/setpriv.1.en.html) (included in Debian). This enables the following improvements:
- Supplementary groups are not lost if `PHOTOPRISM_UID` and `PHOTOPRISM_GID` are set. Supplementary groups are required for hardware transcoding on many devices. (#2228)
- Inherited capabilities from Docker root are no longer passed to `photoprism` if `PHOTOPRISM_UID` is set. (This has no effect in typical use, as CapPrm and CapEff are cleared when changing to unprivileged user in Docker.)
- No longer depends on gosu; removes unnecessary binary from images

`setpriv` has been available in the `util-linux` package since Debian 10.0 [Buster](https://packages.debian.org/buster/amd64/util-linux/filelist) and Ubuntu 20.04 [Focal](https://packages.ubuntu.com/focal/amd64/util-linux/filelist), so it is present in all supported Docker images. It is also listed as an alternative on the gosu [README](https://github.com/tianon/gosu/blob/cc6a15501b77eaa6dfb0a36b783ab4cff79f3405/README.md#setpriv).

### Examples
Before (gosu):
```console
root@220901-bullseye:/photoprism$ gosu "${PHOTOPRISM_UID}" id
uid=1032(user-1032) gid=1032(group-1030) groups=1032(group-1030),33(www-data),44(video),105(davfs2),109(renderd),115(render),937(videodriver),1000(photoprism)

root@220901-bullseye:/photoprism$ gosu "${PHOTOPRISM_UID}:${PHOTOPRISM_GID}" id
uid=1032(user-1032) gid=100(users) groups=100(users)
# setting the GID clears supplementary groups
```

After (setpriv):
```console
root@220901-bullseye:/photoprism$ /usr/bin/setpriv --reuid "${PHOTOPRISM_UID}" --regid "$(/usr/bin/id -g ${PHOTOPRISM_UID})" --init-groups id
uid=1032(user-1032) gid=1032(group-1030) groups=1032(group-1030),33(www-data),44(video),105(davfs2),109(renderd),115(render),937(videodriver),1000(photoprism)

root@220901-bullseye:/photoprism$ /usr/bin/setpriv --reuid "${PHOTOPRISM_UID}" --regid "${PHOTOPRISM_GID}" --init-groups id
uid=1032(user-1032) gid=100(users) groups=100(users),33(www-data),44(video),105(davfs2),109(renderd),115(render),937(videodriver),1000(photoprism),1032(group-1030)
# supplementary groups are preserved
```

<!--
After submitting your first pull request, you will automatically be asked to accept our Contributor License Agreement (CLA):

https://github.com/photoprism/photoprism/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla

Because we want to create the best possible product for our users, we have a set of guidelines to ensure that all submissions are acceptable.
Please check the following items by replacing "[ ]" with "[x]".
You can also do this when viewing the pull request after it was created:
-->

## Acceptance Criteria

- [x] **Features and enhancements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

