### PR TITLE
Frontend: set UTC timezone for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ watch-js:
 	(cd frontend &&	env NODE_ENV=development npm run watch)
 test-js:
 	$(info Running JS unit tests...)
-	(cd frontend && env NODE_ENV=development BABEL_ENV=test npm run test)
+	(cd frontend && env TZ=UTC NODE_ENV=development BABEL_ENV=test npm run test)
 acceptance:
 	$(info Running public-mode tests in 'chromium:headless'...)
 	(cd frontend &&	npm run testcafe -- chrome:headless --test-grep "^(Common|Core)\:*" --test-meta mode=public --config-file ./testcaferc.json "tests/acceptance")


### PR DESCRIPTION
Without explicitly setting `TZ=UTC` when running the frontend tests, the tests fail on any machine that's not in the UTC timezone (which was also reported [here](https://github.com/photoprism/photoprism/issues/2843#issuecomment-1304895807)):

```
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7) model/album should get created date string FAILED
        AssertionError: expected 'Jul 8, 2012, 4:45 PM' to equal 'Jul 8, 2012, 2:45 PM'
            at Context.eval (webpack://photoprism/./tests/unit/model/album_test.js?:107:12)
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7) model/face should get date string FAILED
        AssertionError: expected 'Jul 8, 2012, 4:45 PM' to equal 'Jul 8, 2012, 2:45 PM'
            at Context.eval (webpack://photoprism/./tests/unit/model/face_test.js?:101:12)
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7) model/file should get date string FAILED
        AssertionError: expected 'Jul 8, 2012, 4:45 PM' to equal 'Jul 8, 2012, 2:45 PM'
            at Context.eval (webpack://photoprism/./tests/unit/model/file_test.js?:176:12)
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7) model/folder should get date string FAILED
        AssertionError: expected 'Jul 8, 2012, 4:45 PM' to equal 'Jul 8, 2012, 2:45 PM'
            at Context.eval (webpack://photoprism/./tests/unit/model/folder_test.js?:128:12)
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7) model/label should get date string FAILED
        AssertionError: expected 'Jul 8, 2012, 4:45 PM' to equal 'Jul 8, 2012, 2:45 PM'
            at Context.eval (webpack://photoprism/./tests/unit/model/label_test.js?:111:12)
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7) model/marker should get date string FAILED
        AssertionError: expected 'Jul 8, 2012, 4:45 PM' to equal 'Jul 8, 2012, 2:45 PM'
            at Context.eval (webpack://photoprism/./tests/unit/model/marker_test.js?:121:12)
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7) model/subject should get date string FAILED
        AssertionError: expected 'Jul 8, 2012, 4:45 PM' to equal 'Jul 8, 2012, 2:45 PM'
            at Context.eval (webpack://photoprism/./tests/unit/model/subject_test.js?:152:12)
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7): Executed 320 of 320 (7 FAILED) (0.355 secs / 0.102 secs)
TOTAL: 7 FAILED, 313 SUCCESS
TOTAL: 7 FAILED, 313 SUCCESS
```

After setting this `TZ=UTC`, the tests succeed:

```
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7): Executed 320 of 320 SUCCESS (0.309 secs / 0.08 secs)
TOTAL: 320 SUCCESS
TOTAL: 320 SUCCESS
```

<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

