### PR TITLE
Fedora: Improve Docker build environment compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,7 @@ services:
   ## Docs: https://doc.traefik.io/traefik/
   traefik:
     image: photoprism/traefik:latest
+    privileged: true
     ports:
       - "80:80" # HTTP (redirects to HTTPS)
       - "443:443" # HTTPS (required)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     security_opt:
       - seccomp:unconfined
       - apparmor:unconfined
+    privileged: true
     ports:
       - "2342:2342"   # Default HTTP port (host:container)
       - "2443:2443"   # Default TLS port (host:container)


### PR DESCRIPTION
The problem is that in SELinux enforcing distributions, access to `docker.sock` is restricted in containers even if DAC permissions supposedly allow access. This causes endless log lines when invoking `docker-compose up` similar to the following:

    time="2023-09-18T04:10:56Z" level=error msg="Failed to retrieve information of the docker client and server host: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get \"http://%2Fvar%2Frun%2Fdocker.sock/v1.24/version\": dial unix /var/run/docker.sock: connect: permission denied" providerName=docker

The solution is to run the Traefik container in privileged mode. See https://stackoverflow.com/a/30368817/1198896.

Acceptance Criteria:

(I'm just checking boxes here for CI purposes even though almost all of these are N/A since this is a dev environment change.)

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+