### PR TITLE
Backend: Suport systemd socket activation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/photoprism/photoprism
 
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/djherbis/times v1.5.0
 	github.com/dsoprea/go-exif/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -165,6 +167,7 @@ github.com/goccmack/gocc v0.0.0-20230228185258-2292f9e40198/go.mod h1:DTh/Y2+Nbn
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/scripts/dist/entrypoint.sh
+++ b/scripts/dist/entrypoint.sh
@@ -115,7 +115,7 @@ else
 
   # run command
   ([[ ${DOCKER_ENV} != "prod" ]] || "/scripts/audit.sh") \
-   && (while "$@"; ret=$?; [[ $ret -eq 0 ]]; do echo "${@}"; done) &
+   && if [[ -n $LISTEN_FDS ]]; then exec "$@"; else (while "$@"; ret=$?; [[ $ret -eq 0 ]]; do echo "${@}"; done) & fi
 fi
 
 PID=$!


### PR DESCRIPTION
systemd supports passing an already open TCP or unix socket to an application on startup (enabled via the LISTEN_FDs env variable).  Podman supports passing this socket from the host to the container as of version 3.4 (Docker does not support socket activation for containers).  Socket activation provides the benefit of only starting a service on demand (reducing overall boot time and potentially reducing memory usage), as well as improving security by allowing running containers with '--network=none' and still being able to be exposed.

This PR adds automatic socket-activation support.  If the 'LISTEN_FDS' variable is set, socket activation will automatically be used, otherwise the behavior remains unchanged.  Socket activation can work with unix domain sockets or TCP sockets, and will work with TLS if configured

Acceptance Criteria:

- [X] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [?] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [N/A] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [N/A] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

I will post a separate PR for documentation updates.  There is currently no test infrastructure for the server component that I see, so I'm not sure what to do about writing tests.

This patch does not support AutoTLS.  In theory it should be possible to use autotls if 2 ports are socket-activated, but I don't see how AutoTLS can even work today as it opens 2 listeners on the same port, which I believe should fail.