### PR TITLE
Videos: Improve player compatibility with browser plugins

### DIFF
--- a/frontend/src/component/video/player.vue
+++ b/frontend/src/component/video/player.vue
@@ -82,7 +82,7 @@ export default {
   },
   methods: {
     videoEl() {
-      return this.$el.childNodes[0];
+      return this.$el.getElementsByTagName('video')[0];
     },
     updateStyle() {
       this.style = `width: ${this.width.toString()}px; height: ${this.height.toString()}px`;


### PR DESCRIPTION
When using the extension https://github.com/codebicycle/videospeed it's no longer possible to close the video player. As it grabs the wrong element. Making a more robust approach to always select the correct element.