### PR TITLE
UX: Update counters and covers in the background

### DIFF
--- a/internal/api/batch.go
+++ b/internal/api/batch.go
@@ -72,10 +72,10 @@ func BatchPhotosArchive(router *gin.RouterGroup) {
 		}
 
 		// Update precalculated photo and file counts.
-		logWarn("index", entity.UpdateCounts())
+		go func() { logWarn("index", entity.UpdateCounts()) }()
 
 		// Update album, subject, and label cover thumbs.
-		logWarn("index", query.UpdateCovers())
+		go func() { logWarn("index", query.UpdateCovers()) }()
 
 		UpdateClientConfig()
 
@@ -134,10 +134,10 @@ func BatchPhotosRestore(router *gin.RouterGroup) {
 		}
 
 		// Update precalculated photo and file counts.
-		logWarn("index", entity.UpdateCounts())
+		go func() { logWarn("index", entity.UpdateCounts()) }()
 
 		// Update album, subject, and label cover thumbs.
-		logWarn("index", query.UpdateCovers())
+		go func() { logWarn("index", query.UpdateCovers()) }()
 
 		UpdateClientConfig()
 
@@ -298,7 +298,7 @@ func BatchPhotosPrivate(router *gin.RouterGroup) {
 		}
 
 		// Update precalculated photo and file counts.
-		logWarn("index", entity.UpdateCounts())
+		go func() { logWarn("index", entity.UpdateCounts()) }()
 
 		// Fetch selection from index.
 		if photos, err := query.SelectedPhotos(f); err == nil {
@@ -448,7 +448,7 @@ func BatchPhotosDelete(router *gin.RouterGroup) {
 		// Any photos deleted?
 		if len(deleted) > 0 {
 			// Update precalculated photo and file counts.
-			logWarn("index", entity.UpdateCounts())
+			go func() { logWarn("index", entity.UpdateCounts()) }()
 
 			UpdateClientConfig()
 


### PR DESCRIPTION
I have a library of about 150K of photos. Even with an optimized MariaDB every Approve/Archive Batch action takes about 4 seconds. I debugged and found that from these 4 seconds 3.5 seconds are used to regenerate counters. This can easily be done in the background. 

Now if i move a photo to the archive it takes milliseconds again :smile: 

<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work ( already there )
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

