### PR TITLE
UX: Add preview image to the labels tab in the photo edit dialog

### DIFF
--- a/frontend/src/dialog/photo/edit/labels.vue
+++ b/frontend/src/dialog/photo/edit/labels.vue
@@ -1,93 +1,115 @@
 <template>
   <div class="p-tab p-tab-photo-labels">
-    <v-data-table
-        v-model="selected"
-        :headers="listColumns"
-        :items="model.Labels"
-        hide-actions
-        class="elevation-0 p-files p-files-list p-results"
-        disable-initial-sort
-        item-key="ID"
-        :no-data-text="$gettext('No labels found')"
-    >
-      <template #items="props" class="p-file">
-        <td>
-          <v-edit-dialog
-              :return-value.sync="props.item.Label.Name"
-              lazy
-              class="p-inline-edit"
-              @save="renameLabel(props.item.Label)"
+    <v-layout row wrap align-top fill-height>
+      <v-flex
+        v-if="!$isMobile"
+        class="p-photo pa-2"
+        xs12 sm4 md2
+      >
+        <v-card tile
+                    class="ma-0 elevation-0"
+                    :title="model.Title">
+          <v-img :src="model.thumbnailUrl('tile_500')"
+                     aspect-ratio="1"
+                     class="card darken-1 elevation-0 clickable"
+                     @click.exact="openPhoto()"
           >
-            {{ props.item.Label.Name }}
-            <template #input>
+          </v-img>
+
+        </v-card>
+      </v-flex>
+      <v-flex xs12 sm8 md10 fill-height fill-width>
+        <v-data-table
+            v-model="selected"
+            :headers="listColumns"
+            :items="model.Labels"
+            hide-actions
+            class="elevation-0 p-files p-files-list p-results"
+            disable-initial-sort
+            item-key="ID"
+            :no-data-text="$gettext('No labels found')"
+        >
+          <template #items="props" class="p-file">
+            <td>
+              <v-edit-dialog
+                  :return-value.sync="props.item.Label.Name"
+                  lazy
+                  class="p-inline-edit"
+                  @save="renameLabel(props.item.Label)"
+              >
+                {{ props.item.Label.Name }}
+                <template #input>
+                  <v-text-field
+                      v-model="props.item.Label.Name"
+                      :rules="[nameRule]"
+                      :label="$gettext('Name')"
+                      color="secondary-dark"
+                      class="input-rename background-inherit elevation-0"
+                      single-line autofocus solo hide-details
+                  ></v-text-field>
+                </template>
+              </v-edit-dialog>
+            </td>
+            <td class="text-xs-left">{{ sourceName(props.item.LabelSrc) }}</td>
+            <td class="text-xs-center">{{ 100 - props.item.Uncertainty }}%</td>
+            <td class="text-xs-center">
+              <v-btn v-if="disabled" icon small flat :ripple="false"
+                     class="action-view" title="Search"
+                     @click.stop.prevent="searchLabel(props.item.Label)">
+                <v-icon color="secondary-dark">search</v-icon>
+              </v-btn>
+              <v-btn v-else-if="props.item.Uncertainty < 100 && props.item.LabelSrc === 'manual'" icon
+                     small flat :ripple="false"
+                     class="action-delete" title="Delete"
+                     @click.stop.prevent="removeLabel(props.item.Label)">
+                <v-icon color="secondary-dark">delete</v-icon>
+              </v-btn>
+              <v-btn v-else-if="props.item.Uncertainty < 100" icon small flat :ripple="false"
+                     class="action-remove" title="Remove"
+                     @click.stop.prevent="removeLabel(props.item.Label)">
+                <v-icon color="secondary-dark">remove</v-icon>
+              </v-btn>
+              <v-btn v-else icon small flat :ripple="false"
+                     class="action-on" title="Activate"
+                     @click.stop.prevent="activateLabel(props.item.Label)">
+                <v-icon color="secondary-dark">add</v-icon>
+              </v-btn>
+            </td>
+          </template>
+          <template v-if="!disabled" #footer>
+            <td>
               <v-text-field
-                  v-model="props.item.Label.Name"
+                  v-model="newLabel"
                   :rules="[nameRule]"
-                  :label="$gettext('Name')"
                   color="secondary-dark"
-                  class="input-rename background-inherit elevation-0"
-                  single-line autofocus solo hide-details
+                  browser-autocomplete="off"
+                  :label="$gettext('Name')"
+                  single-line
+                  flat solo hide-details
+                  autofocus
+                  class="input-label"
+                  @keyup.enter.native="addLabel"
               ></v-text-field>
-            </template>
-          </v-edit-dialog>
-        </td>
-        <td class="text-xs-left">{{ sourceName(props.item.LabelSrc) }}</td>
-        <td class="text-xs-center">{{ 100 - props.item.Uncertainty }}%</td>
-        <td class="text-xs-center">
-          <v-btn v-if="disabled" icon small flat :ripple="false"
-                 class="action-view" title="Search"
-                 @click.stop.prevent="searchLabel(props.item.Label)">
-            <v-icon color="secondary-dark">search</v-icon>
-          </v-btn>
-          <v-btn v-else-if="props.item.Uncertainty < 100 && props.item.LabelSrc === 'manual'" icon
-                 small flat :ripple="false"
-                 class="action-delete" title="Delete"
-                 @click.stop.prevent="removeLabel(props.item.Label)">
-            <v-icon color="secondary-dark">delete</v-icon>
-          </v-btn>
-          <v-btn v-else-if="props.item.Uncertainty < 100" icon small flat :ripple="false"
-                 class="action-remove" title="Remove"
-                 @click.stop.prevent="removeLabel(props.item.Label)">
-            <v-icon color="secondary-dark">remove</v-icon>
-          </v-btn>
-          <v-btn v-else icon small flat :ripple="false"
-                 class="action-on" title="Activate"
-                 @click.stop.prevent="activateLabel(props.item.Label)">
-            <v-icon color="secondary-dark">add</v-icon>
-          </v-btn>
-        </td>
-      </template>
-      <template v-if="!disabled" #footer>
-        <td>
-          <v-text-field
-              v-model="newLabel"
-              :rules="[nameRule]"
-              color="secondary-dark"
-              browser-autocomplete="off"
-              :label="$gettext('Name')"
-              single-line
-              flat solo hide-details
-              autofocus
-              class="input-label"
-              @keyup.enter.native="addLabel"
-          ></v-text-field>
-        </td>
-        <td class="text-xs-left">{{ sourceName('manual') }}</td>
-        <td class="text-xs-center">100%</td>
-        <td class="text-xs-center">
-          <v-btn icon small flat :ripple="false" title="Add"
-                 class="p-photo-label-add"
-                 @click.stop.prevent="addLabel">
-            <v-icon color="secondary-dark">add</v-icon>
-          </v-btn>
-        </td>
-      </template>
-    </v-data-table>
+            </td>
+            <td class="text-xs-left">{{ sourceName('manual') }}</td>
+            <td class="text-xs-center">100%</td>
+            <td class="text-xs-center">
+              <v-btn icon small flat :ripple="false" title="Add"
+                     class="p-photo-label-add"
+                     @click.stop.prevent="addLabel">
+                <v-icon color="secondary-dark">add</v-icon>
+              </v-btn>
+            </td>
+          </template>
+        </v-data-table>
+      </v-flex>
+    </v-layout>
   </div>
 </template>
 
 <script>
 import Label from "model/label";
+import Thumb from "model/thumb";
 
 export default {
   name: 'PTabPhotoLabels',
@@ -169,6 +191,9 @@ export default {
     searchLabel(label) {
       this.$router.push({name: 'all', query: {q: 'label:' + label.Slug}}).catch(() => {});
       this.$emit('close');
+    },
+    openPhoto() {
+      this.$viewer.show(Thumb.fromFiles([this.model]), 0);
     },
   },
 };


### PR DESCRIPTION
<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->
This pull requests adds an image preview when editing labels.

![image](https://github.com/photoprism/photoprism/assets/9706673/d84a2981-182c-4d72-b852-85b0643f23ef)

This is to address this issue: https://github.com/photoprism/photoprism/issues/628

The issue points out that there is limited space for thumbnails on mobile devices, so it will be hidden on mobile devices.

Acceptance Criteria:

- [ ] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [ ] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [ ] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

