### PR TITLE
Tensorflow 2.18.0 arm64 Dockerfile to Jammy (issue 222)

### DIFF
--- a/docker/tensorflow/Dockerfile
+++ b/docker/tensorflow/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get upgrade && \
     jq \
     nano
 
-# Install bazelisk
+# Install bazelisk and llvm
 RUN wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && \
     ./llvm.sh 17 && rm llvm.sh && \
     ln -s /usr/bin/python3 /usr/bin/python && \

--- a/docker/tensorflow/arm64/Dockerfile
+++ b/docker/tensorflow/arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.10
+FROM ubuntu:22.04
 
 LABEL maintainer="PhotoPrism UG <hello@photoprism.app>"
 
@@ -23,16 +23,19 @@ RUN apt-get update && apt-get upgrade && \
     build-essential \
     python3 \
     ca-certificates \
-    llvm-17 \
-    clang-17 \
     curl \
     wget \
     git \
+    lsb-release \
+    software-properties-common \
+    gnupg \
     jq \
     nano
 
-# Install bazelisk
-RUN ln -s /usr/bin/python3 /usr/bin/python && \
+# Install bazelisk and llvm
+RUN wget https://apt.llvm.org/llvm.sh && chmod u+x llvm.sh && \
+    ./llvm.sh 17 && rm llvm.sh && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
     ln -s /usr/bin/clang-17 /usr/bin/clang && \
     ln -s /usr/bin/clang++-17 /usr/bin/clang++ && \
     ln -s /usr/bin/clang-cpp /usr/bin/clang-cpp && \


### PR DESCRIPTION
As stated in issue 222, the Dockerfile for arm64 should be changed to jammy, so as to support more versions of glibc.
