### PR TITLE
Backend: Support listening on Unix Socket (#2337)

### DIFF
--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -31,6 +32,15 @@ func statusAction(ctx *cli.Context) error {
 	// running after Get, Head, Post, or Do return and will
 	// interrupt reading of the Response.Body.
 	client := &http.Client{Timeout: 10 * time.Second}
+
+	// make a dial function for unix socket
+	if unixSocketPath := conf.HttpHostAsSocketPath(); unixSocketPath != "" {
+		client.Transport = &http.Transport{
+			Dial: func(network, addr string) (net.Conn, error) {
+				return net.Dial("unix", unixSocketPath)
+			},
+		}
+	}
 
 	url := fmt.Sprintf("http://%s:%d/api/v1/status", conf.HttpHost(), conf.HttpPort())
 

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -104,7 +104,8 @@ func (c *Config) HttpCachePublic() bool {
 
 // HttpHost returns the built-in HTTP server host name or IP address (empty for all interfaces).
 func (c *Config) HttpHost() string {
-	if c.options.HttpHost == "" {
+	// when unix socket used as host, make host as default value. or http client will act weirdly.
+	if c.options.HttpHost == "" || c.HttpHostAsSocketPath() != "" {
 		return "0.0.0.0"
 	}
 
@@ -118,6 +119,15 @@ func (c *Config) HttpPort() int {
 	}
 
 	return c.options.HttpPort
+}
+
+// HttpHostAsSocketPath tries to parse the HttpHost as unix socket path. If failed, return empty string.
+func (c *Config) HttpHostAsSocketPath() string {
+	host := c.options.HttpHost
+	if strings.HasPrefix(host, "unix:") && strings.Contains(host, "/") {
+		return strings.TrimPrefix(host, "unix:")
+	}
+	return ""
 }
 
 // TemplatesPath returns the server templates path.

--- a/internal/config/config_server_test.go
+++ b/internal/config/config_server_test.go
@@ -8,12 +8,22 @@ import (
 	"github.com/photoprism/photoprism/internal/thumb"
 )
 
+func TestConfig_HttpHostAsSocketPath(t *testing.T) {
+	c := NewConfig(CliTestContext())
+
+	assert.Equal(t, "", c.HttpHostAsSocketPath())
+	c.options.HttpHost = "unix:/tmp/photoprism.sock"
+	assert.Equal(t, "/tmp/photoprism.sock", c.HttpHostAsSocketPath())
+}
+
 func TestConfig_HttpServerHost2(t *testing.T) {
 	c := NewConfig(CliTestContext())
 
 	assert.Equal(t, "0.0.0.0", c.HttpHost())
 	c.options.HttpHost = "test"
 	assert.Equal(t, "test", c.HttpHost())
+	c.options.HttpHost = "unix:/tmp/photoprism.sock"
+	assert.Equal(t, "0.0.0.0", c.HttpHost())
 }
 
 func TestConfig_HttpServerPort2(t *testing.T) {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -503,7 +503,7 @@ var Flags = CliFlags{
 		}}, {
 		Flag: cli.StringFlag{
 			Name:   "http-host, ip",
-			Usage:  "Web server `IP` address",
+			Usage:  "Web server `IP` address. If start with unix:, path followed is treated as unix socket path for listening.",
 			EnvVar: EnvVar("HTTP_HOST"),
 		}}, {
 		Flag: cli.IntFlag{

--- a/internal/server/autotls.go
+++ b/internal/server/autotls.go
@@ -16,6 +16,8 @@ func AutoTLS(conf *config.Config) (*autocert.Manager, error) {
 	// Enable automatic HTTPS via Let's Encrypt?
 	if !conf.SiteHttps() {
 		return nil, fmt.Errorf("disabled tls")
+	} else if conf.HttpHostAsSocketPath() != "" {
+		return nil, fmt.Errorf("unix socket not work with auto https")
 	} else if siteDomain = conf.SiteDomain(); !strings.Contains(siteDomain, ".") {
 		return nil, fmt.Errorf("fully qualified domain required to enable tls")
 	} else if tlsEmail = conf.TLSEmail(); tlsEmail == "" {


### PR DESCRIPTION
This patch implements the Unix Domain Socket listening. Users can prevent unnecessary port mappings if they want.

TLS or AutoTLS will not work since there is no TLS layer when using the unix domain socket.


Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [ ] (N/A, no frontend modifications. Existing functions are working) Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [ ] (N/A) In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+
