### PR TITLE
Fix 4604 ffmpeg transcode error 

### DIFF
--- a/internal/ffmpeg/config.go
+++ b/internal/ffmpeg/config.go
@@ -20,6 +20,6 @@ func (o Options) VideoFilter(format PixelFormat) string {
 	} else if format == FormatQSV {
 		return fmt.Sprintf("scale_qsv=w='if(gte(iw,ih), min(%d, iw), -1)':h='if(gte(iw,ih), -1, min(%d, ih))':format=nv12", o.Size, o.Size)
 	} else {
-		return fmt.Sprintf("scale='if(gte(iw,ih), min(%d, iw), -2):if(gte(iw,ih), -2, min(%d, ih))',format=%s", o.Size, o.Size, format)
+		return fmt.Sprintf("\"scale='if(gte(iw,ih), min(%d, iw), -2):if(gte(iw,ih), -2, min(%d, ih))',format=%s\"", o.Size, o.Size, format)
 	}
 }


### PR DESCRIPTION
Adding the double quotation mark to config.go output to fix transcode error https://github.com/photoprism/photoprism/issues/4604 according to ffmpeg wiki https://trac.ffmpeg.org/wiki/Scaling#AvoidingUpscaling

<!--

Thank you for your interest in contributing!

Because we want to create the best possible product for our users, we have a set of criteria to ensure that all submissions are acceptable, see https://docs.photoprism.app/developer-guide/pull-requests/ for details.

(1) Please provide a concise description of your pull request.

- What does it implement / fix / improve? Why?
- Are the changes related to an existing issue?

(2) After you submit your first pull request, you will be asked to accept our CLA, see https://www.photoprism.app/cla.

(3) Finally, please confirm that the following criteria are met by replacing "[ ]" with "[x]" (also possible at a later time).

-->

Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices
- [x] Documentation and translation updates should be provided if needed
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->

