### PR TITLE
Adds standard video resolution options for PHOTOPRISM_FFMPEG_RESOLUTION

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       # PHOTOPRISM_FFMPEG_ENCODER: "nvidia"          # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry", "vaapi") Intel: "intel" for Broadwell or later and "vaapi" for Haswell or earlier
       # PHOTOPRISM_FFMPEG_ENCODER: "intel"           # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry", "vaapi") Intel: "intel" for Broadwell or later and "vaapi" for Haswell or earlier`
       # PHOTOPRISM_FFMPEG_BITRATE: "32"              # FFmpeg encoding bitrate limit in Mbit/s (default: 50)
-      # PHOTOPRISM_FFMPEG_RESOLUTION: "1920"         # FFmpeg encoding resolution limit in pixel height (default: 4096)
+      # PHOTOPRISM_FFMPEG_RESOLUTION: "HD+"          # FFmpeg encoding resolution limit in pixel height (default: 4K)
       # LIBVA_DRIVER_NAME: "i965"                    # For Intel architectures Haswell and older which do not support QSV yet but use VAAPI instead
     ## Share hardware devices with FFmpeg and TensorFlow (optional):
     # devices:

--- a/internal/config/config_ffmpeg.go
+++ b/internal/config/config_ffmpeg.go
@@ -2,7 +2,8 @@ package config
 
 import (
 	"fmt"
-
+	"strconv"
+	"strings"
 	"github.com/photoprism/photoprism/internal/ffmpeg"
 )
 
@@ -39,13 +40,33 @@ func (c *Config) FFmpegBitrate() int {
 
 // FFmpegResolution returns the ffmpeg resolution limit in pixel height. Goes from 144p to 8k.
 func (c *Config) FFmpegResolution() int {
+	resolution := strings.ToLower(c.options.FFmpegResolution)
 	switch {
-	case c.options.FFmpegResolution <= 0:
-		return 4096
-	case c.options.FFmpegResolution >= 8192:
+	case resolution == "8k":
 		return 8192
+	case resolution == "4k":
+		return 4096
+	case resolution == "2k":
+		return 2560
+	case resolution == "hd+":
+		return 1920
+	case resolution == "hd":
+		return 1280
+	case resolution == "sd":
+		return 720
 	default:
-		return c.options.FFmpegResolution
+		number, err := strconv.Atoi(resolution)
+		if err != nil {
+			return 4096
+		}
+		switch {
+		case number <= 0:
+			return 4096
+		case number >= 8192:
+			return 8192
+		default:
+			return number
+		}
 	}
 }
 

--- a/internal/config/config_ffmpeg_test.go
+++ b/internal/config/config_ffmpeg_test.go
@@ -47,11 +47,35 @@ func TestConfig_FFmpegResolution(t *testing.T) {
 	c := NewConfig(CliTestContext())
 	assert.Equal(t, 4096, c.FFmpegResolution())
 
-	c.options.FFmpegResolution = 1920
+	c.options.FFmpegResolution = "1920"
 	assert.Equal(t, 1920, c.FFmpegResolution())
 
-	c.options.FFmpegResolution = 8640
+	c.options.FFmpegResolution = "8640"
 	assert.Equal(t, 8192, c.FFmpegResolution())
+
+	c.options.FFmpegResolution = "8640"
+	assert.Equal(t, 8192, c.FFmpegResolution())
+
+	c.options.FFmpegResolution = "8k"
+	assert.Equal(t, 8192, c.FFmpegResolution())
+
+	c.options.FFmpegResolution = "4k"
+	assert.Equal(t, 4096, c.FFmpegResolution())
+
+	c.options.FFmpegResolution = "2K"
+	assert.Equal(t, 2560, c.FFmpegResolution())
+
+	c.options.FFmpegResolution = "HD+"
+	assert.Equal(t, 1920, c.FFmpegResolution())
+
+	c.options.FFmpegResolution = "HD"
+	assert.Equal(t, 1280, c.FFmpegResolution())
+
+	c.options.FFmpegResolution = "SD"
+	assert.Equal(t, 720, c.FFmpegResolution())
+
+	c.options.FFmpegResolution = "dfgjkn"
+	assert.Equal(t, 4096, c.FFmpegResolution())
 }
 
 func TestConfig_FFmpegBitrateExceeded(t *testing.T) {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -587,7 +587,7 @@ var Flags = CliFlags{
 		}}, {
 		Flag: cli.IntFlag{
 			Name:   "ffmpeg-resolution",
-			Usage:  "maximum FFmpeg encoding `RESOLUTION` (height)",
+			Usage:  "maximum FFmpeg encoding `RESOLUTION` can be specified using SD, HD, HD+, 2k, 4k, and 8k or with the largest possible dimension in pixels.",
 			Value:  4096,
 			EnvVar: EnvVar("FFMPEG_RESOLUTION"),
 		}}, {

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -130,7 +130,7 @@ type Options struct {
 	FFmpegBin             string        `yaml:"FFmpegBin" json:"-" flag:"ffmpeg-bin"`
 	FFmpegEncoder         string        `yaml:"FFmpegEncoder" json:"FFmpegEncoder" flag:"ffmpeg-encoder"`
 	FFmpegBitrate         int           `yaml:"FFmpegBitrate" json:"FFmpegBitrate" flag:"ffmpeg-bitrate"`
-	FFmpegResolution      int           `yaml:"FFmpegResolution" json:"FFmpegResolution" flag:"ffmpeg-resolution"`
+	FFmpegResolution      string        `yaml:"FFmpegResolution" json:"FFmpegResolution" flag:"ffmpeg-resolution"`
 	FFmpegMapVideo        string        `yaml:"FFmpegMapVideo" json:"FFmpegMapVideo" flag:"ffmpeg-map-video"`
 	FFmpegMapAudio        string        `yaml:"FFmpegMapAudio" json:"FFmpegMapAudio" flag:"ffmpeg-map-audio"`
 	ExifToolBin           string        `yaml:"ExifToolBin" json:"-" flag:"exiftool-bin"`

--- a/setup/docker/arm64/docker-compose.yml
+++ b/setup/docker/arm64/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       ## Hardware Video Transcoding:
       # PHOTOPRISM_FFMPEG_ENCODER: "raspberry"       # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry")
       # PHOTOPRISM_FFMPEG_BITRATE: "32"              # FFmpeg encoding bitrate limit in Mbit/s (default: 50)
-      # PHOTOPRISM_FFMPEG_RESOLUTION: "1920"         # FFmpeg encoding resolution limit in pixel height (default: 4096)
+      # PHOTOPRISM_FFMPEG_RESOLUTION: "HD+"          # FFmpeg encoding resolution limit in pixel height (default: 4k)
       ## Run as a non-root user after initialization (supported: 0, 33, 50-99, 500-600, and 900-1200):
       # PHOTOPRISM_UID: 1000
       # PHOTOPRISM_GID: 1000

--- a/setup/docker/docker-compose.yml
+++ b/setup/docker/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       ## Hardware Video Transcoding:
       # PHOTOPRISM_FFMPEG_ENCODER: "software"        # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry")
       # PHOTOPRISM_FFMPEG_BITRATE: "32"              # FFmpeg encoding bitrate limit in Mbit/s (default: 50)
-      # PHOTOPRISM_FFMPEG_RESOLUTION: "1920"         # FFmpeg encoding resolution limit in pixel height (default: 4096)
+      # PHOTOPRISM_FFMPEG_RESOLUTION: "HD+"          # FFmpeg encoding resolution limit in pixel height (default: 4k)
       ## Run as a non-root user after initialization (supported: 0, 33, 50-99, 500-600, and 900-1200):
       # PHOTOPRISM_UID: 1000
       # PHOTOPRISM_GID: 1000

--- a/setup/docker/nvidia/docker-compose.yml
+++ b/setup/docker/nvidia/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       ## see https://docs.photoprism.app/getting-started/advanced/transcoding/#nvidia-container-toolkit
       PHOTOPRISM_FFMPEG_ENCODER: "nvidia"
       PHOTOPRISM_FFMPEG_BITRATE: "50"
-      PHOTOPRISM_FFMPEG_RESOLUTION: "4096"
+      PHOTOPRISM_FFMPEG_RESOLUTION: "4k"
       NVIDIA_VISIBLE_DEVICES: "all"
       NVIDIA_DRIVER_CAPABILITIES: "compute,video,utility"
       ## Run as a non-root user after initialization (supported: 0, 33, 50-99, 500-600, and 900-1200):

--- a/setup/podman/docker-compose.yml
+++ b/setup/podman/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       ## Hardware Video Transcoding:
       # PHOTOPRISM_FFMPEG_ENCODER: "software"        # FFmpeg encoder ("software", "intel", "nvidia", "apple", "raspberry")
       # PHOTOPRISM_FFMPEG_BITRATE: "32"              # FFmpeg encoding bitrate limit in Mbit/s (default: 50)
-      # PHOTOPRISM_FFMPEG_RESOLUTION: "1920"         # FFmpeg encoding resolution limit in pixel (default: 4096)
+      # PHOTOPRISM_FFMPEG_RESOLUTION: "HD+"          # FFmpeg encoding resolution limit in pixel (default: 4k)
       ## Run as a non-root user after initialization (supported: 0, 33, 50-99, 500-600, and 900-1200):
       # PHOTOPRISM_UID: 1000
       # PHOTOPRISM_GID: 1000


### PR DESCRIPTION
This adds the following standard video resolution options: SD, HD, HD+, 2k, 4k, 8k. This is based on [@lastzero  recommendation](https://github.com/photoprism/photoprism/issues/3466#issuecomment-1636774985).
<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

