### PR TITLE
Videos: Add log-statement to convert_video_avc.go

### DIFF
--- a/internal/photoprism/convert_video_avc.go
+++ b/internal/photoprism/convert_video_avc.go
@@ -48,6 +48,7 @@ func (w *Convert) ToAvc(f *MediaFile, encoder ffmpeg.AvcEncoder, noMutex, force 
 		// No, transcode video to AVC.
 	} else if mediaFile.IsVideo() {
 		// Yes, return AVC video file.
+		log.Infof("convert: %s is already in AVC format, no conversion needed", clean.Log(mediaFile.RootRelName()))
 		return mediaFile, nil
 	}
 


### PR DESCRIPTION
Just a small change, this prints out that no conversion is needed when a video already had been previously converted. Currently running `docker compose exec photoprism photoprism convert` is a very quiet command with basically no output if already run at a previous point, leaving me unsure how much progress has been achieved. This small log fixes that by providing a quick log about where the converter is right now

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [x] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

