### PR TITLE
Frontend: Improve icon contrast

### DIFF
--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -276,6 +276,7 @@ body.chrome #photoprism .search-results .result {
     text-transform: none;
     line-height: 1;
     white-space: nowrap;
+    text-shadow: 0 0 2px #000;
 }
 
 #photoprism .cards-view .result .caption {

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -450,6 +450,10 @@ body.chrome #photoprism .search-results .result {
     text-shadow: 0 0 2px #000, 0 0 2px #000;
 }
 
+#photoprism .search-results .type-live.is-playable .input-open .action-live svg {
+    filter: drop-shadow(0 0 2px #000);
+}
+
 #photoprism .search-results .live-player {
     display: none;
 }

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -326,6 +326,7 @@ body.chrome #photoprism .search-results .result {
     opacity: 0.5;
     right: 4px;
     bottom: 4px;
+    text-shadow: 0 0 2px #000, 0 0 2px #000;
 }
 
 #photoprism .search-results .result:hover .input-select,
@@ -351,6 +352,7 @@ body.chrome #photoprism .search-results .result {
     opacity: 0.5;
     left: 4px;
     bottom: 4px;
+    text-shadow: 0 0 2px #000, 0 0 2px #000;
 }
 
 #photoprism .search-results .result.is-favorite .input-favorite {
@@ -364,6 +366,7 @@ body.chrome #photoprism .search-results .result {
 #photoprism .search-results .result .input-hidden .select-off,
 #photoprism .search-results .result.is-hidden .input-hidden .select-on {
     display: inline-flex;
+    text-shadow: 0 0 2px #000, 0 0 2px #000;
 }
 
 #photoprism .search-results .result .input-favorite .select-on,
@@ -444,6 +447,7 @@ body.chrome #photoprism .search-results .result {
 #photoprism .search-results .type-animated.is-playable .input-open .action-animated,
 #photoprism .search-results .type-image.is-stack .input-open .action-stack {
     display: inline-flex;
+    text-shadow: 0 0 2px #000, 0 0 2px #000;
 }
 
 #photoprism .search-results .live-player {

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -366,7 +366,7 @@ body.chrome #photoprism .search-results .result {
 #photoprism .search-results .result .input-hidden .select-off,
 #photoprism .search-results .result.is-hidden .input-hidden .select-on {
     display: inline-flex;
-    text-shadow: 0 0 2px #000, 0 0 2px #000;
+    text-shadow: 0 0 2px #000;
 }
 
 #photoprism .search-results .result .input-favorite .select-on,
@@ -447,7 +447,7 @@ body.chrome #photoprism .search-results .result {
 #photoprism .search-results .type-animated.is-playable .input-open .action-animated,
 #photoprism .search-results .type-image.is-stack .input-open .action-stack {
     display: inline-flex;
-    text-shadow: 0 0 2px #000, 0 0 2px #000;
+    text-shadow: 0 0 2px #000;
 }
 
 #photoprism .search-results .type-live.is-playable .input-open .action-live svg {

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -353,7 +353,11 @@ body.chrome #photoprism .search-results .result {
     opacity: 0.5;
     left: 4px;
     bottom: 4px;
-    text-shadow: 0 0 2px #000, 0 0 2px #000;
+}
+
+#photoprism .cards-view .input-favorite i,
+#photoprism .mosaic-view .input-favorite i {
+    text-shadow: 0 0 2px #000, 0 0 2px #000 !important;
 }
 
 #photoprism .search-results .result.is-favorite .input-favorite {


### PR DESCRIPTION
Currently icons on the thumbnail overlay (favourite, checkbox, etc) are white-ish.
Quite often it's invisible when photo is also light color. This makes it impossible see if photo is liked or selected.

Example:
<img width="358" alt="Screenshot 2023-07-31 at 13 19 43" src="https://github.com/photoprism/photoprism/assets/621293/38f8816f-868e-439a-bd5f-1d12634305a1">

After this change icons have dark shadow so it's more contrasting
<img width="354" alt="Screenshot 2023-07-31 at 15 49 48" src="https://github.com/photoprism/photoprism/assets/621293/b646e0e3-b2f5-48ef-bf3c-625c372db439">


Other affected icons:
<img width="65" alt="Screenshot 2023-07-31 at 13 35 53" src="https://github.com/photoprism/photoprism/assets/621293/54fec6fb-3450-4370-8b90-5d90809e19d8"> <img width="51" alt="Screenshot 2023-07-31 at 13 35 42" src="https://github.com/photoprism/photoprism/assets/621293/4f436006-9aed-490a-b2b4-de41bd9e80cd"> <img width="54" alt="Screenshot 2023-07-31 at 13 49 02" src="https://github.com/photoprism/photoprism/assets/621293/7a91a64c-a163-443b-87b8-3edd7c6a4bc4"> <img width="52" alt="Screenshot 2023-07-31 at 13 51 35" src="https://github.com/photoprism/photoprism/assets/621293/06b6d44f-0cf6-420a-b363-68005a6a6319"> <img width="50" alt="Screenshot 2023-07-31 at 14 15 35" src="https://github.com/photoprism/photoprism/assets/621293/cf750928-0cef-4248-8343-8324a435bf32"> <img width="57" alt="Screenshot 2023-07-31 at 13 58 23" src="https://github.com/photoprism/photoprism/assets/621293/90a95e13-d3b6-467c-a083-4cb1a2b20341"> <img width="53" alt="Screenshot 2023-07-31 at 14 37 32" src="https://github.com/photoprism/photoprism/assets/621293/3bc4e1a6-240a-4cc7-a633-a5df806da2b5">

Acceptance Criteria:

- [ ] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [ ] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+
