### PR TITLE
Correct Traditional Chinese translate

### DIFF
--- a/assets/locales/zh_TW/default.po
+++ b/assets/locales/zh_TW/default.po
@@ -21,7 +21,7 @@ msgstr ""
 
 #: messages.go:94
 msgid "Unexpected error, please try again"
-msgstr "發生預料外的錯誤, 請重試"
+msgstr "發生錯誤, 請重試"
 
 #: messages.go:95
 msgid "Invalid request"
@@ -58,7 +58,7 @@ msgstr "不支持的格式"
 
 #: messages.go:103
 msgid "Originals folder is empty"
-msgstr "原稿文件夹是空的"
+msgstr "原稿文件夾是空的"
 
 #: messages.go:104
 msgid "Selection not found"
@@ -94,7 +94,7 @@ msgstr "找不到人"
 
 #: messages.go:112
 msgid "Face not found"
-msgstr "找不到人像"
+msgstr "找不到面貌"
 
 #: messages.go:113
 msgid "Not available in public mode"
@@ -102,7 +102,7 @@ msgstr "不適用於公開模式"
 
 #: messages.go:114
 msgid "Not available in read-only mode"
-msgstr "只读模式中不可用"
+msgstr "不適用於唯讀模式"
 
 #: messages.go:115
 msgid "Please log in to your account"
@@ -126,11 +126,11 @@ msgstr "未選取任何項目"
 
 #: messages.go:120
 msgid "Failed creating file, please check permissions"
-msgstr "创建文件失败，请检查权限"
+msgstr "建立文件失敗，請檢查權限"
 
 #: messages.go:121
 msgid "Failed creating folder, please check permissions"
-msgstr "创建目录失败，请检查权限"
+msgstr "建立目錄失敗，請檢查權限"
 
 #: messages.go:122
 msgid "Could not connect, please try again"
@@ -158,7 +158,7 @@ msgstr "没有可以下載的檔案"
 
 #: messages.go:128
 msgid "Failed to create zip file"
-msgstr "创建 zip 文件失败"
+msgstr "建立 zip 檔失敗"
 
 #: messages.go:129
 msgid "Invalid credentials"
@@ -179,11 +179,11 @@ msgstr "忙碌中，請稍候再試"
 #: messages.go:133
 #, c-format
 msgid "The wakeup interval is %s, but must be 1h or less"
-msgstr "喚醒間隔為 %s，但必須小於1 小時"
+msgstr "喚醒間隔為 %s，但必須少於1 小時"
 
 #: messages.go:134
 msgid "Your account could not be connected"
-msgstr "您的账户无法连接"
+msgstr "您的賬戶無法連接"
 
 #: messages.go:137
 msgid "Changes successfully saved"
@@ -191,11 +191,11 @@ msgstr "更改成功儲存"
 
 #: messages.go:138
 msgid "Album created"
-msgstr "以建立相簿"
+msgstr "相簿已建立"
 
 #: messages.go:139
 msgid "Album saved"
-msgstr "已儲存相簿"
+msgstr "相簿已儲存"
 
 #: messages.go:140
 #, c-format
@@ -222,7 +222,7 @@ msgstr "選取項目已加入 %s"
 #: messages.go:145
 #, c-format
 msgid "One entry added to %s"
-msgstr "已在 %s 增加一个項目"
+msgstr "已在 %s 增加一個項目"
 
 #: messages.go:146
 #, c-format
@@ -241,28 +241,28 @@ msgstr "%d 個項目已從 %s 移除"
 
 #: messages.go:149
 msgid "Account created"
-msgstr "已建立帳號"
+msgstr "帳號已建立"
 
 #: messages.go:150
 msgid "Account saved"
-msgstr "已儲存帳號"
+msgstr "帳號已儲存"
 
 #: messages.go:151
 msgid "Account deleted"
-msgstr "已刪除帳號"
+msgstr "帳號已刪除"
 
 #: messages.go:152
 msgid "Settings saved"
-msgstr "已儲存設定"
+msgstr "設定已儲存"
 
 #: messages.go:153
 msgid "Password changed"
-msgstr "已更改密碼"
+msgstr "密碼已更改"
 
 #: messages.go:154
 #, c-format
 msgid "Import completed in %d s"
-msgstr "匯入成功, 共花費 %d 秒"
+msgstr "匯入成功, 共用 %d 秒"
 
 #: messages.go:155
 msgid "Import canceled"
@@ -271,7 +271,7 @@ msgstr "匯入取消"
 #: messages.go:156
 #, c-format
 msgid "Indexing completed in %d s"
-msgstr "索引成功, 共花費 %d 秒"
+msgstr "索引建立成功, 共用 %d 秒"
 
 #: messages.go:157
 msgid "Indexing originals..."
@@ -284,7 +284,7 @@ msgstr "建立 %s 中的檔案索引"
 
 #: messages.go:159
 msgid "Indexing canceled"
-msgstr "索引取消"
+msgstr "建立索引取消"
 
 #: messages.go:160
 #, c-format
@@ -303,27 +303,27 @@ msgstr "正在從 %s 中複製檔案"
 
 #: messages.go:163
 msgid "Labels deleted"
-msgstr "已刪除標籤"
+msgstr "標籤已刪除"
 
 #: messages.go:164
 msgid "Label saved"
-msgstr "已儲存標籤"
+msgstr "標籤已儲存"
 
 #: messages.go:165
 msgid "Subject saved"
-msgstr "已儲存主題"
+msgstr "主題已儲存"
 
 #: messages.go:166
 msgid "Subject deleted"
-msgstr "已刪除主題"
+msgstr "主題已刪除"
 
 #: messages.go:167
 msgid "Person saved"
-msgstr "已儲存的人"
+msgstr "人物已儲存"
 
 #: messages.go:168
 msgid "Person deleted"
-msgstr "已刪除人"
+msgstr "人物已刪除"
 
 #: messages.go:169
 msgid "File uploaded"
@@ -332,7 +332,7 @@ msgstr "上載檔案成功"
 #: messages.go:170
 #, c-format
 msgid "%d files uploaded in %d s"
-msgstr "已上傳 %d 個檔案, 共花費 %d 秒"
+msgstr "已上傳 %d 個檔案, 共用 %d 秒"
 
 #: messages.go:171
 msgid "Processing upload..."
@@ -344,7 +344,7 @@ msgstr "上傳已處理"
 
 #: messages.go:173
 msgid "Selection approved"
-msgstr "選擇已核准"
+msgstr "選擇項目已核准"
 
 #: messages.go:174
 msgid "Selection archived"
@@ -356,16 +356,16 @@ msgstr "選取項目已被恢復"
 
 #: messages.go:176
 msgid "Selection marked as private"
-msgstr "選取項目已被設為私人"
+msgstr "選取項目已設為私人"
 
 #: messages.go:177
 msgid "Albums deleted"
-msgstr "已刪除相簿"
+msgstr "相簿已刪除"
 
 #: messages.go:178
 #, c-format
 msgid "Zip created in %d s"
-msgstr "壓縮黨建立成功, 共花費 %d 秒"
+msgstr "Zip檔建立成功, 共用 %d 秒"
 
 #: messages.go:179
 msgid "Permanently deleted"
@@ -374,7 +374,7 @@ msgstr "永久刪除"
 #: messages.go:180
 #, c-format
 msgid "%s has been restored"
-msgstr "%s 已被恢復"
+msgstr "%s 已被回復"
 
 #~ msgid "Not found on server, deleted?"
-#~ msgstr "服务器上不存在此文件, 或已被删除?"
+#~ msgstr "伺服器上不存在此文件, 或已被删除?"


### PR DESCRIPTION
Correct Traditional Chinese translation characters and actual meaning. by Hongkonger

I found that the translation is somehow based on the Google translate. Some words are in simplified Chinese instead of Traditional Chinese.
<!--
After submitting your first pull request, you will automatically be asked to accept our Contributor License Agreement (CLA):

https://github.com/photoprism/photoprism/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla

Because we want to create the best possible product for our users, we have a set of guidelines to ensure that all submissions are acceptable.
Please check the following items by replacing "[ ]" with "[x]".
You can also do this when viewing the pull request after it was created:
-->

Acceptance Criteria:

- [ ] **Features and enhancements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [ ] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [ ] Database-related changes are compatible with SQLite and MariaDB
- [X] Translations have been updated - Tranditional Chinese (zh-TW)
- [ ] Documentation has been / will be updated (specify if needed)
- [ ] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

