### PR TITLE
UX: Don't process all features for clusters exceeding 100 photos.

### DIFF
--- a/frontend/src/page/places.vue
+++ b/frontend/src/page/places.vue
@@ -634,8 +634,7 @@ export default {
         }
       });
 
-      this.map.on('render', this.updateMarkers);
-
+      this.map.on('idle', this.updateMarkers);
 
       this.search();
     },

--- a/frontend/src/page/places.vue
+++ b/frontend/src/page/places.vue
@@ -305,7 +305,7 @@ export default {
       });
     },
     selectClusterById: function(clusterId) {
-      this.getClusterFeatures(clusterId, (clusterFeatures) => {
+      this.getClusterFeatures(clusterId, -1, (clusterFeatures) => {
         let latMin,latMax,lngMin,lngMax;
         for (const feature of clusterFeatures) {
           const [lng,lat] = feature.geometry.coordinates;
@@ -490,16 +490,16 @@ export default {
 
       this.map.on("load", () => this.onMapLoad());
     },
-    getClusterFeatures(clusterId, callback) {
-      this.map.getSource('photos').getClusterLeaves(clusterId, -1, undefined, (error, clusterFeatures) => {
+    getClusterFeatures(clusterId, limit, callback) {
+      this.map.getSource('photos').getClusterLeaves(clusterId, limit, undefined, (error, clusterFeatures) => {
         callback(clusterFeatures);
-      });;
+      });
     },
     getMultipleClusterFeatures(clusterIds, callback) {
       const result = {};
       let handledClusterLeaveResultCount = 0;
       for (const clusterId of clusterIds) {
-        this.getClusterFeatures(clusterId, (clusterFeatures) => {
+        this.getClusterFeatures(clusterId, 100, (clusterFeatures) => {
           result[clusterId] = clusterFeatures;
           handledClusterLeaveResultCount += 1;
 

--- a/frontend/src/page/places.vue
+++ b/frontend/src/page/places.vue
@@ -548,9 +548,10 @@ export default {
 
               const clusterFeatures = clusterFeaturesById[props.cluster_id];
               const previewImageCount = clusterFeatures.length > 3 ? 4 : 2;
-              const images = clusterFeatures
-                .slice(0, previewImageCount)
-                .map((feature) => {
+              const images = Array(previewImageCount)
+                .fill()
+                .map((a,i) => {
+                  const feature = clusterFeatures[Math.floor(clusterFeatures.length * i / previewImageCount)];
                   const imageHash = feature.properties.Hash;
                   const image = document.createElement('div');
                   image.style.backgroundImage = `url(${this.$config.contentUri}/t/${imageHash}/${token}/tile_${50})`;


### PR DESCRIPTION
Fixes performance issues with large numbers of photos. For me I was seeing render take over 6s sometimes. Profiling shows it was spending a lot of time in getClusterLeaves(). This was iterating over thousands of photos for some clusters, which is very slow.

![image](https://github.com/photoprism/photoprism/assets/9706673/320ba60a-4f78-4db2-af3f-1a51d6cb5fb4)

We only need to know about up to 100 photos per cluster, so now the result size is limited to that. This completely resolves the performance issues for me

This could possibly be further optimized, since we only need to store data for the first 4 to be able to render the thumbnail.

<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

Acceptance Criteria:

- [ ] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [ ] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [ ] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

