### PR TITLE
Frontend: Upgrade Axios to v1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@babel/runtime": "^7.20.7",
         "@lcdp/offline-plugin": "^5.1.1",
         "@vvo/tzdb": "^6.86.0",
-        "axios": "^0.27.2",
+        "axios": "^1.3.2",
         "axios-mock-adapter": "^1.21.2",
         "babel-loader": "^9.1.0",
         "babel-plugin-istanbul": "^6.1.1",
@@ -3115,12 +3115,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
+      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -10300,6 +10301,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@babel/runtime": "^7.20.7",
     "@lcdp/offline-plugin": "^5.1.1",
     "@vvo/tzdb": "^6.86.0",
-    "axios": "^0.27.2",
+    "axios": "^1.3.2",
     "axios-mock-adapter": "^1.21.2",
     "babel-loader": "^9.1.0",
     "babel-plugin-istanbul": "^6.1.1",


### PR DESCRIPTION
Closes #2843

While reading through the [v1 changelog](https://github.com/axios/axios/blob/v1.x/CHANGELOG.md), I didn't find anything that would break PhotoPrism. The upgrade turned out to be really smooth! I checked various `.js` files and all the methods that PhotoPrism is using are still available in v1.

After the upgrade, I tested some functionality in the frontend, both in Chrome and Firefox. Here's a screencast from Chrome:

[PhotoPrism.webm](https://user-images.githubusercontent.com/17739158/216759191-bf44a6a7-0a0e-4ccd-802f-ecbaa0e8d759.webm)

The offline mode/handling also works correctly:

<img width="1791" alt="Screenshot 2023-02-04 at 10 04 15" src="https://user-images.githubusercontent.com/17739158/216759211-33e5830c-7aee-4b2b-a067-0adcbd34638f.png">

Tests are looking good too:

```
% make test-js
Running JS unit tests...
(cd frontend && env TZ=UTC NODE_ENV=development BABEL_ENV=test npm run test)

> photoprism@1.0.0 test
> karma start

chrome-bin: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
webpack was not included as a framework in karma configuration, setting this automatically...
Webpack bundling...
asset commons.js 4.2 MiB [emitted] (name: commons) (id hint: commons)
asset runtime.js 7.72 KiB [emitted] (name: runtime)
asset config-options_test.3806546550.js 1.02 KiB [emitted] (name: config-options_test.3806546550)
asset clipboard_test.3827051328.js 1.01 KiB [emitted] (name: clipboard_test.3827051328)
asset options_test.1870539667.js 1.01 KiB [emitted] (name: options_test.1870539667)
asset settings_test.1414744100.js 1.01 KiB [emitted] (name: settings_test.1414744100)
asset caniuse_test.2622028542.js 1.01 KiB [emitted] (name: caniuse_test.2622028542)
asset session_test.3529452177.js 1.01 KiB [emitted] (name: session_test.3529452177)
asset service_test.2911543317.js 1.01 KiB [emitted] (name: service_test.2911543317)
asset config_test.2700275448.js 1.01 KiB [emitted] (name: config_test.2700275448)
asset notify_test.3421491644.js 1.01 KiB [emitted] (name: notify_test.3421491644)
asset subject_test.788580366.js 1.01 KiB [emitted] (name: subject_test.788580366)
asset viewer_test.2045023614.js 1.01 KiB [emitted] (name: viewer_test.2045023614)
asset marker_test.3891758919.js 1.01 KiB [emitted] (name: marker_test.3891758919)
+ 13 assets
webpack 5.75.0 compiled successfully in 3016 ms
Chrome Headless 109.0.5414.119 (Mac OS 10.15.7): Executed 320 of 320 SUCCESS (0.377 secs / 0.123 secs)
TOTAL: 320 SUCCESS
TOTAL: 320 SUCCESS

=============================== Coverage summary ===============================
Statements   : 70.74% ( 1630/2304 )
Branches     : 54.07% ( 770/1424 )
Functions    : 75.17% ( 418/556 )
Lines        : 70.97% ( 1560/2198 )
================================================================================
```

<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

