### PR TITLE
Videos: Refactor slice to array conversion

### DIFF
--- a/pkg/media/video/chunks.go
+++ b/pkg/media/video/chunks.go
@@ -82,7 +82,7 @@ func (c Chunks) FileTypeOffset(file io.ReadSeeker) (int, error) {
 			// Not found.
 		} else if j := i + 4; j < 8 || len(buffer) < j+4 {
 			// Skip.
-		} else if k := j + 4; c.Contains(*(*[4]byte)(buffer[j:k])) {
+		} else if k := j + 4; c.Contains([4]byte(buffer[j:k])) {
 			return offset + i - 4, nil
 		}
 

--- a/pkg/media/video/chunks_test.go
+++ b/pkg/media/video/chunks_test.go
@@ -114,8 +114,8 @@ func TestChunks(t *testing.T) {
 			t.Fatalf("expected to read 12 bytes instead of %d", n)
 		}
 
-		assert.NotEqual(t, ChunkFTYP, *(*[4]byte)(b[4:8]))
-		assert.NotEqual(t, ChunkISOM, *(*[4]byte)(b[8:12]))
+		assert.NotEqual(t, ChunkFTYP, [4]byte(b[4:8]))
+		assert.NotEqual(t, ChunkISOM, [4]byte(b[8:12]))
 	})
 }
 


### PR DESCRIPTION
### Description

These changes improve the codebase by simplifying slice-to-array conversions.

Since Go 1.20, it's possible to convert from a slice to an array using simpler syntax. This PR updates existing conversions to use the new native syntax.

References:

- https://go.dev/ref/spec#Conversions_from_slice_to_array_or_array_pointer
- https://github.com/golang/go/issues/69820