### PR TITLE
UX: Improve GPS position input and dialog components

### DIFF
--- a/frontend/src/component/location/coordinate-input.vue
+++ b/frontend/src/component/location/coordinate-input.vue
@@ -1,0 +1,258 @@
+<template>
+  <v-text-field
+    v-model="coordinateInput"
+    :disabled="disabled"
+    :hide-details="hideDetails"
+    :label="label"
+    :placeholder="placeholder"
+    :density="density"
+    :validate-on="validateOn"
+    :rules="[() => !coordinateInput || isValidCoordinateInput]"
+    autocomplete="off"
+    autocorrect="off"
+    autocapitalize="none"
+    class="input-coordinates"
+    @keydown.enter="applyCoordinates"
+    @update:model-value="onCoordinateInputChange"
+    @paste="pastePosition"
+  >
+    <template #prepend-inner>
+      <v-icon
+        v-if="showMapButton"
+        variant="plain"
+        icon="mdi-crosshairs-gps"
+        :title="mapButtonTitle"
+        :disabled="mapButtonDisabled"
+        class="action-map"
+        @click.stop="$emit('open-map')"
+      >
+      </v-icon>
+      <v-icon v-else variant="plain" icon="mdi-crosshairs-gps" class="text-disabled"> </v-icon>
+    </template>
+    <template #append-inner>
+      <v-icon
+        v-if="showUndoButton"
+        variant="plain"
+        icon="mdi-undo"
+        class="action-undo"
+        @click.stop="undoClear"
+      ></v-icon>
+      <v-icon
+        v-else-if="coordinateInput"
+        variant="plain"
+        icon="mdi-close-circle"
+        class="action-clear"
+        @click.stop="clearCoordinates"
+      ></v-icon>
+    </template>
+  </v-text-field>
+</template>
+
+<script>
+export default {
+  name: "PCoordinateInput",
+  props: {
+    latitude: {
+      type: Number,
+      default: null,
+    },
+    longitude: {
+      type: Number,
+      default: null,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    hideDetails: {
+      type: Boolean,
+      default: true,
+    },
+    label: {
+      type: String,
+      default: "",
+    },
+    placeholder: {
+      type: String,
+      default: "e.g., 52.5208, 13.4049",
+    },
+    density: {
+      type: String,
+      default: "comfortable",
+    },
+    validateOn: {
+      type: String,
+      default: "input",
+    },
+    showMapButton: {
+      type: Boolean,
+      default: false,
+    },
+    mapButtonTitle: {
+      type: String,
+      default: "",
+    },
+    mapButtonDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    enableUndo: {
+      type: Boolean,
+      default: false,
+    },
+    autoApply: {
+      type: Boolean,
+      default: true,
+    },
+    debounceDelay: {
+      type: Number,
+      default: 1000,
+    },
+  },
+  emits: ["update:latitude", "update:longitude", "coordinates-changed", "coordinates-cleared", "open-map"],
+  data() {
+    return {
+      coordinateInput: "",
+      inputTimeout: null,
+      wasCleared: false,
+      lastValidLat: null,
+      lastValidLng: null,
+    };
+  },
+  computed: {
+    isValidCoordinateInput() {
+      if (!this.coordinateInput) return false;
+
+      const parts = this.coordinateInput.split(",").map((part) => part.trim());
+      if (parts.length !== 2) return false;
+
+      const lat = parseFloat(parts[0]);
+      const lng = parseFloat(parts[1]);
+
+      return !isNaN(lat) && !isNaN(lng) && lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
+    },
+    showUndoButton() {
+      return this.enableUndo && this.wasCleared && this.lastValidLat !== null && this.lastValidLng !== null;
+    },
+  },
+  watch: {
+    latitude() {
+      this.updateCoordinateInput();
+    },
+    longitude() {
+      this.updateCoordinateInput();
+    },
+  },
+  mounted() {
+    this.updateCoordinateInput();
+  },
+  beforeUnmount() {
+    if (this.inputTimeout) {
+      clearTimeout(this.inputTimeout);
+    }
+  },
+  methods: {
+    updateCoordinateInput() {
+      const lat = this.latitude;
+      const lng = this.longitude;
+
+      if (lat !== null && lng !== null && !(lat === 0 && lng === 0) && !isNaN(lat) && !isNaN(lng)) {
+        this.coordinateInput = `${parseFloat(lat)}, ${parseFloat(lng)}`;
+        this.wasCleared = false;
+      } else {
+        this.coordinateInput = "";
+      }
+    },
+
+    onCoordinateInputChange(value) {
+      this.coordinateInput = value;
+      this.wasCleared = false;
+
+      if (this.inputTimeout) {
+        clearTimeout(this.inputTimeout);
+      }
+
+      if (this.autoApply) {
+        this.inputTimeout = setTimeout(() => {
+          if (this.isValidCoordinateInput) {
+            this.applyCoordinates();
+          }
+        }, this.debounceDelay);
+      }
+    },
+    applyCoordinates() {
+      if (!this.isValidCoordinateInput) return;
+
+      const parts = this.coordinateInput.split(",").map((part) => part.trim());
+      const lat = parseFloat(parts[0]);
+      const lng = parseFloat(parts[1]);
+
+      this.$emit("update:latitude", lat);
+      this.$emit("update:longitude", lng);
+      this.$emit("coordinates-changed", { latitude: lat, longitude: lng });
+    },
+    clearCoordinates() {
+      if (this.enableUndo) {
+        this.lastValidLat = this.latitude;
+        this.lastValidLng = this.longitude;
+      }
+
+      this.coordinateInput = "";
+      this.wasCleared = true;
+
+      this.$emit("update:latitude", 0);
+      this.$emit("update:longitude", 0);
+      this.$emit("coordinates-changed", { latitude: 0, longitude: 0 });
+      this.$emit("coordinates-cleared", {
+        latitude: 0,
+        longitude: 0,
+        previousLatitude: this.lastValidLat,
+        previousLongitude: this.lastValidLng,
+      });
+    },
+    undoClear() {
+      if (this.lastValidLat !== null && this.lastValidLng !== null) {
+        this.$emit("update:latitude", this.lastValidLat);
+        this.$emit("update:longitude", this.lastValidLng);
+        this.$emit("coordinates-changed", {
+          latitude: this.lastValidLat,
+          longitude: this.lastValidLng,
+        });
+
+        this.wasCleared = false;
+        this.lastValidLat = null;
+        this.lastValidLng = null;
+      }
+    },
+    pastePosition(event) {
+      // Autofill the lat and lng fields if the text in the clipboard contains two float values.
+      const clipboard = event.clipboardData ? event.clipboardData : window.clipboardData;
+
+      if (!clipboard) {
+        return;
+      }
+
+      // Get values from browser clipboard.
+      const text = clipboard.getData("text");
+
+      // Trim spaces before splitting by whitespace and/or commas.
+      const val = text.trim().split(/[ ,]+/);
+
+      if (val.length >= 2) {
+        const lat = parseFloat(val[0]);
+        const lng = parseFloat(val[1]);
+
+        if (!isNaN(lat) && lat >= -90 && lat <= 90 && !isNaN(lng) && lng >= -180 && lng <= 180) {
+          // Update coordinates
+          this.$emit("update:latitude", lat);
+          this.$emit("update:longitude", lng);
+          this.$emit("coordinates-changed", { latitude: lat, longitude: lng });
+
+          // Prevent default action.
+          event.preventDefault();
+        }
+      }
+    },
+  },
+};
+</script>

--- a/frontend/src/component/location/dialog.vue
+++ b/frontend/src/component/location/dialog.vue
@@ -27,7 +27,7 @@
         <v-icon size="28" color="primary">mdi-map-marker</v-icon>
         <h6 class="text-h6">{{ $gettext("Set Location") }}</h6>
       </v-card-title>
-      <v-card-text class="pa-0">
+      <v-card-text class="pt-4">
         <div class="d-flex flex-column flex-md-row">
           <div class="flex-grow-1 position-relative mb-4 mb-md-0">
             <div ref="map" class="p-map" style="height: 50vh; min-height: 300px; width: 100%; border-radius: 4px"></div>
@@ -96,17 +96,19 @@
               </div>
 
               <div>
-                <v-text-field
-                  v-model="coordinateInput"
-                  prepend-inner-icon="mdi-crosshairs-gps"
-                  :append-inner-icon="locationWasCleared ? 'mdi-undo' : coordinateInput ? 'mdi-close-circle' : ''"
+                <p-coordinate-input
+                  :latitude="currentLat"
+                  :longitude="currentLng"
                   density="comfortable"
                   placeholder="e.g., 52.5208, 13.4049"
-                  persistent-hint
-                  @keydown.enter="applyCoordinates"
-                  @update:model-value="onCoordinateInputChange"
-                  @click:append-inner="locationWasCleared ? undoClearLocation() : clearLocation()"
-                ></v-text-field>
+                  :enable-undo="true"
+                  :auto-apply="true"
+                  :label="$gettext('Coordinates')"
+                  @update:latitude="updateLatitude"
+                  @update:longitude="updateLongitude"
+                  @coordinates-changed="onCoordinatesChanged"
+                  @coordinates-cleared="onCoordinatesCleared"
+                ></p-coordinate-input>
               </div>
 
               <div class="d-flex flex-column ga-3 pa-4 border rounded">
@@ -137,9 +139,13 @@
 
 <script>
 import maplibregl from "common/maplibregl";
+import PCoordinateInput from "component/location/coordinate-input.vue";
 
 export default {
   name: "PLocationDialog",
+  components: {
+    PCoordinateInput,
+  },
   props: {
     value: {
       type: Boolean,
@@ -172,12 +178,7 @@ export default {
       loaded: false,
       currentLat: this.latitude,
       currentLng: this.longitude,
-      coordinateInput: "",
       locationInfo: null,
-      locationWasCleared: false,
-      latBeforeClear: null,
-      lngBeforeClear: null,
-      coordinateInputTimeout: null,
       searchQuery: "",
       searchResults: [],
       searchLoading: false,
@@ -186,17 +187,6 @@ export default {
     };
   },
   computed: {
-    isValidCoordinateInput() {
-      if (!this.coordinateInput) return false;
-
-      const parts = this.coordinateInput.split(",").map((part) => part.trim());
-      if (parts.length !== 2) return false;
-
-      const lat = parseFloat(parts[0]);
-      const lng = parseFloat(parts[1]);
-
-      return !isNaN(lat) && !isNaN(lng) && lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
-    },
     simplifiedLocationDisplay() {
       if (!this.locationInfo) return "";
 
@@ -217,7 +207,6 @@ export default {
       if (val) {
         this.currentLat = this.latitude;
         this.currentLng = this.longitude;
-        this.locationWasCleared = false;
         this.$nextTick(() => {
           setTimeout(() => {
             this.initMap();
@@ -242,12 +231,6 @@ export default {
       if (this.map && this.loaded) {
         this.updatePosition(this.currentLat, val);
       }
-    },
-    currentLat() {
-      this.updateCoordinateInput();
-    },
-    currentLng() {
-      this.updateCoordinateInput();
     },
   },
   mounted() {
@@ -289,16 +272,6 @@ export default {
     onDialogClosed() {
       this.cleanupMap();
       this.locationInfo = null;
-      this.coordinateInput = "";
-      this.locationWasCleared = false;
-      this.latBeforeClear = null;
-      this.lngBeforeClear = null;
-
-      // Clear any pending timeout
-      if (this.coordinateInputTimeout) {
-        clearTimeout(this.coordinateInputTimeout);
-        this.coordinateInputTimeout = null;
-      }
 
       // Clear search state
       this.searchQuery = "";
@@ -321,7 +294,6 @@ export default {
         } else {
           this.options.zoom = 12;
           this.options.center = [this.currentLng, this.currentLat];
-          this.updateCoordinateInput();
         }
 
         this.map = new maplibregl.Map(this.options);
@@ -370,7 +342,6 @@ export default {
           this.currentLng = e.lngLat.lng;
           this.updatePosition(e.lngLat.lat, e.lngLat.lng);
           this.fetchLocationInfo(e.lngLat.lat, e.lngLat.lng);
-          this.locationWasCleared = false;
         });
       } catch (error) {
         console.error("map: initialization failed", error);
@@ -416,32 +387,38 @@ export default {
             this.currentLat = lngLat.lat;
             this.currentLng = lngLat.lng;
             this.fetchLocationInfo(lngLat.lat, lngLat.lng);
-            this.locationWasCleared = false;
           });
         }
       }
     },
-    formatCoordinates(lat, lng) {
-      return `${lat.toFixed(6)}, ${lng.toFixed(6)}`;
+    updateLatitude(lat) {
+      this.currentLat = lat;
+      this.updatePosition(lat, this.currentLng);
     },
-    updateCoordinateInput() {
-      if (this.currentLat && this.currentLng && !(this.currentLat === 0 && this.currentLng === 0)) {
-        this.coordinateInput = this.formatCoordinates(this.currentLat, this.currentLng);
-      } else {
-        this.coordinateInput = "";
+    updateLongitude(lng) {
+      this.currentLng = lng;
+      this.updatePosition(this.currentLat, lng);
+    },
+    onCoordinatesChanged(data) {
+      if (data.latitude !== 0 || data.longitude !== 0) {
+        this.fetchLocationInfo(data.latitude, data.longitude);
       }
     },
-    applyCoordinates() {
-      if (!this.isValidCoordinateInput) return;
-      const parts = this.coordinateInput.split(",").map((part) => part.trim());
-      const lat = parseFloat(parts[0]);
-      const lng = parseFloat(parts[1]);
-      this.currentLat = lat;
-      this.currentLng = lng;
-      this.updatePosition(lat, lng);
-      this.fetchLocationInfo(lat, lng);
-      this.locationWasCleared = false;
+    onCoordinatesCleared() {
+      this.locationInfo = null;
+      if (this.marker) {
+        this.marker.remove();
+        this.marker = null;
+      }
+      if (this.map) {
+        this.map.flyTo({
+          center: [0, 20],
+          zoom: 2,
+          essential: true,
+        });
+      }
     },
+
     fetchLocationInfo(lat, lng) {
       this.$api
         .get(`places/reverse?lat=${lat}&lng=${lng}`)
@@ -457,50 +434,7 @@ export default {
           this.locationInfo = null;
         });
     },
-    clearLocation() {
-      this.latBeforeClear = this.currentLat;
-      this.lngBeforeClear = this.currentLng;
-      this.currentLat = 0;
-      this.currentLng = 0;
-      this.coordinateInput = "";
-      if (this.marker) {
-        this.marker.remove();
-        this.marker = null;
-      }
-      this.locationInfo = null;
-      if (this.map) {
-        this.map.flyTo({
-          center: [0, 20],
-          zoom: 2,
-          essential: true,
-        });
-      }
-      this.locationWasCleared = true;
-    },
-    undoClearLocation() {
-      if (this.latBeforeClear !== null && this.lngBeforeClear !== null) {
-        this.currentLat = this.latBeforeClear;
-        this.currentLng = this.lngBeforeClear;
-        this.updatePosition(this.currentLat, this.currentLng);
-        this.fetchLocationInfo(this.currentLat, this.currentLng);
-      }
-      this.locationWasCleared = false;
-      this.latBeforeClear = null;
-      this.lngBeforeClear = null;
-    },
-    onCoordinateInputChange() {
-      this.locationWasCleared = false;
 
-      if (this.coordinateInputTimeout) {
-        clearTimeout(this.coordinateInputTimeout);
-      }
-
-      this.coordinateInputTimeout = setTimeout(() => {
-        if (this.isValidCoordinateInput) {
-          this.applyCoordinates();
-        }
-      }, 1000); // 1 second delay after user stops typing
-    },
     onSearchQueryChange(query) {
       if (this.searchTimeout) {
         clearTimeout(this.searchTimeout);
@@ -547,7 +481,6 @@ export default {
         this.currentLng = place.lng;
         this.updatePosition(place.lat, place.lng);
         this.fetchLocationInfo(place.lat, place.lng);
-        this.locationWasCleared = false;
 
         // Clear search after selection
         this.showSearchMenu = false;

--- a/frontend/src/component/location/dialog.vue
+++ b/frontend/src/component/location/dialog.vue
@@ -25,91 +25,93 @@
           </div>
 
           <div
-            class="map-sidebar ml-0 ml-md-4"
+            class="map-sidebar d-flex flex-column ml-0 ml-md-4"
             :style="{
               width: $vuetify.display.smAndDown ? '100%' : '300px',
               maxWidth: $vuetify.display.smAndDown ? '100%' : '300px',
               minWidth: 0,
             }"
           >
-            <v-card border class="pa-3 mb-3">
-              <!-- div class="text-subtitle-2 mb-2">{{ $gettext("Search Places") }}</div -->
-              <v-menu
-                v-model="showSearchMenu"
-                :close-on-content-click="false"
-                location="bottom"
-                origin="top"
-                max-height="300"
+            <div class="d-flex flex-column flex-grow-1 ga-3">
+              <div>
+                <v-menu
+                  v-model="showSearchMenu"
+                  :close-on-content-click="false"
+                  location="bottom"
+                  origin="top"
+                  max-height="300"
+                >
+                  <template #activator="{ props }">
+                    <v-text-field
+                      v-model="searchQuery"
+                      :label="$gettext('Search')"
+                      prepend-inner-icon="mdi-magnify"
+                      :append-inner-icon="
+                        searchLoading ? 'mdi-loading mdi-spin' : searchQuery ? 'mdi-close-circle' : ''
+                      "
+                      density="compact"
+                      variant="outlined"
+                      placeholder="e.g., Berlin, New York, Tokyo"
+                      v-bind="props"
+                      @update:model-value="onSearchQueryChange"
+                      @click:append-inner="clearSearch"
+                      @focus="onSearchFocus"
+                      @blur="onSearchBlur"
+                    ></v-text-field>
+                  </template>
+                  <v-list v-if="searchResults.length > 0" density="compact">
+                    <v-list-item
+                      v-for="place in searchResults"
+                      :key="place.id"
+                      :title="place.formatted"
+                      @click="onPlaceSelected(place)"
+                    >
+                      <template #prepend>
+                        <v-icon>mdi-map-marker</v-icon>
+                      </template>
+                    </v-list-item>
+                  </v-list>
+                  <v-list v-else-if="searchQuery && searchQuery.length >= 2 && !searchLoading">
+                    <v-list-item>
+                      <v-list-item-title>{{ $gettext("No results found") }}</v-list-item-title>
+                    </v-list-item>
+                  </v-list>
+                </v-menu>
+              </div>
+
+              <div v-if="locationInfo">
+                <div class="text-subtitle-2 mb-2">{{ $gettext("Location Details") }}</div>
+                <div class="text-body-2">
+                  {{ simplifiedLocationDisplay }}
+                </div>
+              </div>
+
+              <div>
+                <v-text-field
+                  v-model="coordinateInput"
+                  prepend-inner-icon="mdi-crosshairs-gps"
+                  :append-inner-icon="locationWasCleared ? 'mdi-undo' : coordinateInput ? 'mdi-close-circle' : ''"
+                  density="comfortable"
+                  placeholder="e.g., 52.5208, 13.4049"
+                  persistent-hint
+                  @keydown.enter="applyCoordinates"
+                  @update:model-value="onCoordinateInputChange"
+                  @click:append-inner="locationWasCleared ? undoClearLocation() : clearLocation()"
+                ></v-text-field>
+              </div>
+
+              <div
+                class="d-flex flex-column ga-3 pa-4"
+                style="border: 1px solid rgba(0, 0, 0, 0.12); border-radius: 4px"
               >
-                <template #activator="{ props }">
-                  <v-text-field
-                    v-model="searchQuery"
-                    :label="$gettext('Search')"
-                    prepend-inner-icon="mdi-magnify"
-                    :append-inner-icon="searchLoading ? 'mdi-loading mdi-spin' : searchQuery ? 'mdi-close-circle' : ''"
-                    density="compact"
-                    variant="outlined"
-                    placeholder="e.g., Berlin, New York, Tokyo"
-                    v-bind="props"
-                    @update:model-value="onSearchQueryChange"
-                    @click:append-inner="clearSearch"
-                    @focus="onSearchFocus"
-                    @blur="onSearchBlur"
-                  ></v-text-field>
-                </template>
-                <v-list v-if="searchResults.length > 0" density="compact">
-                  <v-list-item
-                    v-for="place in searchResults"
-                    :key="place.id"
-                    :title="place.formatted"
-                    @click="onPlaceSelected(place)"
-                  >
-                    <template #prepend>
-                      <v-icon>mdi-map-marker</v-icon>
-                    </template>
-                  </v-list-item>
-                </v-list>
-                <v-list v-else-if="searchQuery && searchQuery.length >= 2 && !searchLoading">
-                  <v-list-item>
-                    <v-list-item-title>{{ $gettext("No results found") }}</v-list-item-title>
-                  </v-list-item>
-                </v-list>
-              </v-menu>
-            </v-card>
-
-            <v-card v-if="locationInfo" border class="pa-3 mb-3">
-              <div class="text-subtitle-2 mb-2">{{ $gettext("Location Details") }}</div>
-              <div class="text-body-2">
-                {{ simplifiedLocationDisplay }}
-              </div>
-            </v-card>
-
-            <v-card border class="pa-3 mb-3">
-              <!-- div class="text-subtitle-2 mb-2">{{ $gettext("Position") }}</div -->
-              <v-text-field
-                v-model="coordinateInput"
-                prepend-inner-icon="mdi-crosshairs-gps"
-                :append-inner-icon="locationWasCleared ? 'mdi-undo' : coordinateInput ? 'mdi-close-circle' : ''"
-                density="comfortable"
-                placeholder="e.g., 52.5208, 13.4049"
-                persistent-hint
-                @keydown.enter="applyCoordinates"
-                @update:model-value="onCoordinateInputChange"
-                @click:append-inner="locationWasCleared ? undoClearLocation() : clearLocation()"
-              ></v-text-field>
-            </v-card>
-
-            <v-card border class="pa-3">
-              <!-- div class="text-subtitle-2 mb-2">{{ $gettext("Instructions") }}</div -->
-              <div class="text-body-2 pb-2">
-                {{ $gettext("Click on the map to set a location. Drag the marker for precise positioning.") }}
-              </div>
-              <div class="mt-3">
-                <div class="d-flex flex-wrap ga-2">
+                <div class="text-body-2">
+                  {{ $gettext("Click on the map to set a location. Drag the marker for precise positioning.") }}
+                </div>
+                <div class="d-flex ga-2">
                   <v-btn
                     variant="flat"
                     color="button"
-                    class="action-cancel flex-grow-1"
+                    class="action-cancel"
                     style="min-width: 120px"
                     @click.stop="close"
                   >
@@ -117,7 +119,6 @@
                   </v-btn>
                   <v-btn
                     color="primary"
-                    class="flex-grow-1"
                     style="min-width: 120px"
                     :disabled="!(currentLat !== null && currentLng !== null)"
                     @click="confirm"
@@ -126,7 +127,7 @@
                   </v-btn>
                 </div>
               </div>
-            </v-card>
+            </div>
           </div>
         </div>
       </v-card-text>

--- a/frontend/src/component/location/dialog.vue
+++ b/frontend/src/component/location/dialog.vue
@@ -17,10 +17,6 @@
         <v-toolbar-title>
           {{ $gettext("Set Location") }}
         </v-toolbar-title>
-        <v-spacer></v-spacer>
-        <v-btn v-if="!$vuetify.display.mdAndDown" icon class="action-close" @click.stop="close">
-          <v-icon>mdi-close</v-icon>
-        </v-btn>
       </v-toolbar>
       <v-card-text class="pa-0">
         <div class="d-flex flex-column flex-md-row py-4 px-2">

--- a/frontend/src/component/location/dialog.vue
+++ b/frontend/src/component/location/dialog.vue
@@ -9,17 +9,26 @@
     @after-leave="onDialogClosed"
   >
     <v-card :tile="$vuetify.display.mdAndDown">
-      <v-toolbar flat color="navigation" :density="$vuetify.display.smAndDown ? 'compact' : 'default'" class="px-4">
-        <v-btn v-if="$vuetify.display.mdAndDown" icon @click.stop="close">
+      <v-toolbar
+        v-if="$vuetify.display.mdAndDown"
+        flat
+        color="navigation"
+        class="mb-4"
+        :density="$vuetify.display.smAndDown ? 'compact' : 'default'"
+      >
+        <v-btn icon @click.stop="close">
           <v-icon>mdi-close</v-icon>
         </v-btn>
-        <v-icon v-else color="primary" class="mr-3">mdi-map-marker</v-icon>
         <v-toolbar-title>
           {{ $gettext("Set Location") }}
         </v-toolbar-title>
       </v-toolbar>
+      <v-card-title v-else class="d-flex justify-start align-center ga-3">
+        <v-icon size="28" color="primary">mdi-map-marker</v-icon>
+        <h6 class="text-h6">{{ $gettext("Set Location") }}</h6>
+      </v-card-title>
       <v-card-text class="pa-0">
-        <div class="d-flex flex-column flex-md-row py-4 px-2">
+        <div class="d-flex flex-column flex-md-row">
           <div class="flex-grow-1 position-relative mb-4 mb-md-0">
             <div ref="map" class="p-map" style="height: 50vh; min-height: 300px; width: 100%; border-radius: 4px"></div>
           </div>
@@ -100,26 +109,17 @@
                 ></v-text-field>
               </div>
 
-              <div
-                class="d-flex flex-column ga-3 pa-4"
-                style="border: 1px solid rgba(0, 0, 0, 0.12); border-radius: 4px"
-              >
+              <div class="d-flex flex-column ga-3 pa-4 border rounded">
                 <div class="text-body-2">
                   {{ $gettext("Click on the map to set a location. Drag the marker for precise positioning.") }}
                 </div>
                 <div class="d-flex ga-2">
-                  <v-btn
-                    variant="flat"
-                    color="button"
-                    class="action-cancel"
-                    style="min-width: 120px"
-                    @click.stop="close"
-                  >
+                  <v-btn variant="flat" color="button" class="action-cancel" min-width="120" @click.stop="close">
                     {{ $gettext("Cancel") }}
                   </v-btn>
                   <v-btn
                     color="primary"
-                    style="min-width: 120px"
+                    min-width="120"
                     :disabled="!(currentLat !== null && currentLng !== null)"
                     @click="confirm"
                   >

--- a/frontend/src/component/photo/edit/details.vue
+++ b/frontend/src/component/photo/edit/details.vue
@@ -710,7 +710,7 @@ export default {
       const lng = this.view.model.Lng;
 
       if (lat !== null && lng !== null && !(lat === 0 && lng === 0) && !isNaN(lat) && !isNaN(lng)) {
-        this.coordinateInput = `${parseFloat(lat).toFixed(6)}, ${parseFloat(lng).toFixed(6)}`;
+        this.coordinateInput = `${parseFloat(lat)}, ${parseFloat(lng)}`;
       } else {
         this.coordinateInput = "";
       }

--- a/frontend/src/component/photo/edit/details.vue
+++ b/frontend/src/component/photo/edit/details.vue
@@ -187,45 +187,24 @@
               ></v-text-field>
             </v-col>
             <v-col cols="12" md="6">
-              <v-text-field
-                v-model="coordinateInput"
+              <p-coordinate-input
+                :latitude="view.model.Lat"
+                :longitude="view.model.Lng"
                 :disabled="disabled"
                 hide-details
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="none"
                 :label="$gettext('Coordinates')"
                 placeholder="e.g., 52.5208, 13.4049"
                 density="comfortable"
                 validate-on="input"
-                :rules="[() => !coordinateInput || isValidCoordinateInput]"
+                :show-map-button="!placesDisabled"
+                :map-button-title="$gettext('Choose Location')"
+                :map-button-disabled="placesDisabled"
                 class="input-coordinates"
-                @keydown.enter="applyCoordinates"
-                @update:model-value="onCoordinateInputChange"
-                @paste="pastePosition"
-              >
-                <template #prepend-inner>
-                  <v-icon
-                    v-if="!placesDisabled"
-                    variant="plain"
-                    icon="mdi-crosshairs-gps"
-                    :title="$gettext('Choose Location')"
-                    :disabled="placesDisabled"
-                    class="action-map"
-                    @click.stop="openMapDialog"
-                  >
-                  </v-icon>
-                </template>
-                <template #append-inner>
-                  <v-icon
-                    v-if="coordinateInput"
-                    variant="plain"
-                    icon="mdi-close-circle"
-                    class="action-clear"
-                    @click.stop="clearLocation"
-                  ></v-icon>
-                </template>
-              </v-text-field>
+                @update:latitude="updateLatitude"
+                @update:longitude="updateLongitude"
+                @coordinates-changed="onCoordinatesChanged"
+                @open-map="openMapDialog"
+              ></p-coordinate-input>
             </v-col>
             <v-col cols="12" md="6" class="p-camera-select">
               <v-select
@@ -454,11 +433,13 @@ import Thumb from "model/thumb";
 import * as options from "options/options";
 import { rules } from "common/form";
 import PLocationDialog from "component/location/dialog.vue";
+import PCoordinateInput from "component/location/coordinate-input.vue";
 
 export default {
   name: "PTabPhotoDetails",
   components: {
     PLocationDialog,
+    PCoordinateInput,
   },
   props: {
     uid: {
@@ -488,7 +469,6 @@ export default {
       rtl: this.$isRtl,
       mapDialogVisible: false,
       placesDisabled: !this.$config.feature("places"),
-      coordinateInput: "",
     };
   },
   computed: {
@@ -501,32 +481,14 @@ export default {
     inReview() {
       return this.featReview && this.view.model.Quality < 3;
     },
-    isValidCoordinateInput() {
-      if (!this.coordinateInput) return false;
-
-      const parts = this.coordinateInput.split(",").map((part) => part.trim());
-      if (parts.length !== 2) return false;
-
-      const lat = parseFloat(parts[0]);
-      const lng = parseFloat(parts[1]);
-
-      return !isNaN(lat) && !isNaN(lng) && lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
-    },
   },
   watch: {
-    "uid"() {
+    uid() {
       this.syncTime();
-    },
-    "view.model.Lat"() {
-      this.updateCoordinateInput();
-    },
-    "view.model.Lng"() {
-      this.updateCoordinateInput();
     },
   },
   created() {
     this.syncTime();
-    this.updateCoordinateInput();
   },
   methods: {
     setDay(v) {
@@ -575,36 +537,7 @@ export default {
       const taken = this.view.model.getDateTime();
       this.time = taken.toFormat("HH:mm:ss");
     },
-    pastePosition(event) {
-      // Autofill the lat and lng fields if the text in the clipboard contains two float values.
-      const clipboard = event.clipboardData ? event.clipboardData : window.clipboardData;
 
-      if (!clipboard) {
-        return;
-      }
-
-      // Get values from browser clipboard.
-      const text = clipboard.getData("text");
-
-      // Trim spaces before splitting by whitespace and/or commas.
-      const val = text.trim().split(/[ ,]+/);
-
-      // Two values found?
-      if (val.length >= 2) {
-        // Parse values.
-        const lat = parseFloat(val[0]);
-        const lng = parseFloat(val[1]);
-
-        // Lat and long must be valid floating point numbers.
-        if (!isNaN(lat) && lat >= -90 && lat <= 90 && !isNaN(lng) && lng >= -180 && lng <= 180) {
-          // Update view.model values.
-          this.view.model.Lat = lat;
-          this.view.model.Lng = lng;
-          // Prevent default action.
-          event.preventDefault();
-        }
-      }
-    },
     updateModel() {
       if (!this.view?.model.hasId()) {
         return;
@@ -669,50 +602,24 @@ export default {
     },
     updateLocation(data) {
       if (data && data.latitude !== undefined && data.longitude !== undefined) {
-        this.view.model.Lat = data.latitude;
-        this.view.model.Lng = data.longitude;
-        this.view.model.PlaceSrc = "manual";
-
-        // Clear country and altitude when coordinates are cleared (0,0)
-        if (data.latitude === 0 && data.longitude === 0) {
-          this.view.model.Country = "zz"; // "Unknown" country code
-          this.view.model.Altitude = "0";
-        }
+        this.updateLatitude(data.latitude);
+        this.updateLongitude(data.longitude);
+        this.onCoordinatesChanged(data);
       }
     },
-    onCoordinateInputChange(value) {
-      this.coordinateInput = value;
-
-      if (this.isValidCoordinateInput) {
-        this.applyCoordinates();
-      }
-    },
-    applyCoordinates() {
-      if (!this.isValidCoordinateInput) return;
-
-      const parts = this.coordinateInput.split(",").map((part) => part.trim());
-      const lat = parseFloat(parts[0]);
-      const lng = parseFloat(parts[1]);
-
-      // Update underlying model
+    updateLatitude(lat) {
       this.view.model.Lat = lat;
+      this.view.model.PlaceSrc = "manual";
+    },
+    updateLongitude(lng) {
       this.view.model.Lng = lng;
       this.view.model.PlaceSrc = "manual";
     },
-    clearLocation() {
-      this.view.model.Lat = 0;
-      this.view.model.Lng = 0;
-      this.view.model.PlaceSrc = "manual";
-      this.updateCoordinateInput();
-    },
-    updateCoordinateInput() {
-      const lat = this.view.model.Lat;
-      const lng = this.view.model.Lng;
-
-      if (lat !== null && lng !== null && !(lat === 0 && lng === 0) && !isNaN(lat) && !isNaN(lng)) {
-        this.coordinateInput = `${parseFloat(lat)}, ${parseFloat(lng)}`;
-      } else {
-        this.coordinateInput = "";
+    onCoordinatesChanged(data) {
+      // Clear country and altitude when coordinates are cleared (0,0)
+      if (data.latitude === 0 && data.longitude === 0) {
+        this.view.model.Country = "zz"; // "Unknown" country code
+        this.view.model.Altitude = "0";
       }
     },
   },

--- a/frontend/src/component/photo/edit/details.vue
+++ b/frontend/src/component/photo/edit/details.vue
@@ -186,21 +186,22 @@
                 style="flex: 0 0 120px"
               ></v-text-field>
             </v-col>
-            <v-col cols="7" md="3">
+            <v-col cols="12" md="6">
               <v-text-field
-                v-model="view.model.Lat"
+                v-model="coordinateInput"
                 :disabled="disabled"
                 hide-details
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="none"
-                :label="$gettext('Latitude')"
-                placeholder=""
+                :label="$gettext('Coordinates')"
+                placeholder="e.g., 52.5208, 13.4049"
                 density="comfortable"
                 validate-on="input"
-                :rules="rules.lat(false)"
-                class="input-latitude"
-                style="flex: 1"
+                :rules="[() => !coordinateInput || isValidCoordinateInput]"
+                class="input-coordinates"
+                @keydown.enter="applyCoordinates"
+                @update:model-value="onCoordinateInputChange"
                 @paste="pastePosition"
               >
                 <template #prepend-inner>
@@ -214,27 +215,16 @@
                     @click.stop="openMapDialog"
                   >
                   </v-icon>
-                  <!-- v-icon v-if="view.model.PlaceSrc === 'manual'" variant="plain" icon="mdi-check"> </v-icon -->
                 </template>
-              </v-text-field>
-            </v-col>
-            <v-col cols="5" md="3">
-              <v-text-field
-                v-model="view.model.Lng"
-                :disabled="disabled"
-                hide-details
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="none"
-                :label="$gettext('Longitude')"
-                placeholder=""
-                density="comfortable"
-                validate-on="input"
-                :rules="rules.lng(false)"
-                class="input-longitude"
-                style="flex: 1"
-                @paste="pastePosition"
-              >
+                <template #append-inner>
+                  <v-icon
+                    v-if="coordinateInput"
+                    variant="plain"
+                    icon="mdi-close-circle"
+                    class="action-clear"
+                    @click.stop="clearLocation"
+                  ></v-icon>
+                </template>
               </v-text-field>
             </v-col>
             <v-col cols="12" md="6" class="p-camera-select">
@@ -498,6 +488,7 @@ export default {
       rtl: this.$isRtl,
       mapDialogVisible: false,
       placesDisabled: !this.$config.feature("places"),
+      coordinateInput: "",
     };
   },
   computed: {
@@ -510,14 +501,32 @@ export default {
     inReview() {
       return this.featReview && this.view.model.Quality < 3;
     },
+    isValidCoordinateInput() {
+      if (!this.coordinateInput) return false;
+
+      const parts = this.coordinateInput.split(",").map((part) => part.trim());
+      if (parts.length !== 2) return false;
+
+      const lat = parseFloat(parts[0]);
+      const lng = parseFloat(parts[1]);
+
+      return !isNaN(lat) && !isNaN(lng) && lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
+    },
   },
   watch: {
-    uid() {
+    "uid"() {
       this.syncTime();
+    },
+    "view.model.Lat"() {
+      this.updateCoordinateInput();
+    },
+    "view.model.Lng"() {
+      this.updateCoordinateInput();
     },
   },
   created() {
     this.syncTime();
+    this.updateCoordinateInput();
   },
   methods: {
     setDay(v) {
@@ -669,6 +678,41 @@ export default {
           this.view.model.Country = "zz"; // "Unknown" country code
           this.view.model.Altitude = "0";
         }
+      }
+    },
+    onCoordinateInputChange(value) {
+      this.coordinateInput = value;
+
+      if (this.isValidCoordinateInput) {
+        this.applyCoordinates();
+      }
+    },
+    applyCoordinates() {
+      if (!this.isValidCoordinateInput) return;
+
+      const parts = this.coordinateInput.split(",").map((part) => part.trim());
+      const lat = parseFloat(parts[0]);
+      const lng = parseFloat(parts[1]);
+
+      // Update underlying model
+      this.view.model.Lat = lat;
+      this.view.model.Lng = lng;
+      this.view.model.PlaceSrc = "manual";
+    },
+    clearLocation() {
+      this.view.model.Lat = 0;
+      this.view.model.Lng = 0;
+      this.view.model.PlaceSrc = "manual";
+      this.updateCoordinateInput();
+    },
+    updateCoordinateInput() {
+      const lat = this.view.model.Lat;
+      const lng = this.view.model.Lng;
+
+      if (lat !== null && lng !== null && !(lat === 0 && lng === 0) && !isNaN(lat) && !isNaN(lng)) {
+        this.coordinateInput = `${parseFloat(lat).toFixed(6)}, ${parseFloat(lng).toFixed(6)}`;
+      } else {
+        this.coordinateInput = "";
       }
     },
   },


### PR DESCRIPTION
The changes made here include the improvements mentioned in this comment 

> - [X] Use a single input field for latitude and longitude in the photo edit dialog, similar to the one in the new selection dialog.
> - [X] Use a flex/grid-based layout for the form instead of v-card components, similar to other existing dialogs.
> - [X] This way, it should be easy to position the Cancel and Apply buttons at the bottom of the right column in desktop browsers, as in other dialogs.
> - [X] Currently, our other dialogs do not have a close button in the upper-right corner when using a desktop browser. For now, I would remove it unless we decide to implement it everywhere, which could require a lot more work.

Original comment https://github.com/photoprism/photoprism/issues/465#issuecomment-3002430996

#### Related Issues and PR

- #465 
- #5043 

