### PR TITLE
Adds Galaxy S10 to cameraModels

### DIFF
--- a/internal/entity/camera_models.go
+++ b/internal/entity/camera_models.go
@@ -42,6 +42,7 @@ var CameraModels = map[string]string{
 	"SM-G950F":                   "Galaxy S8",
 	"SM-G955U1":                  "Galaxy S8+",
 	"SM-G965F":                   "Galaxy S9+",
+	"SM-G973U1":                  "Galaxy S10",
 	"SM-G780F":                   "Galaxy S20",
 	"SM-G781B":                   "Galaxy S20 FE",
 	"SM-G991A":                   "Galaxy S21",


### PR DESCRIPTION
My brother has the S10 and it shows up as Samsung SM-G973U2 right now.