### PR TITLE
Faces: Improve performance and strategy for manual tagging

### DIFF
--- a/internal/api/markers.go
+++ b/internal/api/markers.go
@@ -228,7 +228,7 @@ func UpdateMarker(router *gin.RouterGroup) {
 			return
 		} else if changed {
 			if marker.FaceID != "" && marker.SubjUID != "" && marker.SubjSrc == entity.SrcManual {
-				if res, err := get.Faces().Optimize(); err != nil {
+				if res, err := get.Faces().OptimizeFor(marker.SubjUID); err != nil {
 					log.Errorf("faces: %s (optimize)", err)
 				} else if res.Merged > 0 {
 					log.Infof("faces: merged %s", english.Plural(res.Merged, "cluster", "clusters"))

--- a/internal/entity/query/faces.go
+++ b/internal/entity/query/faces.go
@@ -178,7 +178,9 @@ func PurgeOrphanFaces(faceIds []string, ignored bool) (affected int, err error) 
 		} else if result.RowsAffected > 0 {
 			affected += int(result.RowsAffected)
 		} else {
-			affected += len(ids)
+			// see https://github.com/photoprism/photoprism/issues/3124#issuecomment-2558299360
+			log.Debugf("faces: no affected rows for purge in batch %d - %d", i, j)
+			//affected += len(ids)
 		}
 	}
 
@@ -214,9 +216,9 @@ func MergeFaces(merge entity.Faces, ignored bool) (merged *entity.Face, err erro
 	if removed, err := PurgeOrphanFaces(merge.IDs(), ignored); err != nil {
 		return merged, err
 	} else if removed > 0 {
-		log.Debugf("faces: removed %d orphans for subject %s", removed, clean.Log(subjUID))
+		log.Debugf("faces: removed %d orphans of %d canidates for subject %s", removed, len(merge), clean.Log(subjUID))
 	} else {
-		log.Warnf("faces: failed removing merged clusters for subject %s", clean.Log(subjUID))
+		return merged, fmt.Errorf("faces: failed to remove any orphan clusters of %d canidates for subject %s", len(merge), clean.Log(subjUID))
 	}
 
 	return merged, err

--- a/internal/entity/query/faces_test.go
+++ b/internal/entity/query/faces_test.go
@@ -61,7 +61,7 @@ func TestFaces(t *testing.T) {
 
 func TestManuallyAddedFaces(t *testing.T) {
 	t.Run("Ok", func(t *testing.T) {
-		results, err := ManuallyAddedFaces(false, false)
+		results, err := ManuallyAddedFaces(false, false, "")
 
 		if err != nil {
 			t.Fatal(err)
@@ -74,7 +74,16 @@ func TestManuallyAddedFaces(t *testing.T) {
 		}
 	})
 	t.Run("Hidden", func(t *testing.T) {
-		results, err := ManuallyAddedFaces(true, false)
+		results, err := ManuallyAddedFaces(true, false, "")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Empty(t, results)
+	})
+	t.Run("Specific Subject", func(t *testing.T) {
+		results, err := ManuallyAddedFaces(false, false, "foobar")
 
 		if err != nil {
 			t.Fatal(err)

--- a/internal/photoprism/faces_optimize.go
+++ b/internal/photoprism/faces_optimize.go
@@ -15,6 +15,11 @@ type FacesOptimizeResult struct {
 
 // Optimize optimizes the face lookup table.
 func (w *Faces) Optimize() (result FacesOptimizeResult, err error) {
+	return w.OptimizeFor("")
+}
+
+// Optimize optimizes the face lookup table for the specified subj_uid or "" for all subjects
+func (w *Faces) OptimizeFor(subj_uid string) (result FacesOptimizeResult, err error) {
 	if w.Disabled() {
 		return result, fmt.Errorf("face recognition is disabled")
 	}
@@ -27,12 +32,14 @@ func (w *Faces) Optimize() (result FacesOptimizeResult, err error) {
 		var faces entity.Faces
 
 		// Fetch manually added faces from the database.
-		if faces, err = query.ManuallyAddedFaces(false, false); err != nil {
+		if faces, err = query.ManuallyAddedFaces(false, false, subj_uid); err != nil {
 			return result, err
 		} else if n = len(faces) - 1; n < 1 {
 			// Need at least 2 faces to optimize.
 			break
 		}
+
+		log.Debugf("faces: optimize for %s itr %d n %d", subj_uid, i, n)
 
 		// Find and merge matching faces.
 		for j := 0; j <= n; j++ {

--- a/internal/photoprism/faces_optimize.go
+++ b/internal/photoprism/faces_optimize.go
@@ -42,8 +42,10 @@ func (w *Faces) Optimize() (result FacesOptimizeResult, err error) {
 				if len(merge) < 2 {
 					// Nothing to merge.
 				} else if _, err := query.MergeFaces(merge, false); err != nil {
-					log.Errorf("%s (merge)", err)
+					log.Errorf("%s (merge) itr %d cluster %d count %d", err, i, j, len(merge))
 				} else {
+					// not exactly right, potentially overcounting
+					// see https://github.com/photoprism/photoprism/issues/3124#issuecomment-2558299360
 					result.Merged += len(merge)
 				}
 


### PR DESCRIPTION
# (1) Please provide a concise description of your pull request
## What does it implement / fix / improve? Why?

**What?**: Per [#3124](https://github.com/photoprism/photoprism/issues/3124), this PR implements strategy [(1)](https://github.com/photoprism/photoprism/issues/3124#issuecomment-2558299360) to improve `Optimize()` performance by returning the correct number of rows modified in `PurgeOrphanFaces` and  treating the result `0` as an error condition in `MergeFaces`. Logging around this has been improved in `faces.go` and `faces_optimize.go`. 

**Why?**: To improve performance when manually tagging faces, in the case that it becomes necessary to call `Optimize()`. Please see [issue 3124](https://github.com/photoprism/photoprism/issues/3124#issuecomment-2558299360) for the detailed description of the problem. 

## Are the changes related to an existing issue?

Yes: [#3124](https://github.com/photoprism/photoprism/issues/3124)

# (2) CLA (see https://www.photoprism.app/cla)

Signed and scanned

# (3) Acceptance Criteria:

- [x] Features and enhancements must be fully implemented so that they can be released at any time without additional work
- [ ] Automated unit and/or acceptance tests are mandatory to ensure the changes work as expected and to reduce repetitive manual work *see below!*
- [x] Frontend components must be responsive to work and look properly on phones, tablets, and desktop computers; you must have tested them on all major browsers and different devices *- no frontend changes, but did test on chrome, firefox, safari*
- [x] Documentation and translation updates should be provided if needed *no translations modified*
- [x] In case you submit database-related changes, they must be tested and compatible with SQLite 3 and MariaDB 10.5.12+ *no database schema changes*

<!--

Since reviewing, testing and finally merging pull requests requires significant resources on our side, this can take several months if it's not just a small fix, especially if extensive testing is required to prevent bugs from getting into our stable version.

We thank you for your patience! :)

-->
# Testing issues 

Development machine is Windows 10 (Docker WSLv2). Followed instructions, having test errors that seem disconnected from the modified code:

```
FAIL | UpdateMarker (0.08s)
FAIL |   UpdateMarker/update_cluster_with_existing_subject_2 (0.02s)
     |         markers_test.go:272:
     |                  Error Trace:    /go/src/github.com/photoprism/photoprism/internal/api/markers_test.go:272
     |                  Error:          Not equal:
     |                                  expected: 200
     |                                  actual  : 500
     |                  Test:           TestUpdateMarker/update_cluster_with_existing_subject_2
...
     | time="2024-12-30T18:39:51Z" level=debug msg="api-v1: abort /api/v1/zip with code 400 (unable to do that)"
     | time="2024-12-30T18:39:51Z" level=error msg="download: /go/src/github.com/photoprism/photoprism/storage/testdata/temp/zip/xxx not found"
FAIL |  github.com/photoprism/photoprism/internal/api   72.942s
...
FAIL | MediaFile_NeedsExifToolJson (0.12s)
FAIL |   MediaFile_NeedsExifToolJson/false (0.04s)
     |         mediafile_meta_test.go:84:
     |                  Error Trace:    /go/src/github.com/photoprism/photoprism/internal/photoprism/mediafile_meta_test.go:84
     |                  Error:          Should be true
     |                  Test:           TestMediaFile_NeedsExifToolJson/false
FAIL |  github.com/photoprism/photoprism/internal/photoprism
```

FWIW, in my environment, these tests **all fail on a completely vanilla develop branch**. During my attempt at implementation, there were other errors/failing tests that *were* caught and are now passing, so I assume that these test failures are alright. 

In lieu of passing tests, I built using `make preview` (changing the docker-buildx.sh script to use `--load` instead of `--push`) and set the image in my main photoprism deployment (after backing everything up) to use the local image. Observations will follow in a comment below.