### PR TITLE
Fix duration compare in photos location estimate

### DIFF
--- a/internal/entity/photo_estimate.go
+++ b/internal/entity/photo_estimate.go
@@ -64,7 +64,7 @@ func (m *Photo) EstimateLocation(force bool) {
 		return
 	} else if force || m.EstimatedAt == nil {
 		// Proceed.
-	} else if hours := TimeStamp().Sub(*m.EstimatedAt) / time.Hour; hours < MetadataEstimateInterval {
+	} else if hours := TimeStamp().Sub(*m.EstimatedAt); hours < MetadataEstimateInterval {
 		// Ignore if location has been estimated recently (in the last 7 days by default).
 		return
 	}

--- a/internal/entity/photo_estimate_test.go
+++ b/internal/entity/photo_estimate_test.go
@@ -75,6 +75,21 @@ func TestPhoto_EstimateLocation(t *testing.T) {
 		assert.Equal(t, UnknownCountry.CountryName, m2.CountryName())
 		assert.Equal(t, SrcAuto, m2.PlaceSrc)
 	})
+	t.Run("NotRecentlyEstimated", func(t *testing.T) {
+		estimateTime := TimeStamp().Add(-1 * (MetadataEstimateInterval + 2*time.Hour))
+		m2 := Photo{
+			CameraID:     2,
+			TakenSrc:     SrcMeta,
+			PhotoName:    "PhotoWithoutLocation",
+			OriginalName: "demo/xyy.jpg",
+			EstimatedAt:  &estimateTime,
+			TakenAt:      time.Date(2016, 11, 11, 8, 7, 18, 0, time.UTC)}
+		assert.Equal(t, UnknownID, m2.CountryCode())
+		m2.EstimateLocation(false)
+		assert.Equal(t, "mx", m2.CountryCode())
+		assert.Equal(t, "Mexico", m2.CountryName())
+		assert.Equal(t, SrcEstimate, m2.PlaceSrc)
+	})
 	t.Run("ForceEstimate", func(t *testing.T) {
 		m2 := Photo{
 			CameraID:     2,


### PR DESCRIPTION
There is currently a bug in how durations are compared when determining if locations should be estimated again or not. As a result a photos location is not estimated every 7 days as the code intends. The code converts to number of hours as an int, but compares against a duration which ends up being that many nano seconds. This is best shown with a sample

The following [code](https://go.dev/play/p/PnvRypIMRbH)

```golang
package main

import (
	"fmt"
	"time"
)

func main() {
	p := fmt.Println
	var MetadataEstimateInterval = 24 * 7 * time.Hour

	now := time.Date(2023, 02, 28, 00, 30, 00, 00, time.UTC)
	tenDay := time.Date(2023, 02, 18, 00, 30, 00, 00, time.UTC)
	oneDay := time.Date(2023, 02, 27, 00, 30, 00, 00, time.UTC)

	p(now.Sub(oneDay) / time.Hour)
	p(now.Sub(tenDay) / time.Hour)

	if now.Sub(oneDay)/time.Hour > MetadataEstimateInterval {
		p("Division: One Day is > than 7")
	} else {
		p("Division: One Day is < than 7")
	}

	if now.Sub(tenDay)/time.Hour > MetadataEstimateInterval {
		p("Division: ten Days is > than 7")
	} else {
		p("Division: ten Days is < than 7")
	}

	p("----------------------")

	p(now.Sub(oneDay))
	p(now.Sub(tenDay))

	if now.Sub(oneDay) > MetadataEstimateInterval {
		p("Duration: One Day is > than 7")
	} else {
		p("Duration: One Day is < than 7")
	}

	if now.Sub(tenDay) > MetadataEstimateInterval {
		p("Duration: ten Day is > than 7")
	} else {
		p("Duration: ten Days is < than 7")
	}

}
```

**Produces:** 
```
24ns
240ns
Division: One Day is < than 7
Division: ten Days is < than 7
----------------------
24h0m0s
240h0m0s
Duration: One Day is < than 7
Duration: ten Day is > than 7
```

as you can see, dividing by `time.Hour` does not produce the expect result. Since `Time.Sub` returns a duration, this can simply be compared against the `MetadataEstimateInterval` duration

_Note:_ A result of this change is users libraries will start to be estimated more frequently than today, but based on the comments of the code it appears the intent was always to estimate every 7 days. If users don't want this behavior they can already disable the estimate feature 
<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

**Acceptance Criteria:**

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [ ] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [ ] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

