### PR TITLE
CLI: Add `photoprism find` command to search the index for specific files

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -65,6 +65,7 @@ var PhotoPrism = []cli.Command{
 	ShowCommand,
 	VersionCommand,
 	ShowConfigCommand,
+	SearchCommand,
 	ConnectCommand,
 }
 

--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"context"
+	"time"
+	"strings"
+
+	"fmt"
+
+	"github.com/urfave/cli"
+	"github.com/photoprism/photoprism/internal/form"
+	"github.com/photoprism/photoprism/internal/search"
+	"github.com/photoprism/photoprism/internal/entity"
+)
+
+// SearchCommand registers the search cli command.
+var SearchCommand = cli.Command{
+	Name:      "search",
+	Usage:     "Searches in library using filters",
+	ArgsUsage: "search-query",
+	Action:    searchAction,
+}
+
+// searchAction searches all photos in library
+func searchAction(ctx *cli.Context) error {
+	start := time.Now()
+
+	conf, err := InitConfig(ctx)
+
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err != nil {
+		return err
+	}
+
+	conf.InitDb()
+	defer conf.Shutdown()
+
+	form := form.SearchPhotos{Query: strings.TrimSpace(ctx.Args().First()), Primary: false, Merged: false}
+	photos, _, err := search.Photos(form)
+
+	for _, photo := range photos {
+		p := entity.Photo{ID: photo.ID}
+		p.PreloadFiles()
+		for _, file := range p.Files {
+			fmt.Printf("%s\n", file.FileName)
+		}
+	}
+
+	elapsed := time.Since(start)
+
+	log.Infof("searched in %s", elapsed)
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a CLI command called "search" that takes a search query as its only argument, in the same format as the search box in the UI, and lists all filenames found matching this search query.

For photos that have multiple files, all files are listed.

This is a rather small PR that does not touch any existing code.

As I said on the community chat I couldn't really make tests work for CLI commands, but this might not be a big problem. I looked around a bit but didn't find CLI-specific documentation that needed to be updated to add this new command.

<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

Acceptance Criteria:

- [X] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

