### PR TITLE
Incorrect File and Photo_Keyword Fixtures

### DIFF
--- a/internal/entity/file_fixtures.go
+++ b/internal/entity/file_fixtures.go
@@ -1414,7 +1414,7 @@ var FileFixtures = FileMap{
 		DeletedAt:       nil,
 	},
 	"Photo09.jpg": {
-		ID:              1000036,
+		ID:              1100036,
 		Photo:           PhotoFixtures.Pointer("Photo09"),
 		PhotoID:         PhotoFixtures.Pointer("Photo09").ID,
 		PhotoUID:        PhotoFixtures.Pointer("Photo09").PhotoUID,

--- a/internal/entity/photo_keyword_fixtures.go
+++ b/internal/entity/photo_keyword_fixtures.go
@@ -37,19 +37,19 @@ var PhotoKeywordFixtures = PhotoKeywordMap{
 	},
 	"9": {
 		PhotoID:   10000029,
-		KeywordID: 10000005,
+		KeywordID: 1000005,
 	},
 	"10": {
 		PhotoID:   1000031,
-		KeywordID: 10000006,
+		KeywordID: 1000006,
 	},
 	"11": {
 		PhotoID:   1000032,
-		KeywordID: 10000008,
+		KeywordID: 1000008,
 	},
 	"12": {
 		PhotoID:   1000033,
-		KeywordID: 10000009,
+		KeywordID: 1000009,
 	},
 	"13": {
 		PhotoID:   1000034,

--- a/internal/entity/search/photos_filter_filter_test.go
+++ b/internal/entity/search/photos_filter_filter_test.go
@@ -46,7 +46,7 @@ func TestPhotosFilterFilter(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, len(photos), 0)
+		assert.Equal(t, 1, len(photos))
 	})
 	t.Run("EndsWithPercent", func(t *testing.T) {
 		var f form.SearchPhotos
@@ -286,7 +286,7 @@ func TestPhotosQueryFilter(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, len(photos), 0)
+		assert.Equal(t, 1, len(photos))
 	})
 	t.Run("EndsWithPercent", func(t *testing.T) {
 		var f form.SearchPhotos

--- a/internal/entity/search/photos_geo_filter_near_test.go
+++ b/internal/entity/search/photos_geo_filter_near_test.go
@@ -19,7 +19,7 @@ func TestPhotosGeoFilterNear(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, len(photos), 8)
+		assert.Equal(t, len(photos), 9)
 	})
 	t.Run("ps6sg6byk7wrbk30", func(t *testing.T) {
 		var f form.SearchPhotosGeo
@@ -259,7 +259,7 @@ func TestPhotosGeoQueryNear(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, len(photos), 8)
+		assert.Equal(t, len(photos), 9)
 	})
 	t.Run("ps6sg6byk7wrbk30", func(t *testing.T) {
 		var f form.SearchPhotosGeo

--- a/internal/entity/search/photos_geo_filter_s2_test.go
+++ b/internal/entity/search/photos_geo_filter_s2_test.go
@@ -33,7 +33,7 @@ func TestPhotosGeoFilterS2(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, len(photos), 8)
+		assert.Equal(t, len(photos), 9)
 	})
 	t.Run("StartsWithPercent", func(t *testing.T) {
 		var f form.SearchPhotosGeo
@@ -282,7 +282,7 @@ func TestPhotosGeoQueryS2(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, 8, len(photos))
+		assert.Equal(t, 9, len(photos))
 	})
 	t.Run("85d1ea7d382c pipe 1ef744d1e283", func(t *testing.T) {
 		var f form.SearchPhotosGeo

--- a/internal/entity/search/photos_geo_test.go
+++ b/internal/entity/search/photos_geo_test.go
@@ -454,7 +454,7 @@ func TestGeo(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, 8, len(photos))
+		assert.Equal(t, 9, len(photos))
 	})
 	t.Run("PathOrPath", func(t *testing.T) {
 		var f form.SearchPhotosGeo


### PR DESCRIPTION
This pull request corrects one FileFixtures (which is using a duplicated File ID), and four PhotoKeywordFixtures (which are using incorrect KeywordID's).  

The tests that are impacted by these corrections are also updated.  

The following tests needed their expected value incremented by 1 as there is now a File associated with a Photo which previously did not have this association due to the duplicated ID.  

- TestPhotosGeoFilterNear/ps6sg6be2lvl0y24
- TestPhotosGeoQueryNear/ps6sg6be2lvl0y24
- TestPhotosGeoFilterS2/85d1ea7d382c
- TestPhotosGeoQueryS2/s2:85d1ea7d382c
- TestGeo/City

The following tests needed their expected value incremented by 1 as the Keyword "love&trust" is now associated with a Photo, which causes the search for "I love % dog" to find a photo as the database query becomes a search for "love%" in keywords.  

- TestPhotosFilterFilter/CenterPercent
- TestPhotosQueryFilter/CenterPercent

Acceptance Criteria:  

- [X] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [X] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [X] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [X] Documentation and translation updates should be provided if needed
- [X] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+
