### PR TITLE
Webdav: Enable originals webdav in readonly mode

### DIFF
--- a/internal/config/config_features.go
+++ b/internal/config/config_features.go
@@ -4,7 +4,7 @@ var Sponsor = Env(EnvDemo, EnvSponsor, EnvTest)
 
 // DisableWebDAV checks if the built-in WebDAV server should be disabled.
 func (c *Config) DisableWebDAV() bool {
-	if c.Public() || c.ReadOnly() || c.Demo() {
+	if c.Public() || c.Demo() {
 		return true
 	}
 

--- a/internal/config/config_features_test.go
+++ b/internal/config/config_features_test.go
@@ -30,7 +30,7 @@ func TestConfig_DisableWebDAV(t *testing.T) {
 	c.options.ReadOnly = true
 	c.options.Demo = false
 
-	assert.True(t, c.DisableWebDAV())
+	assert.False(t, c.DisableWebDAV())
 
 	c.options.Public = false
 	c.options.ReadOnly = false

--- a/internal/server/webdav/read_only_dir.go
+++ b/internal/server/webdav/read_only_dir.go
@@ -1,0 +1,32 @@
+package webdav
+
+import (
+	"context"
+	"golang.org/x/net/webdav"
+	"os"
+)
+
+type ReadOnlyDir string
+
+func (d ReadOnlyDir) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+	return os.ErrPermission
+}
+
+func (d ReadOnlyDir) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
+	if flag != os.O_RDONLY {
+		return nil, os.ErrPermission
+	}
+	return webdav.Dir(d).OpenFile(ctx, name, flag, perm)
+}
+
+func (d ReadOnlyDir) RemoveAll(ctx context.Context, name string) error {
+	return os.ErrPermission
+}
+
+func (d ReadOnlyDir) Rename(ctx context.Context, oldName, newName string) error {
+	return os.ErrPermission
+}
+
+func (d ReadOnlyDir) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	return webdav.Dir(d).Stat(ctx, name)
+}


### PR DESCRIPTION
Adds a read only webdav server in readonly mode. 

Acceptance Criteria:

- [X] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [ ] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [ ] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+
