### PR TITLE
Photos: Add a link from the Files tab to the file folder

### DIFF
--- a/frontend/src/dialog/photo/edit/files.vue
+++ b/frontend/src/dialog/photo/edit/files.vue
@@ -62,6 +62,11 @@
                                    @click.stop.prevent="showDeleteDialog(file)">
                               <translate>Delete</translate>
                             </v-btn>
+                            <v-btn v-if="file.Primary" small depressed dark color="primary-button"
+                                   class="btn-action action-open-folder"
+                                   :href="getFolderUri(file)">
+                              <translate>Open folder</translate>
+                            </v-btn>
                           </td>
                         </tr>
                         <tr>
@@ -307,6 +312,12 @@ export default {
     },
     openFile(file) {
       this.$viewer.show([Thumb.fromFile(this.model, file)], 0);
+    },
+    getFolderUri(file) {
+      const fileName = file.Name;
+      const folder = fileName.substring(0, fileName.lastIndexOf('/'));
+
+      return(this.config.baseUri + '/library/index/files/' + folder);
     },
     downloadFile(file) {
       Notify.success(this.$gettext("Downloading…"));


### PR DESCRIPTION
This PR adds a button to link from the “Files” tab to the directory which contain the file:

> ![image](https://user-images.githubusercontent.com/2071331/202909911-fa660eb6-52d5-457f-b0f6-ac68624ab7c1.png)

Since it's a link, users can open it in another tab or the current tab, depending how they click on it.

And the dog will be happy.

It's the first time I write Vue code, please let me know if something needs to be changed.

Acceptance Criteria:

- [x] **Features and enhancements are fully implemented** so that they can be released at any time without additional work
- [ ] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work - it looks like tests should go there https://github.com/photoprism/photoprism/blob/develop/frontend/tests/acceptance/acceptance-public/photos.js but I don't know how to test this feature
- [x] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations will be updated
- [x] Documentation has been / will be updated
- [x] Contributor License Agreement (CLA) has been signed

