### PR TITLE
Backend: Set content-type on metrics endpoints

### DIFF
--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/photoprism/photoprism/internal/auth/acl"
 	"github.com/photoprism/photoprism/internal/config"
 	"github.com/photoprism/photoprism/internal/photoprism/get"
+	"github.com/photoprism/photoprism/pkg/media/http/header"
 )
 
 // GetMetrics provides a prometheus-compatible metrics endpoint for monitoring.
@@ -30,6 +31,8 @@ func GetMetrics(router *gin.RouterGroup) {
 
 		conf := get.Config()
 		counts := conf.ClientUser(false).Count
+
+		header.SetContentType(c.Request, header.ContentTypePrometheus)
 
 		c.Stream(func(w io.Writer) bool {
 			reg := prometheus.NewRegistry()

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -29,6 +29,7 @@ func TestGetMetrics(t *testing.T) {
 		assert.Regexp(t, regexp.MustCompile(`photoprism_statistics_media_count{stat="folders"} \d+`), body)
 		assert.Regexp(t, regexp.MustCompile(`photoprism_statistics_media_count{stat="files"} \d+`), body)
 	})
+
 	t.Run("expose build information", func(t *testing.T) {
 		app, router, _ := NewApiTest()
 
@@ -43,5 +44,19 @@ func TestGetMetrics(t *testing.T) {
 		body := resp.Body.String()
 
 		assert.Regexp(t, regexp.MustCompile(`photoprism_build_info{edition=".+",goversion=".+",version=".+"} 1`), body)
+	})
+
+	t.Run("has prometheus exposition format as content type", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+
+		GetMetrics(router)
+
+		resp := PerformRequestWithStream(app, "GET", "/api/v1/metrics")
+		if resp.Code != http.StatusOK {
+			t.Fatal(resp.Body.String())
+		}
+		if contentType := resp.Result().Header.Get("Content-Type"); contentType != "" {
+			t.Fatalf("unexpected response content-type: %s", contentType)
+		}
 	})
 }

--- a/pkg/media/http/header/content_types.go
+++ b/pkg/media/http/header/content_types.go
@@ -96,16 +96,17 @@ const (
 
 // Standard ContentType strings for markup and sidecar files.
 const (
-	ContentTypeBinary    = "application/octet-stream"
-	ContentTypeForm      = "application/x-www-form-urlencoded"
-	ContentTypeMultipart = "multipart/form-data"
-	ContentTypeJson      = "application/json"
-	ContentTypeJsonUtf8  = "application/json; charset=utf-8"
-	ContentTypeXml       = "text/xml"
-	ContentTypeHtml      = "text/html; charset=utf-8"
-	ContentTypeText      = "text/plain; charset=utf-8"
-	ContentTypePDF       = "application/pdf"
-	ContentTypeZip       = "application/zip"
+	ContentTypeBinary     = "application/octet-stream"
+	ContentTypeForm       = "application/x-www-form-urlencoded"
+	ContentTypeMultipart  = "multipart/form-data"
+	ContentTypeJson       = "application/json"
+	ContentTypeJsonUtf8   = "application/json; charset=utf-8"
+	ContentTypeXml        = "text/xml"
+	ContentTypeHtml       = "text/html; charset=utf-8"
+	ContentTypeText       = "text/plain; charset=utf-8"
+	ContentTypePDF        = "application/pdf"
+	ContentTypeZip        = "application/zip"
+	ContentTypePrometheus = "text/plain; version=0.0.4"
 )
 
 // HasContentType checks weather the Content-Type header has the specified type.


### PR DESCRIPTION
### Overview

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

The prometheus text format requires metrics endpoints respond with the content-type `text/plain; version=0.0.4`. Without this, newer versions of prometheus fail to scrape the metrics endpoint and report an error. It's possible to work around this by setting the `fallback_scrape_protocol` setting in the prometheus scrape target configuration, but this revision sets the content type appropriately to avoid this in the first place.

Add test for the content type in the response.

### Fix Details

With the latest version of Prometheus, after configuring photoprism as a scrape target with standard configuration, prometheus scrapes fail with the error below:

```
time=2025-06-01T15:33:53.612Z level=ERROR source=scrape.go:1627 msg="Failed to determine correct type of scrape target." component="scrape manager" scrape_pool=photoprism target=http://photoprism:8080/api/v1/metrics content_type="" fallback_media_type="" err="non-compliant scrape target sending blank Content-Type and no fallback_scrape_protocol specified for target"
```

I've been using the docker compose configuration below for my testing, and you can use this to test if you'd like. I believe the standard compose configuration in the project should suffice too.

```yaml
services:
  photoprism:
    image: photoprism/photoprism:develop
    build: .
    ports:
      - 8080:8080
    environment:
      PHOTOPRISM_ADMIN_USER: admin
      PHOTOPRISM_ADMIN_PASSWORD: admin
      PHOTOPRISM_DISABLE_PLACES: true
      PHOTOPRISM_DISABLE_FFMPEG: true
      PHOTOPRISM_DISABLE_DARKTABLE: true
      PHOTOPRISM_DISABLE_RAWTHERAPEE: true
      PHOTOPRISM_DISABLE_SIPS: true
      PHOTOPRISM_DISABLE_HEIFCONVERT: true
      PHOTOPRISM_DISABLE_TENSORFLOW: true
      PHOTOPRISM_DISABLE_FACES: true
      PHOTOPRISM_DETECT_NSFW: true
      PHOTOPRISM_UPLOAD_NSFW: true
      PHOTOPRISM_SITE_AUTHOR: PhotoPrism
      PHOTOPRISM_SITE_TITLE: PhotoPrism (local)
      PHOTOPRISM_HTTP_PORT: 8080
      PHOTOPRISM_HTTP_MODE: release
      PHOTOPRISM_HTTP_COMPRESSION: gzip
      PHOTOPRISM_IMPORT_PATH: /photoprism/storage/import
      PHOTOPRISM_ORIGINALS_PATH: /photoprism/storage/originals
      PHOTOPRISM_STORAGE_PATH: /photoprism/storage
      PHOTOPRISM_SIDECAR_PATH: /photoprism/storage/sidecar
      PHOTOPRISM_CACHE_PATH: /photoprism/storage/cache
      PHOTOPRISM_TEMP_PATH: /photoprism/storage/temp
      PHOTOPRISM_BACKUP_PATH: /photoprism/storage/backup
      PHOTOPRISM_DATABASE_DRIVER: sqlite
      PHOTOPRISM_DATABASE_DSN: /photoprism/storage/photoprism.db
      PHOTOPRISM_DATABASE_USER: photoprism-sqlite-user
      PHOTOPRISM_DATABASE_PASSWORD: admin
      PHOTOPRISM_APP_ICON: app
      PHOTOPRISM_SPONSOR: true
      PHOTOPRISM_DISABLE_TLS: true
    working_dir: "/go/src/github.com/photoprism/photoprism"
    volumes:
      - ".:/go/src/github.com/photoprism/photoprism"
      - "./storage:/photoprism"
      - "go-mod:/go/pkg/mod"

  prom:
    image: prom/prometheus:latest
    ports:
      - 9090:9090
    configs:
      - source: prometheus.yml
        target: /etc/prometheus/prometheus.yml
        mode: 0444

volumes:
  go-mod:
    driver: local

configs:
  prometheus.yml:
    content: |
      global:
        scrape_interval: 60s
        scrape_timeout: 10s
      scrape_configs:
        - job_name: "photoprism"
          metrics_path: "/api/v1/metrics"
          oauth2:
            client_id: "cs5cpu17n6gj2qo5"
            client_secret: "xcCbOrw6I0vcoXzhnOmXhjpVSyFq0l0e"
            token_url: "http://photoprism:8080/api/v1/oauth/token"
            scopes:
              - 'metrics'
            endpoint_params:
              grant_type: "client_credentials"
          static_configs:
            - targets: ["photoprism:8080"]
```

After this revision, the scrape succeeds.

The prometheus exposition format documentation can be found [here](https://prometheus.io/docs/instrumenting/exposition_formats/).

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [x] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes
- [x] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [x] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->