### PR TITLE
Clarify trusted-proxy option env TRUSTED_PROXY

### DIFF
--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -448,7 +448,7 @@ var Flags = CliFlags{
 		}}, {
 		Flag: cli.StringSliceFlag{
 			Name:   "trusted-proxy",
-			Usage:  "`CIDR` range from which reverse proxy headers can be trusted",
+			Usage:  "`CIDR` ranges or IPv4/v6 addresses from which reverse proxy headers can be trusted, separated by commas",
 			Value:  &cli.StringSlice{header.CidrDockerInternal},
 			EnvVar: EnvVar("TRUSTED_PROXY"),
 		}}, {


### PR DESCRIPTION
Clarify that PHOTOPRISM_TRUSTED_PROXY is passed to Gin per https://github.com/gin-gonic/gin/blob/457fabd7e14f36ca1b5f302f7247efeb4690e49c/docs/doc.md#dont-trust-all-proxies

See https://github.com/photoprism/photoprism/discussions/3382

Acceptance Criteria:

- [NA] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [NA] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [NA] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [NA] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

It's unclear to me if there are translations for these strings. Searching the translation tool on https://translate.photoprism.app for "trusted" has no hits.
