### PR TITLE
prevent rerendering of faces page on every typed letter

### DIFF
--- a/frontend/src/model/face.js
+++ b/frontend/src/model/face.js
@@ -117,15 +117,15 @@ export class Face extends RestModel {
     return Api.put(this.getEntityResource(), { Hidden: this.Hidden });
   }
 
-  setName() {
-    if (!this.Name || this.Name.trim() === "") {
+  setName(newName = this.Name) {
+    if (!newName || newName.trim() === "") {
       // Can't save an empty name.
       return Promise.resolve(this);
     }
 
     this.SubjSrc = src.Manual;
 
-    const payload = { SubjSrc: this.SubjSrc, Name: this.Name };
+    const payload = { SubjSrc: this.SubjSrc, Name: newName };
 
     return Api.put(Marker.getCollectionResource() + "/" + this.MarkerUID, payload).then((resp) => {
       if (resp && resp.data && resp.data.Name) {

--- a/frontend/src/page/people/new.vue
+++ b/frontend/src/page/people/new.vue
@@ -65,7 +65,7 @@
                 <v-layout v-if="model.SubjUID" row wrap align-center>
                   <v-flex xs12 class="text-xs-left pa-0">
                     <v-text-field
-                        v-model="model.Name"
+                        :value="model.Name"
                         :rules="[textRule]"
                         :readonly="readonly"
                         browser-autocomplete="off"
@@ -73,15 +73,15 @@
                         hide-details
                         single-line
                         solo-inverted
-                        @change="onRename(model)"
-                        @keyup.enter.native="onRename(model)"
+                        @change="(newName) => {onRename(model, newName)}"
+                        @keyup.enter.native="(event) => {onRename(model, event.target.value)}"
                     ></v-text-field>
                   </v-flex>
                 </v-layout>
                 <v-layout v-else row wrap align-center>
                   <v-flex xs12 class="text-xs-left pa-0">
                     <v-combobox
-                        v-model="model.Name"
+                        :value="model.Name"
                         style="z-index: 250"
                         :items="$config.values.people"
                         item-value="Name"
@@ -100,8 +100,8 @@
                         prepend-inner-icon="person_add"
                         browser-autocomplete="off"
                         class="input-name pa-0 ma-0"
-                        @change="onRename(model)"
-                        @keyup.enter.native="onRename(model)"
+                        @change="(newName) => {onRename(model, newName)}"
+                        @keyup.enter.native="(event) => {onRename(model, event.target.value)}"
                     >
                     </v-combobox>
                   </v-flex>
@@ -536,8 +536,8 @@ export default {
         }
       });
     },
-    onRename(model) {
-      if (this.busy || !model || !model.Name || model.Name.trim() === "") {
+    onRename(model, newName) {
+      if (this.busy || !model || !newName || newName.trim() === "") {
         // Ignore if busy, refuse to save empty name.
         return;
       }
@@ -545,7 +545,7 @@ export default {
       this.busy = true;
       this.$notify.blockUI();
 
-      model.setName().finally(() => {
+      model.setName(newName).finally(() => {
         this.$notify.unblockUI();
         this.busy = false;
         this.changeFaceCount(-1);


### PR DESCRIPTION
This Fixes https://github.com/photoprism/photoprism/issues/3151.

Setting and then editing a name of a face was slow, because the whole faces-page with all its components rerendered on every typed letter. This was because the face-model-name was bound directly to the input, therefore updating the model on every letter change.

With these changes, the model is only updated when the user actually commits the change (either by leaving the input or pressing enter).

The faces page still renders slow because it uses a LOT of vue-components (instead of native dom-elements), but speeding that up would require a more invasive change. With these less invasive changes, the rerender might still be slow, but because it only happens if something actually changes, the user-experience is improved.

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [ ] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [ ] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+