### PR TITLE
CSS tooltips for context menus for #3727

### DIFF
--- a/frontend/src/component/album/clipboard.vue
+++ b/frontend/src/component/album/clipboard.vue
@@ -24,56 +24,61 @@
         <v-btn
             v-if="canShare"
             fab dark small
-            :title="$gettext('Share')"
+									  
             color="share"
             :disabled="selection.length !== 1"
             class="action-share"
             @click.stop="shareDialog()"
         >
           <v-icon>share</v-icon>
+          <div class="tooltip">{{$gettext('Share')}}</div>
         </v-btn>
         <v-btn
             v-if="canManage"
             fab dark small
-            :title="$gettext('Edit')"
+									 
             color="edit"
             :disabled="selection.length !== 1"
             class="action-edit"
             @click.stop="editDialog()"
         >
           <v-icon>edit</v-icon>
+          <div class="tooltip">{{$gettext('Edit')}}</div>
         </v-btn>
         <v-btn
             fab dark small
-            :title="$gettext('Download')"
+										 
             color="download"
             class="action-download"
             :disabled="!canDownload || selection.length !== 1"
             @click.stop="download()"
         >
           <v-icon>get_app</v-icon>
+          <div class="tooltip">{{$gettext('Download')}}</div>
         </v-btn>
         <v-btn
             v-if="canManage"
             fab dark small
-            :title="$gettext('Add to album')"
+											 
             color="album"
             :disabled="selection.length === 0"
             class="action-clone"
             @click.stop="dialog.album = true"
         >
           <v-icon>bookmark</v-icon>
+          <div class="tooltip">{{$gettext('Add to album')}}</div>
         </v-btn>
         <v-btn
             v-if="canDelete && deletable.includes(context)"
             fab dark small
             color="remove"
-            :title="$gettext('Delete')"
+									   
             :disabled="selection.length === 0"
             class="action-delete"
             @click.stop="dialog.delete = true"
         >
           <v-icon>delete</v-icon>
+          <div class="tooltip">{{$gettext('Delete')}}</div>
         </v-btn>
         <v-btn
             fab dark small

--- a/frontend/src/component/file/clipboard.vue
+++ b/frontend/src/component/file/clipboard.vue
@@ -26,25 +26,27 @@
         <v-btn
             v-if="$config.feature('download')" fab dark
             small
-            :title="$gettext('Download')"
+										 
             color="download"
             class="action-download"
             :disabled="selection.length === 0"
             @click.stop="download()"
         >
           <v-icon>get_app</v-icon>
+          <div class="tooltip">{{$gettext('Download')}}</div>
         </v-btn>
 
         <v-btn
             v-if="$config.feature('albums')"
             fab dark small
-            :title="$gettext('Add to album')"
+											 
             color="album"
             :disabled="selection.length === 0"
             class="action-album"
             @click.stop="dialog.album = true"
         >
           <v-icon>bookmark</v-icon>
+          <div class="tooltip">{{$gettext('Add to album')}}</div>
         </v-btn>
 
         <v-btn

--- a/frontend/src/component/label/clipboard.vue
+++ b/frontend/src/component/label/clipboard.vue
@@ -27,33 +27,36 @@
                 fab
                 dark
                 small
-                :title="$gettext('Download')"
+											 
                 color="download"
                 @click.stop="download()"
                 class="p-label-clipboard-download"
                 :disabled="selection.length !== 1"
         >
-            <v-icon>cloud_download</v-icon>
+          <v-icon>cloud_download</v-icon>
+          <div class="tooltip">{{$gettext('Download')}}</div>
         </v-btn -->
         <v-btn
             fab dark small
-            :title="$gettext('Add to album')"
+											 
             color="album"
             :disabled="!canAddAlbums || selection.length === 0"
             class="action-album"
             @click.stop="dialog.album = true"
         >
           <v-icon>bookmark</v-icon>
+          <div class="tooltip">{{$gettext('Add to album')}}</div>
         </v-btn>
         <v-btn
             fab dark small
             color="remove"
-            :title="$gettext('Delete')"
+									   
             :disabled="!canManage || selection.length === 0"
             class="action-delete"
             @click.stop="dialog.delete = true"
         >
           <v-icon>delete</v-icon>
+          <div class="tooltip">{{$gettext('Delete')}}</div>
         </v-btn>
 
         <v-btn

--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -25,113 +25,123 @@
         <v-btn
             v-if="canShare && context !== 'archive' && context !== 'review'" fab dark
             small
-            :title="$gettext('Share')"
+									  
             color="share"
             :disabled="selection.length === 0 || busy"
             class="action-share"
             @click.stop="dialog.share = true"
         >
           <v-icon>cloud</v-icon>
+          <div class="tooltip">{{$gettext('Share')}}</div>
         </v-btn>
 
         <v-btn
             v-if="canManage && context === 'review'" fab dark
             small
-            :title="$gettext('Approve')"
+										
             color="share"
             :disabled="selection.length === 0 || busy"
             class="action-approve"
             @click.stop="batchApprove"
         >
           <v-icon>check</v-icon>
+          <div class="tooltip">{{$gettext('Approve')}}</div>
         </v-btn>
         <v-btn
             v-if="canEdit" fab dark
             small
-            :title="$gettext('Edit')"
+									 
             color="edit"
             :disabled="selection.length === 0 || busy"
             class="action-edit"
             @click.stop="edit"
         >
           <v-icon>edit</v-icon>
+          <div class="tooltip">{{$gettext('Edit')}}</div>
         </v-btn>
         <v-btn
             v-if="canTogglePrivate" fab dark
             small
-            :title="$gettext('Change private flag')"
+													
             color="private"
             :disabled="selection.length === 0 || busy"
             class="action-private"
             @click.stop="batchPrivate"
         >
           <v-icon>lock</v-icon>
+          <div class="tooltip">{{$gettext('Change private flag')}}</div>
         </v-btn>
         <v-btn
             v-if="canDownload && context !== 'archive'" fab dark
             small
-            :title="$gettext('Download')"
+										 
             :disabled="busy"
             color="download"
             class="action-download"
             @click.stop="download()"
         >
           <v-icon>get_app</v-icon>
+          <div class="tooltip">{{$gettext('Download')}}</div>
         </v-btn>
         <v-btn
             v-if="canEditAlbum && context !== 'archive'" fab dark
             small
-            :title="$gettext('Add to album')"
+											 
             color="album"
             :disabled="selection.length === 0 || busy"
             class="action-album"
             @click.stop="dialog.album = true"
         >
           <v-icon>bookmark</v-icon>
+          <div class="tooltip">{{$gettext('Add to album')}}</div>
         </v-btn>
         <v-btn
             v-if="canArchive && !isAlbum && context !== 'archive'" fab dark
             small
             color="remove"
-            :title="$gettext('Archive')"
+										
             :disabled="selection.length === 0 || busy"
             class="action-archive"
             @click.stop="archivePhotos"
         >
           <v-icon>archive</v-icon>
+          <div class="tooltip">{{$gettext('Archive')}}</div>
         </v-btn>
         <v-btn
             v-if="canArchive && !album && context === 'archive'" fab dark
             small
             color="restore"
-            :title="$gettext('Restore')"
+										
             :disabled="selection.length === 0 || busy"
             class="action-restore"
             @click.stop="batchRestore"
         >
           <v-icon>unarchive</v-icon>
+          <div class="tooltip">{{$gettext('Restore')}}</div>
         </v-btn>
         <v-btn
             v-if="canEditAlbum && isAlbum" fab dark
             small
-            :title="$gettext('Remove from album')"
+												  
             color="remove"
             :disabled="selection.length === 0 || busy"
             class="action-remove"
             @click.stop="removeFromAlbum"
         >
           <v-icon>eject</v-icon>
+          <div class="tooltip">{{$gettext('Remove from album')}}</div>
         </v-btn>
         <v-btn
             v-if="canDelete && !album && context === 'archive'" fab dark
             small
-            :title="$gettext('Delete')"
+									   
             color="remove"
             :disabled="selection.length === 0 || busy"
             class="action-delete"
             @click.stop="deletePhotos"
         >
           <v-icon>delete</v-icon>
+          <div class="tooltip">{{$gettext('Delete')}}</div>
         </v-btn>
         <v-btn
             fab dark small

--- a/frontend/src/component/subject/clipboard.vue
+++ b/frontend/src/component/subject/clipboard.vue
@@ -25,25 +25,27 @@
 
         <v-btn
             fab dark small
-            :title="$gettext('Download')"
+										 
             color="download"
             class="action-download"
             :disabled="!canDownload || selection.length !== 1"
             @click.stop="download()"
         >
           <v-icon>get_app</v-icon>
+          <div class="tooltip">{{$gettext('Download')}}</div>
         </v-btn>
 
         <v-btn
             v-if="canAddAlbums"
             fab dark small
-            :title="$gettext('Add to album')"
+											 
             color="album"
             :disabled="selection.length === 0"
             class="action-album"
             @click.stop="dialog.album = true"
         >
           <v-icon>bookmark</v-icon>
+          <div class="tooltip">{{$gettext('Add to album')}}</div>
         </v-btn>
 
         <v-btn

--- a/frontend/src/css/navigation.css
+++ b/frontend/src/css/navigation.css
@@ -316,3 +316,50 @@ nav .v-list__tile__title.title {
     fill: #ffffff;
     color: #ffffff;
 }
+
+#photoprism .v-btn .tooltip {
+	position: absolute;
+	top: 0;
+	right: 125%;
+	margin-top: 5px;
+	margin-left: -100%;
+	background-color: #000;
+	color: #fff;
+	text-align: center;
+	border-radius: 6px;
+	padding: 5px 15px;
+
+	/* Reset Vuetify CSS */
+	transform: rotate(0deg);
+	text-transform: none;
+	opacity: 0.75;
+	left: auto;
+}
+
+#photoprism .v-btn .tooltip:after {
+	content: '';
+	position: absolute;
+	right: 0;
+	top: 50%;
+	width: 0;
+	height: 0;
+	border: 7px solid transparent;
+	border-left-color: #000;
+	border-right: 0;
+	margin: -7px -7px 0 0;
+}
+
+@media only screen and (min-width: 600px) {
+
+	#photoprism .v-btn .tooltip {
+		transition: opacity 0.5s;
+		visibility: hidden;
+		opacity: 0;
+	}
+
+	#photoprism .v-btn:hover .tooltip {
+		visibility: visible;
+		opacity: 0.75;
+	}
+
+}


### PR DESCRIPTION
<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

This pull requests implements tooltips for context menus (as defined in "clipboard.vue"-files) to clarify icons for improved usability. On smaller devices, the tooltips will automatically persist instead of being activated on mouse over. Potential improvement could be to use device type i.s.o. screen dimensions to trigger this behavior.

Acceptance Criteria:

- [ ] Tooltips for context menu icons to clarify related actions
- [ ] Fully functional implementation for showing automatic tooltips for context menu items, persistent tooltips on smaller screen sizes
- [ ] No backend changes: no changes to automated tests
- [ ] Tested on various devices / dimensions with major browsers (e.g. Edge, Chrome & FireFox)
- [ ] No DB changes (GUI change only)

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

