### PR TITLE
Use legacy thumb library in ARMv7 compose example

### DIFF
--- a/compose.armv7.yaml
+++ b/compose.armv7.yaml
@@ -60,6 +60,7 @@ services:
       PHOTOPRISM_THUMB_UNCACHED: "true"              # Enables on-demand thumbnail rendering (high memory and cpu usage)
       PHOTOPRISM_THUMB_SIZE: 1920                    # Pre-rendered thumbnail size limit (default 1920, min 720, max 7680)
       # PHOTOPRISM_THUMB_SIZE: 4096                  # Retina 4K, DCI 4K (requires more storage); 7680 for 8K Ultra HD
+      PHOTOPRISM_THUMB_LIBRARY: "imaging"            # Use the legacy image to render thumbnails. Must be set for ARMv7
       PHOTOPRISM_THUMB_SIZE_UNCACHED: 7680           # On-demand rendering size limit (default 7680, min 720, max 7680)
       PHOTOPRISM_JPEG_SIZE: 7680                     # Size limit for converted image files in pixels (720-30000)
       TF_CPP_MIN_LOG_LEVEL: 0                        # Show TensorFlow log messages for development


### PR DESCRIPTION
As `libvips`, the new thumb library from the May 23rd release, doesn't seem to work on ARMv7, the fallback option enabling the use of the legacy library is added to the docker-compose example for ARMv7.

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+