### PR TITLE
Auth: Correct feature for account settings

### DIFF
--- a/frontend/src/component/navigation.vue
+++ b/frontend/src/component/navigation.vue
@@ -539,7 +539,7 @@
           </v-list-tile-content>
         </v-list-tile>
 
-        <v-list-tile v-show="auth && !isPublic && $config.feature('settings')" class="p-profile" @click.stop="onAccount">
+        <v-list-tile v-show="auth && !isPublic && $config.feature('account')" class="p-profile" @click.stop="onAccount">
           <v-list-tile-avatar size="36">
             <img :src="userAvatarURL" :alt="accountInfo" :title="accountInfo">
           </v-list-tile-avatar>


### PR DESCRIPTION
Use the `account` feature to determine whether the account settings and login button should be shown (and not the `settings` feature, which has a different purpose).