### PR TITLE
WebDAV: Add depth header to service discovery request for Hetzner compatibility

### DIFF
--- a/internal/service/remote.go
+++ b/internal/service/remote.go
@@ -44,6 +44,7 @@ const (
 
 func HttpOk(method, rawUrl string) bool {
 	req, err := http.NewRequest(method, rawUrl, nil)
+	req.Header.Add("Depth", "1")
 
 	if err != nil {
 		return false


### PR DESCRIPTION
I noticed that I couldn't connect to my Hetzner storage box via webdav, as it does not allow `PROPFIND` requests without `Depth` set as `0` or `1`. When a request is created via `NewRequest` it doesn't have a `Depth` field, which Hetzner interprets as `infinity`:

```
$ curl -X PROPFIND https://XXXX:XXXXX@XXXXXXXXX/webdav/
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<title>403 Forbidden</title>
</head><body>
<h1>Forbidden</h1>
<p>PROPFIND requests with a Depth of "infinity" are not allowed for /webdav/.</p>
</body></html>
```

I believe this is the same issue as https://github.com/photoprism/photoprism/issues/4074 https://github.com/photoprism/photoprism/issues/3541

I've tested the change locally and it works. However photoprism still uses `PROPFIND` with `Depth = infinity` somehwere else, I'd suspect it's because of https://github.com/photoprism/photoprism/blob/c096382dbd6e891c2408466bce7642f39d2fd14c/internal/workers/sync_refresh.go#L28 , but this is the first Go code I've ever written and I'm not familiar with the `http` and `webdav` packages.