### PR TITLE
Places: Add cluster preview resize handle

### DIFF
--- a/frontend/src/css/places.css
+++ b/frontend/src/css/places.css
@@ -1,148 +1,164 @@
 /* Maps & Places */
 
 #photoprism .map-control {
-    position: absolute;
-    background: transparent;
-    top: 10px;
-    left: 10px;
-    z-index: 2;
+  position: absolute;
+  background: transparent;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
 }
 
 #photoprism.is-rtl .map-control {
-    left: auto;
-    right: 10px;
+  left: auto;
+  right: 10px;
 }
 
 #photoprism .map-control .map-control-search {
-    overflow: hidden;
-    border-radius: 24px;
+  overflow: hidden;
+  border-radius: 24px;
 }
 
 #photoprism #map .marker {
-    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12) !important;
-    background-color: rgba(23, 23, 23, 0.23);
-    color: rgba(0, 0, 0, 0.87);
-    display: block;
-    border-radius: 50%;
-    cursor: pointer;
-    border: 1px solid #ffffff99;
+  box-shadow:
+    0px 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+    0px 1px 5px 0px rgba(0, 0, 0, 0.12) !important;
+  background-color: rgba(23, 23, 23, 0.23);
+  color: rgba(0, 0, 0, 0.87);
+  display: block;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 1px solid #ffffff99;
 }
 
 #photoprism #map .cluster-marker {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-gap: 1px;
-    overflow: hidden;
-    /* background-color: #ffffff99; */
-    width: 100%;
-    height: 100%
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 1px;
+  overflow: hidden;
+  /* background-color: #ffffff99; */
+  width: 100%;
+  height: 100%;
 }
 
 #photoprism #map .counter-bubble {
-    border-radius: 100%;
-    position: absolute;
-    width: 24px;
-    height: 24px;
-    font-size: 12px;
-    display: flex;
-    color: #ffffff;
-    top: -5px;
-    right: -5px;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0px 3px 1px -2px rgb(0 0 0 / 20%), 0px 2px 2px 0px rgb(0 0 0 / 14%), 0px 1px 5px 0px rgb(0 0 0 / 12%);
+  border-radius: 100%;
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  font-size: 12px;
+  display: flex;
+  color: #ffffff;
+  top: -5px;
+  right: -5px;
+  align-items: center;
+  justify-content: center;
+  box-shadow:
+    0px 3px 1px -2px rgb(0 0 0 / 20%),
+    0px 2px 2px 0px rgb(0 0 0 / 14%),
+    0px 1px 5px 0px rgb(0 0 0 / 12%);
 }
 
 #photoprism #map .cluster-marker > div {
-    width: 100%;
-    height: 100%;
-    background-size: cover;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
 }
 
 #photoprism .maplibregl-ctrl-attrib-inner a {
-    color: #333 !important;
+  color: #333 !important;
 }
 
 #photoprism .maplibregl-style-list {
-    display: none;
+  display: none;
 }
 
 #photoprism .maplibregl-ctrl-group .maplibregl-style-list button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    display: block;
-    font-size: 14px;
-    padding: 8px 8px 6px;
-    text-align: right;
-    width: 100%;
-    height: auto;
-    color: #000000;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: block;
+  font-size: 14px;
+  padding: 8px 8px 6px;
+  text-align: right;
+  width: 100%;
+  height: auto;
+  color: #000000;
 }
 
 #photoprism .maplibregl-style-list button.active {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 #photoprism .maplibregl-style-list button:hover {
-    background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 #photoprism .maplibregl-style-list button + button {
-    border-top: 1px solid #ddd;
+  border-top: 1px solid #ddd;
 }
 
 #photoprism .maplibregl-style-switcher {
-    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/PjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJDYXBhXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iNTQuODQ5cHgiIGhlaWdodD0iNTQuODQ5cHgiIHZpZXdCb3g9IjAgMCA1NC44NDkgNTQuODQ5IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1NC44NDkgNTQuODQ5OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGc+PGc+PGc+PHBhdGggZD0iTTU0LjQ5NywzOS42MTRsLTEwLjM2My00LjQ5bC0xNC45MTcsNS45NjhjLTAuNTM3LDAuMjE0LTEuMTY1LDAuMzE5LTEuNzkzLDAuMzE5Yy0wLjYyNywwLTEuMjU0LTAuMTA0LTEuNzktMC4zMThsLTE0LjkyMS01Ljk2OEwwLjM1MSwzOS42MTRjLTAuNDcyLDAuMjAzLTAuNDY3LDAuNTI0LDAuMDEsMC43MTZMMjYuNTYsNTAuODFjMC40NzcsMC4xOTEsMS4yNTEsMC4xOTEsMS43MjksMEw1NC40ODgsNDAuMzNDNTQuOTY0LDQwLjEzOSw1NC45NjksMzkuODE3LDU0LjQ5NywzOS42MTR6Ii8+PHBhdGggZD0iTTU0LjQ5NywyNy41MTJsLTEwLjM2NC00LjQ5MWwtMTQuOTE2LDUuOTY2Yy0wLjUzNiwwLjIxNS0xLjE2NSwwLjMyMS0xLjc5MiwwLjMyMWMtMC42MjgsMC0xLjI1Ni0wLjEwNi0xLjc5My0wLjMyMWwtMTQuOTE4LTUuOTY2TDAuMzUxLDI3LjUxMmMtMC40NzIsMC4yMDMtMC40NjcsMC41MjMsMC4wMSwwLjcxNkwyNi41NiwzOC43MDZjMC40NzcsMC4xOSwxLjI1MSwwLjE5LDEuNzI5LDBsMjYuMTk5LTEwLjQ3OUM1NC45NjQsMjguMDM2LDU0Ljk2OSwyNy43MTYsNTQuNDk3LDI3LjUxMnoiLz48cGF0aCBkPSJNMC4zNjEsMTYuMTI1bDEzLjY2Miw1LjQ2NWwxMi41MzcsNS4wMTVjMC40NzcsMC4xOTEsMS4yNTEsMC4xOTEsMS43MjksMGwxMi41NDEtNS4wMTZsMTMuNjU4LTUuNDYzYzAuNDc3LTAuMTkxLDAuNDgtMC41MTEsMC4wMS0wLjcxNkwyOC4yNzcsNC4wNDhjLTAuNDcxLTAuMjA0LTEuMjM2LTAuMjA0LTEuNzA4LDBMMC4zNTEsMTUuNDFDLTAuMTIxLDE1LjYxNC0wLjExNiwxNS45MzUsMC4zNjEsMTYuMTI1eiIvPjwvZz48L2c+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjwvc3ZnPg==);
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: 70%;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/PjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJDYXBhXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iNTQuODQ5cHgiIGhlaWdodD0iNTQuODQ5cHgiIHZpZXdCb3g9IjAgMCA1NC44NDkgNTQuODQ5IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1NC44NDkgNTQuODQ5OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGc+PGc+PGc+PHBhdGggZD0iTTU0LjQ5NywzOS42MTRsLTEwLjM2My00LjQ5bC0xNC45MTcsNS45NjhjLTAuNTM3LDAuMjE0LTEuMTY1LDAuMzE5LTEuNzkzLDAuMzE5Yy0wLjYyNywwLTEuMjU0LTAuMTA0LTEuNzktMC4zMThsLTE0LjkyMS01Ljk2OEwwLjM1MSwzOS42MTRjLTAuNDcyLDAuMjAzLTAuNDY3LDAuNTI0LDAuMDEsMC43MTZMMjYuNTYsNTAuODFjMC40NzcsMC4xOTEsMS4yNTEsMC4xOTEsMS43MjksMEw1NC40ODgsNDAuMzNDNTQuOTY0LDQwLjEzOSw1NC45NjksMzkuODE3LDU0LjQ5NywzOS42MTR6Ii8+PHBhdGggZD0iTTU0LjQ5NywyNy41MTJsLTEwLjM2NC00LjQ5MWwtMTQuOTE2LDUuOTY2Yy0wLjUzNiwwLjIxNS0xLjE2NSwwLjMyMS0xLjc5MiwwLjMyMWMtMC42MjgsMC0xLjI1Ni0wLjEwNi0xLjc5My0wLjMyMWwtMTQuOTE4LTUuOTY2TDAuMzUxLDI3LjUxMmMtMC40NzIsMC4yMDMtMC40NjcsMC41MjMsMC4wMSwwLjcxNkwyNi41NiwzOC43MDZjMC40NzcsMC4xOSwxLjI1MSwwLjE5LDEuNzI5LDBsMjYuMTk5LTEwLjQ3OUM1NC45NjQsMjguMDM2LDU0Ljk2OSwyNy43MTYsNTQuNDk3LDI3LjUxMnoiLz48cGF0aCBkPSJNMC4zNjEsMTYuMTI1bDEzLjY2Miw1LjQ2NWwxMi41MzcsNS4wMTVjMC40NzcsMC4xOTEsMS4yNTEsMC4xOTEsMS43MjksMGwxMi41NDEtNS4wMTZsMTMuNjU4LTUuNDYzYzAuNDc3LTAuMTkxLDAuNDgtMC41MTEsMC4wMS0wLjcxNkwyOC4yNzcsNC4wNDhjLTAuNDcxLTAuMjA0LTEuMjM2LTAuMjA0LTEuNzA4LDBMMC4zNTEsMTUuNDFDLTAuMTIxLDE1LjYxNC0wLjExNiwxNS45MzUsMC4zNjEsMTYuMTI1eiIvPjwvZz48L2c+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjxnPjwvZz48Zz48L2c+PGc+PC9nPjwvc3ZnPg==);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 70%;
 }
 
 #photoprism .cluster-control {
-    background: #2f3031;
-    position: absolute;
-    top: auto;
-    z-index: 2;
-    bottom: 0;
-    margin: 0;
-    padding: 0;
-    left: 4px;
-    right: 4px;
-    border-top-left-radius: 16px;
-    border-top-right-radius: 16px;
-    max-height: 90vh;
-    overflow: hidden;
-    box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
-    transition: all 650ms cubic-bezier(0.32, 1, 0.23, 1) 0ms;
+  background: #2f3031;
+  position: absolute;
+  top: auto;
+  z-index: 2;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+  left: 4px;
+  right: 4px;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  max-height: 90vh;
+  overflow: hidden;
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+  transition: all 650ms cubic-bezier(0.32, 1, 0.23, 1) 0ms;
+}
+
+#photoprism .cluster-control-resize-handle {
+  height: 8px;
+  cursor: row-resize;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 2;
 }
 
 #photoprism .cluster-control-container {
-    min-height: 40vh;
+  height: 100%;
 }
 
 #photoprism .cluster-control .p-photos {
-    position: absolute;
-    top: 45px;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    overflow: auto;
+  position: absolute;
+  top: 45px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  overflow: auto;
 }
 
 @media only screen and (min-height: 1500px) {
-    #photoprism .cluster-control-container {
-        min-height: 45vh;
-    }
+  #photoprism .cluster-control-container {
+    min-height: 45vh;
+  }
 }
 
 @media only screen and (max-width: 599px) {
-    #photoprism .cluster-control {
-        left: 0;
-        right: 0;
-    }
+  #photoprism .cluster-control {
+    left: 0;
+    right: 0;
+  }
 
-    #photoprism .cluster-control-container {
-        min-height: 66vh;
-    }
+  #photoprism .cluster-control-container {
+    min-height: 66vh;
+  }
 }

--- a/frontend/src/css/places.css
+++ b/frontend/src/css/places.css
@@ -106,7 +106,6 @@
 }
 
 #photoprism .cluster-control {
-  background: #2f3031;
   position: absolute;
   top: auto;
   z-index: 2;
@@ -115,11 +114,7 @@
   padding: 0;
   left: 4px;
   right: 4px;
-  border-top-left-radius: 16px;
-  border-top-right-radius: 16px;
   max-height: 90vh;
-  overflow: hidden;
-  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
   transition: all 650ms cubic-bezier(0.32, 1, 0.23, 1) 0ms;
 }
 
@@ -133,7 +128,19 @@
   z-index: 2;
 }
 
+@media only screen and (hover: none) {
+  #photoprism .cluster-control-resize-handle {
+    height: 24px;
+    top: -12px;
+  }
+}
+
 #photoprism .cluster-control-container {
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+  background: #2f3031;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  overflow: hidden;
   height: 100%;
 }
 

--- a/frontend/src/page/photos.vue
+++ b/frontend/src/page/photos.vue
@@ -220,6 +220,9 @@ export default {
 
       this.routeName = this.$route.name;
       this.search();
+    },
+    staticFilter() {
+      this.refresh();
     }
   },
   created() {

--- a/frontend/src/page/places.vue
+++ b/frontend/src/page/places.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid fill-height :class="$config.aclClasses('places')" class="pa-0 p-page p-page-places">
-    <div style="width: 100%; height: 100%; position: relative;">
+    <div style="width: 100%; height: 100%; position: relative; overflow: hidden;">
       <div v-if="canSearch" class="map-control search-control">
         <div class="maplibregl-ctrl maplibregl-ctrl-group map-control-search">
           <v-text-field v-model.lazy.trim="filter.q"

--- a/frontend/src/page/places.vue
+++ b/frontend/src/page/places.vue
@@ -749,31 +749,33 @@ export default {
       return Math.max(Math.min(0.85*vh, height), 0.3*vh);
     },
     startClusterControlResize(e) {
-      console.log("start cluster control resize")
-      this.isClusterControlResizing = true;
-      const initialY = e.clientY;
-      const initialHeight = this.clusterControlHeight;
-      window.addEventListener('mousemove', (event) => this.clusterControlResize(event, initialY, initialHeight));
-      window.addEventListener('mouseup', this.stopClusterControlResize);
-    },
-    clusterControlResize(e, initialY, initialHeight) {
-      console.log("cluster control resize")
-      if (this.isClusterControlResizing) {
-        this.clusterControlHeight = this.clampClusterControlHeight(initialHeight - (e.clientY - initialY));
-      }
-    },
-    stopClusterControlResize() {
-      console.log("cstop luster control resize")
-      this.isClusterControlResizing = false;
-      const clusterControlContainer = this.$refs.clusterControlContainer;
-      if (clusterControlContainer) {
-        this.clusterControlHeight = clusterControlContainer.clientHeight;
-      }
-      localStorage.setItem('clusterControlHeight', this.clusterControlHeight);
-      window.removeEventListener('mousemove', this.clusterControlResize);
-      window.removeEventListener('mouseup', this.stopClusterControlResize);
-    },
+    console.log("start cluster control resize");
+    this.isClusterControlResizing = true;
+    const initialY = e.clientY;
+    const initialHeight = this.clusterControlHeight;
+    
+    this.clusterControlResizeHandler = (event) => this.clusterControlResize(event, initialY, initialHeight);
+    window.addEventListener('mousemove', this.clusterControlResizeHandler);
+    window.addEventListener('mouseup', this.stopClusterControlResize);
   },
+  clusterControlResize(e, initialY, initialHeight) {
+    console.log("cluster control resize")
+    if (this.isClusterControlResizing) {
+      this.clusterControlHeight = this.clampClusterControlHeight(initialHeight - (e.clientY - initialY));
+    }
+  },
+  stopClusterControlResize() {
+    console.log("stop cluster control resize");
+    this.isClusterControlResizing = false;
+    const clusterControlContainer = this.$refs.clusterControlContainer;
+    if (clusterControlContainer) {
+      this.clusterControlHeight = clusterControlContainer.clientHeight;
+    }
+    localStorage.setItem('clusterControlHeight', this.clusterControlHeight);
+    window.removeEventListener('mousemove', this.clusterControlResizeHandler);
+    window.removeEventListener('mouseup', this.stopClusterControlResize);
+  },
+},
   created() {
     const storedClusterControlHeight = localStorage.getItem('clusterControlHeight');
     if (storedClusterControlHeight) {

--- a/frontend/src/page/places.vue
+++ b/frontend/src/page/places.vue
@@ -749,7 +749,6 @@ export default {
       return Math.max(Math.min(0.85*vh, height), 0.3*vh);
     },
     startClusterControlResize(e) {
-    console.log("start cluster control resize");
     this.isClusterControlResizing = true;
     const initialY = e.clientY;
     const initialHeight = this.clusterControlHeight;
@@ -759,13 +758,11 @@ export default {
     window.addEventListener('mouseup', this.stopClusterControlResize);
   },
   clusterControlResize(e, initialY, initialHeight) {
-    console.log("cluster control resize")
     if (this.isClusterControlResizing) {
       this.clusterControlHeight = this.clampClusterControlHeight(initialHeight - (e.clientY - initialY));
     }
   },
   stopClusterControlResize() {
-    console.log("stop cluster control resize");
     this.isClusterControlResizing = false;
     const clusterControlContainer = this.$refs.clusterControlContainer;
     if (clusterControlContainer) {

--- a/frontend/src/page/places.vue
+++ b/frontend/src/page/places.vue
@@ -349,9 +349,6 @@ export default {
       });
     },
     selectClusterById: function (clusterId) {
-      if(this.showCluster) {
-        this.showCluster = false;
-      }
 
       this.getClusterFeatures(clusterId, -1, (clusterFeatures) => {
         let latNorth, lngEast, latSouth, lngWest;


### PR DESCRIPTION
This pull request implements a handle to the cluster view in places as asked in issue #3747. It's compatible with touchscreens with a larger touch area to be easier to use.
I didn't add tests as I don't think it's necessary for this.

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [ ] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [ ] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

