### PR TITLE
Fix: timezone handling in sidebar component

### DIFF
--- a/frontend/src/component/sidebar/info.vue
+++ b/frontend/src/component/sidebar/info.vue
@@ -120,10 +120,14 @@ export default {
         return this.$gettext("Unknown");
       }
 
-      if (model.TimeZone && model.TimeZone !== "Local") {
-        return DateTime.fromISO(model.TakenAtLocal, { zone: model.TimeZone }).toLocaleString(formats.DATETIME_MED_TZ);
+      // Always parse as UTC to avoid time shifts
+      const dateTime = DateTime.fromISO(model.TakenAtLocal, { zone: "UTC" });
+
+      if (model.TimeZone && model.TimeZone !== "Local" && model.TimeZone !== "UTC") {
+        // We use the real timezone just for display, but don't shift the time (prevents double timezone offset as backend already applied it)
+        return dateTime.setZone(model.TimeZone, { keepLocalTime: true }).toLocaleString(formats.DATETIME_MED_TZ);
       } else {
-        return DateTime.fromISO(model.TakenAtLocal, { zone: "UTC" }).toLocaleString(formats.DATETIME_MED);
+        return dateTime.toLocaleString(formats.DATETIME_MED);
       }
     },
   },


### PR DESCRIPTION
The backend stores the TakenAtLocal value as the local time of the specified timezone, like Berlin's time for Europe/Berlin. If we interpret TakenAtLocal with the timezone (DateTime.fromISO(time, {zone: timezone})), it results in a double time offset. To fix this, we should interpret TakenAtLocal as UTC to avoid time shifts, add timezone information only for display (using keepLocalTime: true), and thus preserve the correct local time while showing the timezone.

Related Issues:

- https://github.com/photoprism/photoprism/issues/5018