### PR TITLE
Metadata: Update list of unwanted descriptions

### DIFF
--- a/internal/meta/sanitize.go
+++ b/internal/meta/sanitize.go
@@ -14,6 +14,9 @@ var UnwantedStrings = map[string]bool{
 	"Created by Imlib":         true, // Apps
 	"iClarified":               true,
 	"OLYMPUS DIGITAL CAMERA":   true, // Olympus
+	"MEDION DIGITAL CAMERA":    true, // Medion
+	"My beautiful picture":     true,
+	"HELLOMOTO":                true, // Motorola
 	"SAMSUNG":                  true, // Samsung
 	"SAMSUNG CAMERA PICTURES":  true,
 	"<Digimax i5, Samsung #1>": true,
@@ -45,11 +48,16 @@ var UnwantedStrings = map[string]bool{
 	"cof":                      true,
 	"qrf":                      true,
 	"fshbty":                   true,
+	"_cuva":                    true,
+	"smart":                    true,
+	"hdr":                      true,
+	"bsh":                      true,
 	"binary comment":           true, // Other
 	"default":                  true,
 	"Exif_JPEG_PICTURE":        true,
 	"DVC 10.1 HDMI":            true,
 	"charset=Ascii":            true,
+	"Digital Camera":           true,
 }
 
 var LowerCaseRegexp = regexp.MustCompile("[a-z\\d_\\-]+")


### PR DESCRIPTION
Just scanned my collection for dubious image captions coming from EXIF data. Huawei seems to be most notorious here, but a few other popped up. FYI, here's the numbers from my collection:

```
+-----------------------+-----+-------------------------------+
| photo_caption         | cnt | camera                        |
+-----------------------+-----+-------------------------------+
| _cuva                 | 786 | HUAWEI Pura 70 Pro+           |
| smart                 |  58 | HUAWEI CTR-AL00               |
| My beautiful picture  |  56 | Medion 636Z3                  |
| hdr                   |  41 | HUAWEI C8817E                 |
| HELLOMOTO             |  26 | Motorola Phone                |
| MEDION DIGITAL CAMERA |  22 | MEDION OPTICAL CO,LTD MD411Z3 |
| bsh                   |  14 | HUAWEI P20 Pro                |
| Digital Camera        |   8 | Unknown                       |
+-----------------------+-----+-------------------------------+
```