### PR TITLE
Config: Improve parsing of boolean environment variables

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/photoprism/photoprism/pkg/list"
@@ -26,10 +27,19 @@ func EnvVar(flag string) string {
 // Env checks the presence of environment and command-line flags.
 func Env(vars ...string) bool {
 	for _, s := range vars {
-		if (os.Getenv(EnvVar(s)) == "true" || list.Contains(os.Args, "--"+s)) && !list.Contains(os.Args, "--"+s+"=false") {
+		if (envIsTrue(EnvVar(s)) || list.Contains(os.Args, "--"+s)) && !list.Contains(os.Args, "--"+s+"=false") {
 			return true
 		}
 	}
 
 	return false
+}
+
+func envIsTrue(env string) bool {
+	v := os.Getenv(env)
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		log.Warnf("Invalid boolean value for env %s, assuming false", env)
+	}
+	return b
 }


### PR DESCRIPTION
<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

This commit changes the existing code to also accept "true", "1" and other
truthy values as specified by [strconv.ParseBool] from environment variables,
rather than assuming that only "true" is truthy. It also warns the user if a
boolean value is invalid.

For more information on [strconv.ParseBool], see:
https://pkg.go.dev/strconv#ParseBool

This change is not related to an existing issue.

---

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [ ] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [ ] Documentation and translation updates should be provided if needed
- [ ] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

