### PR TITLE
Auth: Allow public WebDAV access without password

### DIFF
--- a/frontend/src/common/config.js
+++ b/frontend/src/common/config.js
@@ -570,12 +570,20 @@ export default class Config {
     return [];
   }
 
+  isAuthRequired() {
+    return this.values && this.values.authMode === "password";
+  }
+
   isPublic() {
     return this.values && this.values.public;
   }
 
   isDemo() {
     return this.values && this.values.demo;
+  }
+
+  isSingleUser() {
+    return this.values && this.values.authMode === "singleUser";
   }
 
   isSponsor() {

--- a/frontend/src/component/navigation.vue
+++ b/frontend/src/component/navigation.vue
@@ -530,7 +530,7 @@
           </v-list-tile-content>
         </v-list-tile>
 
-        <v-list-tile v-show="auth && !isPublic && $config.feature('settings')" class="p-profile" @click.stop="onAccount">
+        <v-list-tile v-show="auth && isAuthRequired && $config.feature('settings')" class="p-profile" @click.stop="onAccount">
           <v-list-tile-avatar size="36">
             <img :src="userAvatarURL" :alt="accountInfo" :title="accountInfo">
           </v-list-tile-avatar>
@@ -549,7 +549,7 @@
           </v-list-tile-action>
         </v-list-tile>
 
-        <v-list-tile v-show="isMini && auth && !isPublic" class="nav-logout" @click.stop.prevent="onLogout">
+        <v-list-tile v-show="isMini && auth && isAuthRequired" class="nav-logout" @click.stop.prevent="onLogout">
           <v-list-tile-action :title="$gettext('Logout')">
             <v-icon>power_settings_new</v-icon>
           </v-list-tile-action>
@@ -565,7 +565,7 @@
     <div id="mobile-menu" :class="{'active': speedDial}" @click.stop="speedDial = false">
       <div class="menu-content grow-top-right">
         <div class="menu-icons">
-          <a v-if="auth && !isPublic" href="#" :title="$gettext('Logout')" class="menu-action nav-logout"
+          <a v-if="auth && isAuthRequired" href="#" :title="$gettext('Logout')" class="menu-action nav-logout"
              @click.prevent="onLogout">
             <v-icon>power_settings_new</v-icon>
           </a>
@@ -584,7 +584,7 @@
              class="menu-action nav-upload" @click.prevent="openUpload()">
             <v-icon>cloud_upload</v-icon>
           </a>
-          <router-link v-if="!auth && !isPublic" :to="{ name: 'login' }" :title="$gettext('Login')"
+          <router-link v-if="!auth && isAuthRequired" :to="{ name: 'login' }" :title="$gettext('Login')"
                        class="menu-action nav-login">
             <v-icon>login</v-icon>
           </router-link>
@@ -706,6 +706,7 @@ export default {
       isRestricted: isRestricted,
       isMini: localStorage.getItem('last_navigation_mode') !== 'false' || isRestricted,
       isPublic: this.$config.get("public"),
+      isAuthRequired: this.$config.isAuthRequired(),
       isDemo: this.$config.get("demo"),
       isAdmin: this.$session.isAdmin(),
       isSponsor: this.$config.isSponsor(),
@@ -734,7 +735,7 @@ export default {
   },
   computed: {
     auth() {
-      return this.session.auth || this.isPublic;
+      return this.session.auth || !this.isAuthRequired;
     },
     visible() {
       return !this.$route.meta.hideNav;

--- a/frontend/src/page/login.vue
+++ b/frontend/src/page/login.vue
@@ -141,6 +141,16 @@ export default {
       return this.loading || this.username.trim() === "" || this.password.trim() === "";
     }
   },
+  mounted() {
+    if (!this.$config.isAuthRequired()) {
+      this.loading = true;
+      this.$session.login('', '').then(
+        () => {
+          this.load();
+        }
+      ).catch(() => this.loading = false);
+    }
+  },
   created() {
     this.$scrollbar.hide(this.$isMobile);
   },

--- a/frontend/src/page/settings.vue
+++ b/frontend/src/page/settings.vue
@@ -58,6 +58,7 @@ export default {
     const isDemo = this.$config.isDemo();
     const isPublic = this.$config.isPublic();
     const isSuperAdmin = this.$session.isSuperAdmin();
+    const isSingleUser = this.$config.isSingleUser();
 
     const tabs = [
       {
@@ -71,6 +72,7 @@ export default {
         'admin': true,
         'demo': true,
         'show': config.feature('settings'),
+        'singleUser': true,
       },
       {
         'name': 'settings_media',
@@ -83,6 +85,7 @@ export default {
         'admin': true,
         'demo': true,
         'show': config.allow("config", "manage") && isSuperAdmin,
+        'singleUser': true,
       },
       {
         'name': 'settings_advanced',
@@ -95,6 +98,7 @@ export default {
         'admin': true,
         'demo': true,
         'show': config.allow("config", "manage"),
+        'singleUser': true,
       },
       {
         'name': 'settings_services',
@@ -107,6 +111,7 @@ export default {
         'admin': true,
         'demo': true,
         'show': config.feature('services') && config.allow("services", "manage"),
+        'singleUser': true,
       },
       {
         'name': 'settings_account',
@@ -119,6 +124,7 @@ export default {
         'admin': true,
         'demo': true,
         'show': config.feature('account'),
+        'singleUser': false,
       },
     ];
 
@@ -126,6 +132,8 @@ export default {
       initTabs("demo", tabs);
     } else if (isPublic) {
       initTabs("public", tabs);
+    } else if (isSingleUser) {
+      initTabs("singleUser", tabs);
     } else {
       initTabs("show", tabs);
     }

--- a/internal/api/api_ws.go
+++ b/internal/api/api_ws.go
@@ -82,7 +82,7 @@ func WebSocket(router *gin.RouterGroup) {
 		// Init connection.
 		wsAuth.mutex.Lock()
 
-		if conf.Public() {
+		if !conf.Auth() {
 			wsAuth.user[connId] = entity.Admin
 		} else {
 			wsAuth.user[connId] = entity.UnknownUser

--- a/internal/api/auth_session.go
+++ b/internal/api/auth_session.go
@@ -23,7 +23,7 @@ func SessionID(c *gin.Context) (sessId string) {
 // Session finds the client session for the given ID or returns nil otherwise.
 func Session(id string) *entity.Session {
 	// Skip authentication if app is running in public mode.
-	if get.Config().Public() {
+	if !get.Config().Auth() {
 		return get.Session().Public()
 	} else if id == "" {
 		return nil

--- a/internal/api/auth_session_create.go
+++ b/internal/api/auth_session_create.go
@@ -29,7 +29,7 @@ func CreateSession(router *gin.RouterGroup) {
 		conf := get.Config()
 
 		// Skip authentication if app is running in public mode.
-		if conf.Public() {
+		if !conf.Auth() {
 			sess := get.Session().Public()
 			data := gin.H{
 				"status":   "ok",

--- a/internal/api/auth_session_delete.go
+++ b/internal/api/auth_session_delete.go
@@ -20,7 +20,7 @@ func DeleteSession(router *gin.RouterGroup) {
 		if id == "" {
 			AbortBadRequest(c)
 			return
-		} else if get.Config().Public() {
+		} else if !get.Config().Auth() {
 			c.JSON(http.StatusOK, gin.H{"status": "authentication disabled", "id": id})
 			return
 		}

--- a/internal/api/auth_session_get.go
+++ b/internal/api/auth_session_get.go
@@ -29,7 +29,7 @@ func GetSession(router *gin.RouterGroup) {
 
 		// Skip authentication if app is running in public mode.
 		var sess *entity.Session
-		if conf.Public() {
+		if !conf.Auth() {
 			sess = get.Session().Public()
 		} else {
 			sess = Session(id)

--- a/internal/api/users_password.go
+++ b/internal/api/users_password.go
@@ -23,7 +23,7 @@ func UpdateUserPassword(router *gin.RouterGroup) {
 		conf := get.Config()
 
 		// You cannot change any passwords without authentication and settings enabled.
-		if conf.Public() || conf.DisableSettings() {
+		if !conf.Auth() || conf.DisableSettings() {
 			Abort(c, http.StatusForbidden, i18n.ErrPublic)
 			return
 		}

--- a/internal/config/client_config.go
+++ b/internal/config/client_config.go
@@ -205,7 +205,7 @@ func (c *Config) Flags() (flags []string) {
 
 // ClientPublic returns config values for use by the JavaScript UI and other clients.
 func (c *Config) ClientPublic() ClientConfig {
-	if c.Public() {
+	if !c.Auth() {
 		return c.ClientUser(true).ApplyACL(acl.Resources, acl.RoleAdmin)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,7 +172,7 @@ func (c *Config) Propagate() {
 	// Set API preview and download default tokens.
 	entity.PreviewToken.Set(c.PreviewToken(), entity.TokenConfig)
 	entity.DownloadToken.Set(c.DownloadToken(), entity.TokenConfig)
-	entity.CheckTokens = !c.Public()
+	entity.CheckTokens = !c.Auth()
 
 	// Set face recognition parameters.
 	face.ScoreThreshold = c.FaceScore()

--- a/internal/config/config_auth.go
+++ b/internal/config/config_auth.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	AuthModePublic = "public"
-	AuthModePasswd = "password"
+	AuthModePublic     = "public"
+	AuthModePasswd     = "password"
+	AuthModeSingleUser = "singleUser"
 )
 
 func isBcrypt(s string) bool {
@@ -77,6 +78,10 @@ func (c *Config) SetAuthMode(mode string) {
 		c.options.AuthMode = AuthModePublic
 		c.options.Public = true
 		entity.CheckTokens = false
+	case AuthModeSingleUser:
+		c.options.AuthMode = AuthModeSingleUser
+		c.options.Public = false
+		entity.CheckTokens = false
 	default:
 		c.options.AuthMode = AuthModePasswd
 		c.options.Public = false
@@ -86,7 +91,7 @@ func (c *Config) SetAuthMode(mode string) {
 
 // Auth checks if authentication is required.
 func (c *Config) Auth() bool {
-	return !c.Public()
+	return c.AuthMode() == AuthModePasswd
 }
 
 // AuthMode returns the authentication mode.
@@ -98,6 +103,8 @@ func (c *Config) AuthMode() string {
 	switch c.options.AuthMode {
 	case AuthModePublic:
 		return AuthModePublic
+	case AuthModeSingleUser:
+		return AuthModeSingleUser
 	default:
 		return AuthModePasswd
 	}
@@ -105,7 +112,7 @@ func (c *Config) AuthMode() string {
 
 // LoginUri returns the user login URI.
 func (c *Config) LoginUri() string {
-	if c.Public() {
+	if !c.Auth() {
 		return c.BaseUri("/library/browse")
 	}
 
@@ -118,7 +125,7 @@ func (c *Config) LoginUri() string {
 
 // RegisterUri returns the user registration URI.
 func (c *Config) RegisterUri() string {
-	if c.Public() {
+	if !c.Auth() {
 		return ""
 	}
 

--- a/internal/config/config_auth_test.go
+++ b/internal/config/config_auth_test.go
@@ -33,6 +33,8 @@ func TestAuthMode(t *testing.T) {
 	c.options.Demo = false
 	c.options.AuthMode = "pass"
 	assert.Equal(t, AuthModePasswd, c.AuthMode())
+	c.options.AuthMode = "singleUser"
+	assert.Equal(t, AuthModeSingleUser, c.AuthMode())
 	c.options.AuthMode = "password"
 	assert.Equal(t, AuthModePasswd, c.AuthMode())
 	c.options.Debug = false
@@ -41,6 +43,8 @@ func TestAuthMode(t *testing.T) {
 	c.options.Debug = true
 	c.SetAuthMode(AuthModePublic)
 	assert.Equal(t, AuthModePublic, c.AuthMode())
+	c.SetAuthMode(AuthModeSingleUser)
+	assert.Equal(t, AuthModeSingleUser, c.AuthMode())
 	c.SetAuthMode(AuthModePasswd)
 	assert.Equal(t, AuthModePasswd, c.AuthMode())
 	c.options.Debug = false


### PR DESCRIPTION
SingleUser use case:

Home lan users only, don't want password. But authmode=public also disable webdav

Changes:
- No login required when auth_mode=singleUser(actually login with empty name&password, so create session api respond with built-in admin user)
- Account tab hidden
- Webdav enabled

<!--
Please describe your pull request:
- What does it implement / fix / improve?
- Is it related to an existing issue?
-->

<!--
After submitting your first pull request, you will automatically be asked to accept our Contributor License Agreement (CLA):

https://github.com/photoprism/photoprism/blob/develop/CONTRIBUTING.md#contributor-license-agreement-cla

Because we want to create the best possible product for our users, we have a set of guidelines to ensure that all submissions are acceptable.
Please check the following items by replacing "[ ]" with "[x]".
You can also do this when viewing the pull request after it was created:
-->

Acceptance Criteria:

- [x] **Features and enhancements are fully implemented** so that they can be released at any time without additional work
- [x] **Automated unit and/or acceptance tests have been added** to ensure the changes work as expected and to reduce repetitive manual work
- [x] **User interface changes are fully responsive** and have been tested on all major browsers and various devices
- [x] Database-related changes are compatible with SQLite and MariaDB
- [x] Translations have been / will be updated (specify if needed)
- [x] Documentation has been / will be updated (specify if needed)
- [x] Contributor License Agreement (CLA) has been signed

<!--
Reviewing, testing and finally merging pull requests consumes significant resources on our side. Unless it's just a small fix, it may take several months.

Thanks for your patience :)
-->

