### PR TITLE
FFmpeg: Improve performance by seeking input rather than output video

### DIFF
--- a/internal/photoprism/convert_image_jpeg.go
+++ b/internal/photoprism/convert_image_jpeg.go
@@ -29,7 +29,7 @@ func (c *Convert) JpegConvertCommands(f *MediaFile, jpegName string, xmpName str
 	// Extract a still image to be used as preview.
 	if f.IsAnimated() && !f.IsWebP() && c.conf.FFmpegEnabled() {
 		// Use "ffmpeg" to extract a JPEG still image from the video.
-		result = append(result, exec.Command(c.conf.FFmpegBin(), "-y", "-i", f.FileName(), "-ss", ffmpeg.PreviewTimeOffset(f.Duration()), "-vframes", "1", jpegName))
+		result = append(result, exec.Command(c.conf.FFmpegBin(), "-y", "-ss", ffmpeg.PreviewTimeOffset(f.Duration()), "-i", f.FileName(), "-vframes", "1", jpegName))
 	}
 
 	// Use heif-convert for HEIC/HEIF and AVIF image files.

--- a/internal/photoprism/convert_image_png.go
+++ b/internal/photoprism/convert_image_png.go
@@ -28,7 +28,7 @@ func (c *Convert) PngConvertCommands(f *MediaFile, pngName string) (result []*ex
 	// Extract a video still image that can be used as preview.
 	if f.IsAnimated() && !f.IsWebP() && c.conf.FFmpegEnabled() {
 		// Use "ffmpeg" to extract a PNG still image from the video.
-		result = append(result, exec.Command(c.conf.FFmpegBin(), "-y", "-i", f.FileName(), "-ss", ffmpeg.PreviewTimeOffset(f.Duration()), "-vframes", "1", pngName))
+		result = append(result, exec.Command(c.conf.FFmpegBin(), "-y", "-ss", ffmpeg.PreviewTimeOffset(f.Duration()), "-i", f.FileName(), "-vframes", "1", pngName))
 	}
 
 	// Use heif-convert for HEIC/HEIF and AVIF image files.


### PR DESCRIPTION
This improves performance when converting video to images as we no longer have to decode and then discard the first x seconds of video.

The current code creates an ffmpeg command like this:

```
/usr/bin/ffmpeg -y -i /go/src/github.com/photoprism/photoprism/storage/originals/2023/01/20230130_101623_A472124D.mp4 -ss 00:00:30.000 -vframes 1 /go/src/github.com/photoprism/photoprism/storage/sidecar/2023/01/20230130_101623_A472124D.mp4.jpg
```

This tells ffmpeg to decode the first 30s of the input before extracting a frame and writing it as a jpg.

This pull request changes the ffmpeg command to:

```
/usr/bin/ffmpeg -y -ss 00:00:30.000 -i /go/src/github.com/photoprism/photoprism/storage/originals/2023/01/20230130_101623_A472124D.mp4 -vframes 1 /go/src/github.com/photoprism/photoprism/storage/sidecar/2023/01/20230130_101623_A472124D.mp4.jpg
```

This tells ffmpeg to efficiently seek to the desired frame, write the jpg and then exit. This results in a significant speed up when importing large video files.

Log file before:

```
2023-11-19 10:15:27 INFO upload has been processed
2023-11-19 10:15:27 INFO upload: imported 2 files
2023-11-19 10:15:27 INFO upload: deleted empty folder /go/src/github.com/photoprism/photoprism/storage/users/us4d78b290vwb8x0/upload/sessk1toutkldiu6jt
2023-11-19 10:15:27 WARN import: 2023/01/20230130_101623_A472124D.mp4 exceeds file size limit (2.8 GB / 1.0 GB)
2023-11-19 10:15:27 INFO media: created 11 thumbnails for 2023/01/20230130_101623_A472124D.mp4.jpg [428.211754ms]
2023-11-19 10:15:27 INFO convert: 20230130_101623_A472124D.mp4.jpg created in 9.770663681s (ffmpeg)
2023-11-19 10:15:17 INFO convert: converting 20230130_101623_A472124D.mp4 to 20230130_101623_A472124D.mp4.jpg (ffmpeg)
2023-11-19 10:15:09 INFO import: moving main mp4 file P1870007.MP4 to 2023/01/20230130_101623_A472124D.mp4
2023-11-19 10:15:02 INFO media: P1870007.MP4 was taken at 2023-01-30 10:16:23.337 +0000 UTC (meta)
```

Log file after:

```
2023-11-19 10:32:39 INFO upload has been processed
2023-11-19 10:32:39 INFO upload: imported 2 files
2023-11-19 10:32:39 INFO upload: deleted empty folder /go/src/github.com/photoprism/photoprism/storage/users/us4d78b290vwb8x0/upload/sessk1toutkliytixjf
2023-11-19 10:32:39 WARN import: 2023/01/20230130_101623_A472124D.mp4 exceeds file size limit (2.8 GB / 1.0 GB)
2023-11-19 10:32:39 INFO media: created 11 thumbnails for 2023/01/20230130_101623_A472124D.mp4.jpg [461.212762ms]
2023-11-19 10:32:38 INFO convert: 20230130_101623_A472124D.mp4.jpg created in 707.282911ms (ffmpeg)
2023-11-19 10:32:38 INFO convert: converting 20230130_101623_A472124D.mp4 to 20230130_101623_A472124D.mp4.jpg (ffmpeg)
2023-11-19 10:32:30 INFO import: moving main mp4 file P1870007.MP4 to 2023/01/20230130_101623_A472124D.mp4
2023-11-19 10:32:24 INFO media: P1870007.MP4 was taken at 2023-01-30 10:16:23.337 +0000 UTC (meta)
```


Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+


