### PR TITLE
Docker: Add Lunar-specific Darktable installation

### DIFF
--- a/scripts/dist/install-darktable.sh
+++ b/scripts/dist/install-darktable.sh
@@ -32,6 +32,11 @@ case $DESTARCH in
       curl -fsSL https://download.opensuse.org/repositories/graphics:darktable/xUbuntu_22.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/graphics_darktable.gpg > /dev/null
       apt-get update
       apt-get -qq install darktable
+    elif [[ $VERSION_CODENAME == "lunar" ]]; then
+      echo 'deb http://download.opensuse.org/repositories/graphics:/darktable/xUbuntu_23.04/ /' | sudo tee /etc/apt/sources.list.d/graphics:darktable.list
+      curl -fsSL https://download.opensuse.org/repositories/graphics:darktable/xUbuntu_23.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/graphics_darktable.gpg > /dev/null
+      sudo apt update
+      sudo apt install darktable
     elif [[ $VERSION_CODENAME == "bullseye" ]]; then
       apt-get update
       apt-get -qq install -t bullseye-backports darktable


### PR DESCRIPTION
When on Lunar, add the Lunar-specific repo for Darktable and install it from there, instead of falling back to the system package version (which is not the latest release).

Like the current installation code, the code for 23.04 was pulled straight from [here](https://software.opensuse.org/download.html?project=graphics:darktable&package=darktable).

---

Please note: I don't think there are tests for this, but if I'm mistaken, please point me to them and I'm happy to add them.

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

