### PR TITLE
Albums: Add option to sort albums/states chronologically by date of assigned photos

### DIFF
--- a/internal/entity/album.go
+++ b/internal/entity/album.go
@@ -901,13 +901,13 @@ func (m *Album) RemovePhotos(UIDs []string) (removed PhotoAlbums) {
 			photo.PhotoUID != "" {
 			takenAt := photo.TakenAt
 			if isOldest := takenAt.Equal(m.AlbumOldest); isOldest {
-				if oldestPhoto, err := AlbumOldestOrNewest(m.AlbumUID, true); err == nil {
+				if oldestPhoto, err := AlbumOldestOrNewest(m.AlbumUID, true, ""); err == nil {
 					// update the oldest of the album
 					updatedAlbumOldest = oldestPhoto.TakenAt
 				}
 			}
 			if isNewest := takenAt.Equal(m.AlbumNewest); isNewest {
-				if newestPhoto, err := AlbumOldestOrNewest(m.AlbumUID, false); err == nil {
+				if newestPhoto, err := AlbumOldestOrNewest(m.AlbumUID, false, ""); err == nil {
 					// update the newest of the album
 					updatedAlbumNewest = newestPhoto.TakenAt
 				}
@@ -935,7 +935,7 @@ func (m *Album) Links() Links {
 	return FindLinks("", m.AlbumUID)
 }
 
-func AlbumOldestOrNewest(albumUid string, isOldest bool) (Photo, error) {
+func AlbumOldestOrNewest(albumUid string, isOldest bool, exceptPhotoUid string) (Photo, error) {
 	var photo Photo
 	var orderDirection string
 	if isOldest {
@@ -948,6 +948,7 @@ func AlbumOldestOrNewest(albumUid string, isOldest bool) (Photo, error) {
 		"JOIN photos_albums ON photos.photo_uid = "+
 			"photos_albums.photo_uid",
 	).Joins("JOIN albums ON photos_albums.album_uid = albums.album_uid").
+		Where("photos.photo_uid != ?", exceptPhotoUid).
 		Where("albums.album_uid = ?", albumUid).
 		Where("photos_albums.hidden = 0").
 		Order(

--- a/internal/entity/album.go
+++ b/internal/entity/album.go
@@ -166,9 +166,15 @@ func AddPhotoToUserAlbums(photoUid string, albums []string, userUid string) (err
 
 			}
 
-			// Refresh updated timestamp and album oldest/newest values.
-			err = UpdateAlbum(albumUid, Values{"updated_at": TimePointer(),
-				"albumOldest": albumOldest, "albumNewest": albumNewest})
+			if !albumOldest.Equal(album.AlbumOldest) || !albumNewest.Equal(album.AlbumNewest) {
+				// Refresh updated timestamp and album oldest/newest values.
+				err = UpdateAlbum(
+					albumUid, Values{
+						"updated_at":  TimePointer(),
+						"albumOldest": albumOldest, "albumNewest": albumNewest,
+					},
+				)
+			}
 		}
 	}
 
@@ -853,10 +859,15 @@ func (m *Album) AddPhotos(UIDs []string) (added PhotoAlbums) {
 	}
 
 	// Refresh updated timestamp and album oldest/newest values.
-	if err := UpdateAlbum(m.AlbumUID, Values{"updated_at": TimePointer(),
-		"albumOldest": albumOldest, "albumNewest": albumNewest,
-		}); err != nil {
-		log.Errorf("album: %s (update %s)", err.Error(), m)
+	if !albumOldest.Equal(m.AlbumOldest) || !albumNewest.Equal(m.AlbumNewest) {
+		if err := UpdateAlbum(
+			m.AlbumUID, Values{
+				"updated_at":  TimePointer(),
+				"albumOldest": albumOldest, "albumNewest": albumNewest,
+			},
+		); err != nil {
+			log.Errorf("album: %s (update %s)", err.Error(), m)
+		}
 	}
 
 	return added
@@ -905,13 +916,15 @@ func (m *Album) RemovePhotos(UIDs []string) (removed PhotoAlbums) {
 	}
 
 	// Refresh updated timestamp.
-	if err := UpdateAlbum(
-		m.AlbumUID, Values{
-			"updated_at": TimePointer(), "albumOldest": updatedAlbumOldest,
-			"albumNewest": updatedAlbumNewest,
-		},
-	); err != nil {
-		log.Errorf("album: %s (update %s)", err.Error(), m)
+	if !updatedAlbumOldest.Equal(m.AlbumOldest) || !updatedAlbumNewest.Equal(m.AlbumNewest) {
+		if err := UpdateAlbum(
+			m.AlbumUID, Values{
+				"updated_at": TimePointer(), "albumOldest": updatedAlbumOldest,
+				"albumNewest": updatedAlbumNewest,
+			},
+		); err != nil {
+			log.Errorf("album: %s (update %s)", err.Error(), m)
+		}
 	}
 
 	return removed

--- a/internal/entity/album.go
+++ b/internal/entity/album.go
@@ -145,7 +145,7 @@ func AddPhotoToUserAlbums(photoUid string, albums []string, userUid string) (err
 			var albumOldest time.Time
 			var albumNewest time.Time
 			if err := Db().Model(&Photo{}).Where("photo_uid = ?",
-				photoUid).First(&photo).Error; err == nil && photo.UUID != "" {
+				photoUid).First(&photo).Error; err == nil && photo.PhotoUID != "" {
 				takenAt := photo.TakenAt
 				if err := Db().Model(&Album{}).Where("album_uid = ?",
 					albumUid).First(&album).Error; err == nil && album.
@@ -835,7 +835,7 @@ func (m *Album) AddPhotos(UIDs []string) (added PhotoAlbums) {
 		// update the oldest or newest date of the album, if needed
 		var photo Photo
 		if err := Db().Model(&Photo{}).Where("photo_uid = ?",
-			uid).First(&photo).Error; err == nil && photo.UUID != "" {
+			uid).First(&photo).Error; err == nil && photo.PhotoUID != "" {
 			takenAt := photo.TakenAt
 			if before := takenAt.Before(albumOldest); before {
 				albumOldest = takenAt

--- a/internal/entity/album.go
+++ b/internal/entity/album.go
@@ -842,7 +842,11 @@ func (m *Album) AddPhotos(UIDs []string) (added PhotoAlbums) {
 			takenAt := photo.TakenAt
 			if before := takenAt.Before(albumOldest); before {
 				albumOldest = takenAt
-			} else if after := takenAt.After(albumNewest); after {
+			} else if zero := albumOldest.IsZero(); zero {
+				albumOldest = takenAt
+			}
+
+			if after := takenAt.After(albumNewest); after {
 				albumNewest = takenAt
 			}
 		}

--- a/internal/entity/photo.go
+++ b/internal/entity/photo.go
@@ -155,6 +155,9 @@ func NewUserPhoto(stackable bool, userUid string) Photo {
 // SavePhotoForm saves a model in the database using form data.
 func SavePhotoForm(model Photo, form form.Photo) error {
 	locChanged := model.PhotoLat != form.PhotoLat || model.PhotoLng != form.PhotoLng || model.PhotoCountry != form.PhotoCountry
+	oldTakenAt := model.TakenAt
+	oldTakenAtLocal := model.TakenAtLocal
+	takenAtChanged := oldTakenAt != form.TakenAt || oldTakenAtLocal != form.TakenAtLocal
 
 	if err := deepcopier.Copy(&model).From(form); err != nil {
 		return err
@@ -172,6 +175,10 @@ func SavePhotoForm(model Photo, form form.Photo) error {
 	}
 
 	model.UpdateDateFields()
+
+	if takenAtChanged {
+		model.UpdateDateFieldsOfAlbums(oldTakenAt)
+	}
 
 	details := model.GetDetails()
 

--- a/internal/migrate/testdata/migrate_mysql.sql
+++ b/internal/migrate/testdata/migrate_mysql.sql
@@ -148,6 +148,8 @@ CREATE TABLE `albums` (
   `album_day` int(11) DEFAULT NULL,
   `album_favorite` tinyint(1) DEFAULT NULL,
   `album_private` tinyint(1) DEFAULT NULL,
+  `album_oldest` datetime DEFAULT NULL,
+  `album_newest` datetime DEFAULT NULL,
   `thumb` varbinary(128) DEFAULT '',
   `thumb_src` varbinary(8) DEFAULT '',
   `created_at` datetime DEFAULT NULL,

--- a/internal/search/albums.go
+++ b/internal/search/albums.go
@@ -86,8 +86,7 @@ func UserAlbums(f form.SearchAlbums, sess *entity.Session) (results AlbumResults
 		s = s.Order("photo_count DESC, albums.album_title, albums.album_uid DESC")
 	case sortby.Moment, sortby.Newest:
 		if f.Type == entity.AlbumManual || f.Type == entity.AlbumState {
-			s = s.Order("albums.album_uid DESC") // needs to change: dont
-			// sort by album_uid
+			s = s.Order("albums.album_newest DESC")
 		} else if f.Type == entity.AlbumMoment {
 			s = s.Order("has_year, albums.album_year DESC, albums.album_month DESC, albums.album_day DESC, albums.album_title, albums.album_uid DESC")
 		} else {
@@ -95,8 +94,7 @@ func UserAlbums(f form.SearchAlbums, sess *entity.Session) (results AlbumResults
 		}
 	case sortby.Oldest:
 		if f.Type == entity.AlbumManual || f.Type == entity.AlbumState {
-			s = s.Order("albums.album_uid ASC") // needs to change: dont sort
-			// by album_uid
+			s = s.Order("albums.album_oldest ASC")
 		} else if f.Type == entity.AlbumMoment {
 			s = s.Order("has_year, albums.album_year ASC, albums.album_month ASC, albums.album_day ASC, albums.album_title, albums.album_uid ASC")
 		} else {

--- a/internal/search/albums.go
+++ b/internal/search/albums.go
@@ -86,7 +86,8 @@ func UserAlbums(f form.SearchAlbums, sess *entity.Session) (results AlbumResults
 		s = s.Order("photo_count DESC, albums.album_title, albums.album_uid DESC")
 	case sortby.Moment, sortby.Newest:
 		if f.Type == entity.AlbumManual || f.Type == entity.AlbumState {
-			s = s.Order("albums.album_uid DESC")
+			s = s.Order("albums.album_uid DESC") // needs to change: dont
+			// sort by album_uid
 		} else if f.Type == entity.AlbumMoment {
 			s = s.Order("has_year, albums.album_year DESC, albums.album_month DESC, albums.album_day DESC, albums.album_title, albums.album_uid DESC")
 		} else {
@@ -94,7 +95,8 @@ func UserAlbums(f form.SearchAlbums, sess *entity.Session) (results AlbumResults
 		}
 	case sortby.Oldest:
 		if f.Type == entity.AlbumManual || f.Type == entity.AlbumState {
-			s = s.Order("albums.album_uid ASC")
+			s = s.Order("albums.album_uid ASC") // needs to change: dont sort
+			// by album_uid
 		} else if f.Type == entity.AlbumMoment {
 			s = s.Order("has_year, albums.album_year ASC, albums.album_month ASC, albums.album_day ASC, albums.album_title, albums.album_uid ASC")
 		} else {


### PR DESCRIPTION
https://github.com/photoprism/photoprism/issues/3763

- [x] When a photo is added, update the album oldest / newest fields if needed
- [x] When a photo is removed, re-compute the album oldest / newest if needed and update the fields
- [x] When a user updates the date of a photo that is the newest or oldest in an album, check if it is still the newest or oldest, re-compute the album oldest / newest if needed and update the fields
- [ ] Make sure the code and the queries are optimized