### PR TITLE
Samsung: Improved support for Motion Photos

### DIFF
--- a/internal/meta/json_exiftool.go
+++ b/internal/meta/json_exiftool.go
@@ -366,11 +366,13 @@ func (data *Data) Exiftool(jsonData []byte, originalName string) (err error) {
 	data.Artist = SanitizeMeta(data.Artist)
 
 	// Set the name of the embedded video data field, if any.
-	if embeddedVideo, ok := data.json["EmbeddedVideoFile"]; ok && embeddedVideo != "" {
-		data.EmbeddedVideo = "EmbeddedVideoFile"
-	} else if embeddedVideo, ok = data.json["MotionPhotoVideo"]; ok && embeddedVideo != "" {
-		data.EmbeddedVideo = "MotionPhotoVideo"
+	if _, ok := Vendors[data.json["Make"]]; ok {
+		// supported vendor; find the embedded video
+		if embeddedVideo, ok := data.json["EmbeddedVideoFile"]; ok && embeddedVideo != "" {
+			data.EmbeddedVideo = "EmbeddedVideoFile"
+		} else if embeddedVideo, ok = data.json["MotionPhotoVideo"]; ok && embeddedVideo != "" {
+			data.EmbeddedVideo = "MotionPhotoVideo"
+		}
 	}
-
 	return nil
 }

--- a/internal/meta/vendor.go
+++ b/internal/meta/vendor.go
@@ -1,0 +1,7 @@
+package meta
+
+var Vendors = map[string]bool{
+	"samsung": true,
+	"Apple":   true,
+	// TODO: add other supported vendors
+}

--- a/internal/photoprism/mediafile.go
+++ b/internal/photoprism/mediafile.go
@@ -332,6 +332,17 @@ func (m *MediaFile) ExtractEmbeddedVideo() (string, error) {
 
 	// Get the embedded video field name from the file metadata.
 	if metaData := m.MetaData(); metaData.Error == nil && metaData.EmbeddedVideo != "" {
+		// Check if an embedded video sidecar already exists
+		if embeddedVideo := m.HasEmbeddedVideo(); embeddedVideo != "" {
+			return embeddedVideo, nil
+		}
+
+		// Check if the camera make is supported
+		if _, ok := entity.CameraMakes[metaData.CameraMake]; !ok {
+			return "", errors.New("unrecognised camera make")
+		}
+
+		// Extract the embedded video
 		outputPath := filepath.Join(Config().TempPath(), m.RootRelPath(), "%f")
 		cmd := exec.Command(Config().ExifToolBin(),
 			fmt.Sprintf("-%s", metaData.EmbeddedVideo), // TODO: Is this safe?

--- a/internal/photoprism/mediafile.go
+++ b/internal/photoprism/mediafile.go
@@ -333,13 +333,8 @@ func (m *MediaFile) ExtractEmbeddedVideo() (string, error) {
 	// Get the embedded video field name from the file metadata.
 	if metaData := m.MetaData(); metaData.Error == nil && metaData.EmbeddedVideo != "" {
 		// Check if an embedded video sidecar already exists
-		if embeddedVideo := m.HasEmbeddedVideo(); embeddedVideo != "" {
+		if embeddedVideo := m.SidecarFileName(fs.VideoMP4); embeddedVideo != "" {
 			return embeddedVideo, nil
-		}
-
-		// Check if the camera make is supported
-		if _, ok := entity.CameraMakes[metaData.CameraMake]; !ok {
-			return "", errors.New("unrecognised camera make")
 		}
 
 		// Extract the embedded video

--- a/internal/photoprism/mediafile_meta.go
+++ b/internal/photoprism/mediafile_meta.go
@@ -53,13 +53,9 @@ func (m *MediaFile) NeedsExifToolJson() bool {
 	return !fs.FileExists(jsonName)
 }
 
-// Checks if an .mp4 video file exists for this file in the sidecar path
-func (m *MediaFile) HasEmbeddedVideo() string {
-	sidecarFile := filepath.Join(Config().SidecarPath(), m.RootRelPath(), m.BasePrefix(false)+fs.ExtMP4)
-	if fs.FileExists(sidecarFile) {
-		return sidecarFile
-	}
-	return ""
+// Checks if a file with the same name and the given extension exists in the sidecar path
+func (m *MediaFile) SidecarFileName(t fs.Type) string {
+	return t.FindFirst(m.FileName(), []string{Config().SidecarPath(), fs.HiddenPath}, Config().OriginalsPath(), false)
 }
 
 // CreateExifToolJson extracts metadata to a JSON file using Exiftool.

--- a/internal/photoprism/mediafile_meta.go
+++ b/internal/photoprism/mediafile_meta.go
@@ -53,6 +53,15 @@ func (m *MediaFile) NeedsExifToolJson() bool {
 	return !fs.FileExists(jsonName)
 }
 
+// Checks if an .mp4 video file exists for this file in the sidecar path
+func (m *MediaFile) HasEmbeddedVideo() string {
+	sidecarFile := filepath.Join(Config().SidecarPath(), m.RootRelPath(), m.BasePrefix(false)+fs.ExtMP4)
+	if fs.FileExists(sidecarFile) {
+		return sidecarFile
+	}
+	return ""
+}
+
 // CreateExifToolJson extracts metadata to a JSON file using Exiftool.
 func (m *MediaFile) CreateExifToolJson(convert *Convert) error {
 	if !m.NeedsExifToolJson() {


### PR DESCRIPTION
As a follow-up to https://github.com/photoprism/photoprism/pull/3588
- check if a video sidecar file already exists before extracting the embedded video
- check if the original file was created by a supported camera make