### PR TITLE
Server: Delete Unix domain socket after shutdown

### DIFF
--- a/internal/server/start.go
+++ b/internal/server/start.go
@@ -108,6 +108,13 @@ func Start(ctx context.Context, conf *config.Config) {
 		var unixAddr *net.UnixAddr
 		var err error
 
+		// Clean up Unix Domain Socket file if it exists
+		if err := os.Remove(unixSocket); err != nil && !os.IsNotExist(err) {
+			log.Warnf("server: failed to remove existing unix socket file %s: %v", unixSocket, err)
+		} else {
+			log.Debugf("server: cleaned up existing unix socket file %s", unixSocket)
+		}
+
 		if unixAddr, err = net.ResolveUnixAddr("unix", unixSocket); err != nil {
 			log.Errorf("server: invalid unix socket (%s)", err)
 			return

--- a/internal/server/start.go
+++ b/internal/server/start.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"golang.org/x/crypto/acme/autocert"
@@ -180,6 +181,15 @@ func Start(ctx context.Context, conf *config.Config) {
 	err := server.Close()
 	if err != nil {
 		log.Errorf("server: shutdown failed (%s)", err)
+	}
+
+	// Clean up Unix Domain Socket file if it exists
+	if unixSocket := conf.HttpSocket(); unixSocket != "" {
+		if err := os.Remove(unixSocket); err != nil && !os.IsNotExist(err) {
+			log.Errorf("server: failed to remove unix socket file %s: %v", unixSocket, err)
+		} else {
+			log.Debugf("server: removed unix socket file %s", unixSocket)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #4673: Unable to start photoprism container if domain socket file is exist

Added proper cleanup of Unix Domain Socket files both during server startup and shutdown to prevent "address already in use" errors and ensure clean server restarts.

