### PR TITLE
SQLite: Fix "too many SQL variables" error when flagging pictures as hidden

### DIFF
--- a/internal/entity/query/photo.go
+++ b/internal/entity/query/photo.go
@@ -185,7 +185,7 @@ func FlagHiddenPhotos() (err error) {
 
 	ids := Db().Select("id").
 		Where("id NOT IN (SELECT photo_id FROM files WHERE file_primary = 1 AND file_missing = 0 AND file_error = '' AND deleted_at IS NULL) AND photo_quality > -1").
-		Table(entity.Photo{}.TableName())
+		Table(entity.Photo{}.TableName()).SubQuery()
 	if result := UnscopedDb().Table(entity.Photo{}.TableName()).
 		Where("id IN (?) AND photo_quality > -1", ids).
 		UpdateColumn("photo_quality", -1); result.Error != nil {

--- a/internal/entity/query/photo.go
+++ b/internal/entity/query/photo.go
@@ -180,48 +180,20 @@ func FlagHiddenPhotos() (err error) {
 	// Start time for logs.
 	start := time.Now()
 
-	// IDs of hidden photos.
-	var hidden []uint
-
 	// Number of updated records.
 	affected := 0
 
-	// Find and flag hidden photos.
-	if err = Db().Table(entity.Photo{}.TableName()).
+	ids := Db().Select("id").
 		Where("id NOT IN (SELECT photo_id FROM files WHERE file_primary = 1 AND file_missing = 0 AND file_error = '' AND deleted_at IS NULL) AND photo_quality > -1").
-		Pluck("id", &hidden).Error; err != nil {
-		// Find query failed.
-		return err
-	} else if found := len(hidden); found == 0 {
-		// Nothing to update.
-		return nil
+		Table(entity.Photo{}.TableName())
+	if result := UnscopedDb().Table(entity.Photo{}.TableName()).
+		Where("id IN (?) AND photo_quality > -1", ids).
+		UpdateColumn("photo_quality", -1); result.Error != nil {
+		// Failed to flag all hidden photos.
+		log.Warnf("index: failed to flag photos as hidden")
+		return fmt.Errorf("%s while flagging hidden photos", result.Error)
 	} else {
-		// Update photos in batches to be compatible with SQLite.
-		batchSize := BatchSize()
-
-		for i := 0; i < len(hidden); i += batchSize {
-			j := i + batchSize
-
-			if j > len(hidden) {
-				j = len(hidden)
-			}
-
-			// Next batch.
-			ids := hidden[i:j]
-
-			// Set photos.photo_quality = -1.
-			if result := UnscopedDb().Table(entity.Photo{}.TableName()).
-				Where("id IN (?) AND photo_quality > -1", ids).
-				UpdateColumn("photo_quality", -1); result.Error != nil {
-				// Failed to flag all hidden photos.
-				log.Warnf("index: failed to flag %d photos as hidden", len(hidden)-affected)
-				return fmt.Errorf("%s while flagging hidden photos", result.Error)
-			} else if result.RowsAffected > 0 {
-				affected += int(result.RowsAffected)
-			} else {
-				affected += len(ids)
-			}
-		}
+		affected = int(result.RowsAffected)
 	}
 
 	// Log number of affected rows, if any.


### PR DESCRIPTION
### Description

These changes fix issue #3742 SQLite: Fix "too many SQL variables" error when updating the index
It is achieved by refactoring the two SQL statements into single statement.
A new test has been added to test that 1000 photos can be flagged as hidden.

#### Related Issues

- Issue #3742

### Acceptance Criteria

- [X] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [X] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [X] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+



### Testing Results
#### SQLite
```
photoprism@250502-plucky:/go/src/github.com/photoprism/photoprism/internal/entity/query$ go test -v -run FlagHiddenPhotos
     | time="2025-06-26T10:31:54Z" level=info msg="initializing sqlite3 test db in .test.db"
     | time="2025-06-26T10:31:54Z" level=debug msg="migrate: running database migrations"
     | time="2025-06-26T10:31:54Z" level=info msg="migrate: 20221015-100000 successful [3.132394ms]"
     | time="2025-06-26T10:31:54Z" level=info msg="migrate: 20221015-100100 successful [4.173835ms]"
     | time="2025-06-26T10:31:54Z" level=info msg="migrate: 20240709-000001 successful [3.20308ms]"
     | time="2025-06-26T10:31:54Z" level=info msg="migrate: 20250117-000001 successful [3.488882ms]"
     | time="2025-06-26T10:31:54Z" level=info msg="migrate: 20250315-000001 successful [7.798259ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20211121-094727 successful [3.090782ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20211124-120008 successful [2.628217ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220329-040000 successful [3.997414ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220329-050000 successful [4.457904ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220329-061000 successful [3.261677ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220329-071000 successful [2.8366ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220329-081000 successful [5.297377ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220329-083000 successful [2.84964ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220329-091000 successful [10.998087ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220329-093000 successful [4.257711ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20220421-200000 successful [9.452199ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20230309-000001 successful [3.076135ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20230313-000001 successful [2.873759ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20240112-000001 successful [4.393036ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20241010-000001 successful [2.777557ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20241202-000001 successful [5.077835ms]"
     | time="2025-06-26T10:31:55Z" level=info msg="migrate: 20250416-000001 successful [6.595396ms]"
     | time="2025-06-26T10:31:56Z" level=debug msg="search: updated index [6.595294ms]"
     | time="2025-06-26T10:31:56Z" level=debug msg="migrate: recreated test fixtures [1.766783175s]"
     | time="2025-06-26T10:31:56Z" level=debug msg="search: updated index [5.868548ms]"
     | time="2025-06-26T10:31:56Z" level=debug msg="migrate: completed in 1.773548679s"
START| FlagHiddenPhotos
START|   FlagHiddenPhotos/Success
     | time="2025-06-26T10:31:56Z" level=info msg="index: flagged 6 photos as hidden [2.237976ms]"
START|   FlagHiddenPhotos/SuccessWith1000
     | time="2025-06-26T10:31:59Z" level=info msg="index: flagged 1,000 photos as hidden [8.322035ms]"
PASS | FlagHiddenPhotos (3.11s)
PASS |   FlagHiddenPhotos/Success (0.00s)
PASS |   FlagHiddenPhotos/SuccessWith1000 (3.10s)
PASS | github.com/photoprism/photoprism/internal/entity/query 
```

#### MariaDB
```
photoprism@250502-plucky:/go/src/github.com/photoprism/photoprism/internal/entity/query$ PHOTOPRISM_TEST_DRIVER="mysql" PHOTOPRISM_TEST_DSN="root:photoprism@tcp(mariadb:4001)/acceptance?charset=utf8mb4,utf8&collation=utf8mb4_unicode_ci&parseTime=true" go test -v -run FlagHiddenPhotos
     | time="2025-06-26T10:36:48Z" level=info msg="initializing mysql test db in root:photoprism@tcp(mariadb:4001)/acceptance?charset=utf8mb4,utf8&collation=utf8mb4_unicode_ci&parseTime=true"
     | time="2025-06-26T10:36:48Z" level=debug msg="migrate: running database migrations"
     | time="2025-06-26T10:36:48Z" level=info msg="migrate: 20221015-100000 successful [2.109834ms]"
     | time="2025-06-26T10:36:48Z" level=info msg="migrate: 20221015-100100 successful [2.025473ms]"
     | time="2025-06-26T10:36:48Z" level=info msg="migrate: 20240709-000001 successful [1.783619ms]"
     | time="2025-06-26T10:36:48Z" level=info msg="migrate: 20250117-000001 successful [2.778222ms]"
     | time="2025-06-26T10:36:48Z" level=info msg="migrate: 20250315-000001 successful [1.666818ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20211121-094727 successful [3.996243ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20211124-120008 successful [3.441587ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-030000 successful [11.309296ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-040000 successful [13.304296ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-050000 successful [4.219959ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-060000 successful [96.085722ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-061000 successful [3.425215ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-070000 successful [7.002793ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-071000 successful [2.93139ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-080000 successful [9.344792ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-081000 successful [16.383025ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-083000 successful [4.023955ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-090000 successful [9.462409ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-091000 successful [6.802387ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220329-093000 successful [1.973018ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220421-200000 successful [12.199857ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220521-000001 successful [25.034879ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220521-000002 successful [5.110898ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220521-000003 successful [27.832ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20220927-000100 successful [6.921984ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20221002-000100 successful [1.925026ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20230102-000001 successful [10.913788ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20230211-000001 successful [10.009452ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20230309-000001 successful [3.333204ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20230313-000001 successful [1.954821ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20240112-000001 successful [16.221271ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20240701-000001 successful [10.3318ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20240915-000001 successful [15.836132ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20241010-000001 successful [2.780246ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20241202-000001 successful [2.428118ms]"
     | time="2025-06-26T10:36:49Z" level=info msg="migrate: 20250416-000001 successful [2.740056ms]"
     | time="2025-06-26T10:36:50Z" level=debug msg="search: updated index [7.686369ms]"
     | time="2025-06-26T10:36:50Z" level=debug msg="migrate: recreated test fixtures [2.366359084s]"
     | time="2025-06-26T10:36:50Z" level=debug msg="search: updated index [1.070773ms]"
     | time="2025-06-26T10:36:50Z" level=debug msg="migrate: completed in 2.367778172s"
START| FlagHiddenPhotos
START|   FlagHiddenPhotos/Success
     | time="2025-06-26T10:36:50Z" level=info msg="index: flagged 6 photos as hidden [2.025331ms]"
START|   FlagHiddenPhotos/SuccessWith1000
     | time="2025-06-26T10:36:52Z" level=info msg="index: flagged 1,000 photos as hidden [11.028382ms]"
PASS | FlagHiddenPhotos (1.50s)
PASS |   FlagHiddenPhotos/Success (0.00s)
PASS |   FlagHiddenPhotos/SuccessWith1000 (1.50s)
PASS | github.com/photoprism/photoprism/internal/entity/query 
```