### PR TITLE
allow to use make with docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,15 @@ else
     GOTEST=go test
 endif
 
+# Compatibility layer to support “docker-compose” and “docker compose”
+HAS_DOCKER_COMPOSE_WITH_DASH := $(shell which docker-compose)
+
+ifdef HAS_DOCKER_COMPOSE_WITH_DASH
+    DOCKER_COMPOSE=docker-compose
+else
+    DOCKER_COMPOSE=docker compose
+endif
+
 # Declare "make" targets.
 all: dep build-js
 dep: dep-tensorflow dep-npm dep-js
@@ -67,7 +76,7 @@ upgrade: dep-upgrade-js dep-upgrade
 devtools: install-go dep-npm
 .SILENT: help;
 logs:
-	docker compose logs -f
+	$(DOCKER_COMPOSE) logs -f
 help:
 	@echo "For build instructions, visit <https://docs.photoprism.app/developer-guide/>."
 fix-permissions:
@@ -140,10 +149,10 @@ start:
 stop:
 	./photoprism stop
 terminal:
-	docker compose exec -u $(UID) photoprism bash
+	$(DOCKER_COMPOSE) exec -u $(UID) photoprism bash
 rootshell: root-terminal
 root-terminal:
-	docker compose exec -u root photoprism bash
+	$(DOCKER_COMPOSE) exec -u root photoprism bash
 migrate:
 	go run cmd/photoprism/photoprism.go migrations run
 generate:
@@ -287,11 +296,11 @@ test-coverage:
 	go tool cover -html=coverage.txt -o coverage.html
 	go tool cover -func coverage.txt  | grep total:
 docker-pull:
-	docker compose pull --ignore-pull-failures
-	docker compose -f docker-compose.latest.yml pull --ignore-pull-failures
+	$(DOCKER_COMPOSE) pull --ignore-pull-failures
+	$(DOCKER_COMPOSE) -f docker-compose.latest.yml pull --ignore-pull-failures
 docker-build:
-	docker compose pull --ignore-pull-failures
-	docker compose build
+	$(DOCKER_COMPOSE) pull --ignore-pull-failures
+	$(DOCKER_COMPOSE) build
 docker-develop: docker-develop-latest
 docker-develop-all: docker-develop-latest docker-develop-other
 docker-develop-latest: docker-develop-ubuntu
@@ -432,31 +441,31 @@ docker-release-impish:
 	docker pull --platform=arm64 ubuntu:impish
 	scripts/docker/buildx-multi.sh photoprism linux/amd64,linux/arm64 impish /impish
 start-local:
-	docker compose -f docker-compose.local.yml up -d --wait
+	$(DOCKER_COMPOSE) -f docker-compose.local.yml up -d --wait
 stop-local:
-	docker compose -f docker-compose.local.yml stop
+	$(DOCKER_COMPOSE) -f docker-compose.local.yml stop
 mysql:
-	docker compose -f docker-compose.mysql.yml pull mysql
-	docker compose -f docker-compose.mysql.yml stop mysql
-	docker compose -f docker-compose.mysql.yml up -d --wait mysql
+	$(DOCKER_COMPOSE) -f docker-compose.mysql.yml pull mysql
+	$(DOCKER_COMPOSE) -f docker-compose.mysql.yml stop mysql
+	$(DOCKER_COMPOSE) -f docker-compose.mysql.yml up -d --wait mysql
 start-mysql:
-	docker compose -f docker-compose.mysql.yml up -d --wait mysql
+	$(DOCKER_COMPOSE) -f docker-compose.mysql.yml up -d --wait mysql
 stop-mysql:
-	docker compose -f docker-compose.mysql.yml stop mysql
+	$(DOCKER_COMPOSE) -f docker-compose.mysql.yml stop mysql
 logs-mysql:
-	docker compose -f docker-compose.mysql.yml logs -f mysql
+	$(DOCKER_COMPOSE) -f docker-compose.mysql.yml logs -f mysql
 latest:
-	docker compose -f docker-compose.latest.yml pull photoprism-latest
-	docker compose -f docker-compose.latest.yml stop photoprism-latest
-	docker compose -f docker-compose.latest.yml up -d --wait photoprism-latest
+	$(DOCKER_COMPOSE) -f docker-compose.latest.yml pull photoprism-latest
+	$(DOCKER_COMPOSE) -f docker-compose.latest.yml stop photoprism-latest
+	$(DOCKER_COMPOSE) -f docker-compose.latest.yml up -d --wait photoprism-latest
 start-latest:
-	docker compose -f docker-compose.latest.yml up photoprism-latest
+	$(DOCKER_COMPOSE) -f docker-compose.latest.yml up photoprism-latest
 stop-latest:
-	docker compose -f docker-compose.latest.yml stop photoprism-latest
+	$(DOCKER_COMPOSE) -f docker-compose.latest.yml stop photoprism-latest
 terminal-latest:
-	docker compose -f docker-compose.latest.yml exec photoprism-latest bash
+	$(DOCKER_COMPOSE) -f docker-compose.latest.yml exec photoprism-latest bash
 logs-latest:
-	docker compose -f docker-compose.latest.yml logs -f photoprism-latest
+	$(DOCKER_COMPOSE) -f docker-compose.latest.yml logs -f photoprism-latest
 docker-local: docker-local-bookworm
 docker-local-all: docker-local-bookworm docker-local-bullseye docker-local-buster docker-local-jammy
 docker-local-bookworm:


### PR DESCRIPTION
The `Makefile` doesn't work with the current LTS version of Ubuntu:

```
$ lsb_release --all
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.1 LTS
Release:	22.04
Codename:	jammy

$ docker --version
Docker version 20.10.12, build 20.10.12-0ubuntu4

$ make docker-build
docker compose pull --ignore-pull-failures
unknown flag: --ignore-pull-failures
See 'docker --help'.

Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

[…]

Run 'docker COMMAND --help' for more information on a command.

To get more help with docker, check out our guides at https://docs.docker.com/go/guides/

make: *** [Makefile:297 : docker-build] Erreur 125
```

So this PR add the ability to use `docker-compose` instead of `docker compose`.

Acceptance Criteria:

- [x] **Features and enhancements are fully implemented** so that they can be released at any time without additional work
- [x] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [x] Documentation has been updated: https://github.com/photoprism/photoprism-docs/pull/136
- [x] Contributor License Agreement (CLA) has been signed
