### PR TITLE
feat: use a smaller skeleton when calling useradd

### DIFF
--- a/docker/develop/armv7/Dockerfile
+++ b/docker/develop/armv7/Dockerfile
@@ -73,10 +73,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     cp -r /etc/skel/.config /root/.config && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     cp /scripts/convert/policy.xml /etc/ImageMagick-6/policy.xml && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \

--- a/docker/develop/bookworm-slim/Dockerfile
+++ b/docker/develop/bookworm-slim/Dockerfile
@@ -55,11 +55,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
       libmatroska-dev libdvdread-dev libebml5 libgav1-bin libatomic1 \
       iputils-ping dnsutils binutils binutils-gold \
     && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
       /photoprism/originals \

--- a/docker/develop/bookworm/Dockerfile
+++ b/docker/develop/bookworm/Dockerfile
@@ -79,10 +79,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     cp -r /etc/skel/.config /root/.config && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     cp /scripts/convert/policy.xml /etc/ImageMagick-6/policy.xml && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \

--- a/docker/develop/bullseye-slim/Dockerfile
+++ b/docker/develop/bullseye-slim/Dockerfile
@@ -75,11 +75,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     && \
     /scripts/install-mariadb.sh mariadb-client && \
     /scripts/install-darktable.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
       /photoprism/originals \

--- a/docker/develop/bullseye/Dockerfile
+++ b/docker/develop/bullseye/Dockerfile
@@ -117,10 +117,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-darktable.sh && \
     /scripts/install-go-tools.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: ALL" >> /etc/sudoers.d/all && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
       /photoprism/originals \

--- a/docker/develop/buster/Dockerfile
+++ b/docker/develop/buster/Dockerfile
@@ -113,10 +113,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-darktable.sh && \
     /scripts/install-go-tools.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: ALL" >> /etc/sudoers.d/all && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
       /photoprism/originals \

--- a/docker/develop/impish/Dockerfile
+++ b/docker/develop/impish/Dockerfile
@@ -111,11 +111,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-chrome.sh && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: ALL" >> /etc/sudoers.d/all && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
       /photoprism/originals \

--- a/docker/develop/jammy-slim/Dockerfile
+++ b/docker/develop/jammy-slim/Dockerfile
@@ -59,11 +59,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-darktable.sh && \
     /scripts/install-yt-dlp.sh && \
     /scripts/install-libheif.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
         /photoprism/originals \

--- a/docker/develop/jammy/Dockerfile
+++ b/docker/develop/jammy/Dockerfile
@@ -87,10 +87,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     cp -r /etc/skel/.config /root/.config && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     cp /scripts/convert/policy.xml /etc/ImageMagick-6/policy.xml && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \

--- a/docker/develop/lunar-slim/Dockerfile
+++ b/docker/develop/lunar-slim/Dockerfile
@@ -54,11 +54,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-mariadb.sh mariadb-client && \
     /scripts/install-darktable.sh && \
     /scripts/install-libheif.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
         /photoprism/originals \

--- a/docker/develop/lunar/Dockerfile
+++ b/docker/develop/lunar/Dockerfile
@@ -78,10 +78,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: ALL" >> /etc/sudoers.d/all && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     cp /scripts/convert/policy.xml /etc/ImageMagick-6/policy.xml && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \

--- a/docker/develop/mantic-slim/Dockerfile
+++ b/docker/develop/mantic-slim/Dockerfile
@@ -54,11 +54,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-mariadb.sh mariadb-client && \
     /scripts/install-darktable.sh && \
     /scripts/install-libheif.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
         /photoprism/originals \

--- a/docker/develop/mantic/Dockerfile
+++ b/docker/develop/mantic/Dockerfile
@@ -78,10 +78,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: ALL" >> /etc/sudoers.d/all && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     cp /scripts/convert/policy.xml /etc/ImageMagick-6/policy.xml && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \

--- a/docker/develop/noble-slim/Dockerfile
+++ b/docker/develop/noble-slim/Dockerfile
@@ -56,11 +56,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-mariadb.sh mariadb-client && \
     /scripts/install-darktable.sh && \
     /scripts/install-libheif.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
         /photoprism/originals \

--- a/docker/develop/noble/Dockerfile
+++ b/docker/develop/noble/Dockerfile
@@ -83,10 +83,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     cp -r /etc/skel/.config /root/.config && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     cp /scripts/convert/policy.xml /etc/ImageMagick-6/policy.xml && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \

--- a/docker/develop/oracular-slim/Dockerfile
+++ b/docker/develop/oracular-slim/Dockerfile
@@ -59,11 +59,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-mariadb.sh mariadb-client && \
     /scripts/install-darktable.sh && \
     /scripts/install-libheif.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
         /photoprism/originals \

--- a/docker/develop/oracular/Dockerfile
+++ b/docker/develop/oracular/Dockerfile
@@ -86,10 +86,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     cp -r /etc/skel/.config /root/.config && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     cp /scripts/convert/policy.xml /etc/ImageMagick-6/policy.xml && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \

--- a/docker/develop/plucky-slim/Dockerfile
+++ b/docker/develop/plucky-slim/Dockerfile
@@ -60,11 +60,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     /scripts/install-darktable.sh && \
     /scripts/install-yt-dlp.sh && \
     /scripts/install-libheif.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
         /photoprism/originals \

--- a/docker/develop/plucky/Dockerfile
+++ b/docker/develop/plucky/Dockerfile
@@ -92,10 +92,8 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     cp -r /etc/skel/.config /root/.config && \
     /scripts/install-go.sh && \
     /scripts/install-go-tools.sh && \
-    echo 'alias go=richgo ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     cp /scripts/convert/policy.xml /etc/ImageMagick-7/policy.xml && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \

--- a/docker/photoprism/armv7/Dockerfile
+++ b/docker/photoprism/armv7/Dockerfile
@@ -114,11 +114,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
     && \
     /scripts/install-yt-dlp.sh && \
     /scripts/install-libheif.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
         /photoprism/originals \

--- a/docker/photoprism/buster/Dockerfile
+++ b/docker/photoprism/buster/Dockerfile
@@ -117,11 +117,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
       libavcodec-extra \
     && \
     /scripts/install-darktable.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
       /photoprism/originals \

--- a/docker/photoprism/impish/Dockerfile
+++ b/docker/photoprism/impish/Dockerfile
@@ -116,11 +116,9 @@ RUN echo 'APT::Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries && \
       libavcodec-extra \
     && \
     /scripts/install-darktable.sh && \
-    echo 'alias ll="ls -alh"' >> /etc/skel/.bashrc && \
-    echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/skel/.bashrc && \
+    /scripts/install-bashrc.sh && \
     echo "ALL ALL=(ALL) NOPASSWD:SETENV: /scripts/entrypoint-init.sh" >> /etc/sudoers.d/init && \
     /scripts/install-dircolors.sh && \
-    cp /etc/skel/.bashrc /root/.bashrc && \
     /scripts/create-users.sh && \
     install -d -m 0777 -o 1000 -g 1000 \
       /photoprism/originals \

--- a/scripts/dist/create-users.sh
+++ b/scripts/dist/create-users.sh
@@ -39,16 +39,23 @@ echo "✅ Added group photoprism (1000)."
 # add existing www-data user to groups
 usermod -a -G photoprism,video,davfs2,renderd,render,ssl-cert,videodriver www-data
 
+# a directory that will be used as a custom skeleton when creating users
+SKELETON="/tmp/custom-skeleton"
+mkdir --parents "${SKELETON}"
+
+# copy the .config/ directory from the default skeleton
+cp -r /etc/skel/.config/ ${SKELETON}/.config/
+
 # create user 'videodriver'
 userdel -r -f videodriver >/dev/null 2>&1
-useradd -u 937 -r -N -g 937 -G photoprism,www-data,video,davfs2,renderd,render,ssl-cert -s /bin/bash -m -d "/home/videodriver" videodriver
+useradd -u 937 -r -N -g 937 -G photoprism,www-data,video,davfs2,renderd,render,ssl-cert -s /bin/bash -m -d "/home/videodriver" --skel "${SKELETON}" videodriver
 echo "✅ Added user videodriver (937)."
 
 # create user 'photoprism'
 userdel -r -f ubuntu >/dev/null 2>&1
 userdel -r -f photoprism >/dev/null 2>&1
 userdel -r -f 1000 >/dev/null 2>&1
-useradd -u 1000 -N -g photoprism -G www-data,video,davfs2,renderd,render,ssl-cert,videodriver -s /bin/bash -m -d "/home/photoprism" photoprism
+useradd -u 1000 -N -g photoprism -G www-data,video,davfs2,renderd,render,ssl-cert,videodriver -s /bin/bash -m -d "/home/photoprism" --skel "${SKELETON}" photoprism
 echo "✅ Added user photoprism (1000)."
 
 add_user()
@@ -56,7 +63,7 @@ add_user()
   userdel -r -f "user-$1" >/dev/null 2>&1
   groupdel -f "group-$1" >/dev/null 2>&1
   groupadd -f -g "$1" "group-$1"
-  useradd -u "$1" -g "$1" -G photoprism,www-data,video,davfs2,renderd,render,ssl-cert,videodriver -s /bin/bash -m -d "/home/user-$1" "user-$1" 2>/dev/null
+  useradd -u "$1" -g "$1" -G photoprism,www-data,video,davfs2,renderd,render,ssl-cert,videodriver -s /bin/bash -m -d "/home/user-$1" --skel "${SKELETON}" "user-$1" 2>/dev/null
   printf "."
 }
 
@@ -72,5 +79,8 @@ for i in $(seq 2000 2100); do add_user "$i"; done
 printf " ✔\n"
 
 chgrp -f -R 1000 /home
+
+# remove the custom skeleton
+rm -rf "${SKELETON}"
 
 echo "Done."

--- a/scripts/dist/install-bashrc.sh
+++ b/scripts/dist/install-bashrc.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Add go alias and custom prompt in /etc/bash.bashrc:
+# bash <(curl -s https://raw.githubusercontent.com/photoprism/photoprism/develop/scripts/dist/install-profile.sh)
+
+# Abort if not executed as root.
+if [[ $(id -u) != "0" ]]; then
+  echo "Usage: run ${0##*/} as root" 1>&2
+  exit 1
+fi
+
+set -e
+
+echo "Add ll alias and custom prompt in /etc/bash.bashrc"
+
+echo 'alias ll="ls -alh"' >> /etc/bash.bashrc
+echo 'export PS1="\u@$DOCKER_TAG:\w\$ "' >> /etc/bash.bashrc
+
+echo "Add alias of go to richgo if it's available"
+
+# Source: https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script/677212#677212
+if command -v richgo >/dev/null 2>&1; then
+  echo 'alias go=richgo' >> /etc/bash.bashrc
+fi
+
+echo "Remove the unnecessary custom .bashrc for the root user"
+
+rm /root/.bashrc

--- a/scripts/dist/install-dircolors.sh
+++ b/scripts/dist/install-dircolors.sh
@@ -298,13 +298,13 @@ EOF
 # Make sure file only writable by root, but readable by everyone
 chmod 644 /etc/dir_colors
 
-# Activate colors in /etc/skel/.bashrc, if not done yet
-if ! grep -q 'export SHELL=/bin/bash' /etc/skel/.bashrc; then
-    echo 'export SHELL=/bin/bash' >> /etc/skel/.bashrc
+# Activate colors in /etc/bash.bashrc, if not done yet
+if ! grep -q 'export SHELL=/bin/bash' /etc/bash.bashrc; then
+    echo 'export SHELL=/bin/bash' >> /etc/bash.bashrc
 fi
 # shellcheck disable=SC2016
-if ! grep -q 'eval "$(dircolors /etc/dir_colors)"' /etc/skel/.bashrc; then
-    echo 'eval "$(dircolors /etc/dir_colors)"' >> /etc/skel/.bashrc
+if ! grep -q 'eval "$(dircolors /etc/dir_colors)"' /etc/bash.bashrc; then
+    echo 'eval "$(dircolors /etc/dir_colors)"' >> /etc/bash.bashrc
 fi
 
 echo "Done."


### PR DESCRIPTION
### Description

These changes reduce the size of the Docker image.

#### Before

```
./scripts/docker/build.sh develop photoprism /plucky
docker run -t --rm photoprism/develop:photoprism ls -lha /home/user-2086/
total 44K
drwxr-x--- 3 user-2086 photoprism 4.0K Aug  7 13:42 .
drwxr-xr-x 1 root      photoprism  20K Aug  7 13:42 ..
-rw-r--r-- 1 user-2086 photoprism  220 Mar  5 02:35 .bash_logout
-rw-r--r-- 1 user-2086 photoprism 3.9K Aug  7 13:41 .bashrc
drwxr-xr-x 3 user-2086 photoprism 4.0K Aug  7 13:41 .config
-rw-r--r-- 1 user-2086 photoprism  807 Mar  5 02:35 .profile
```

#### After

```
./scripts/docker/build.sh develop photoprism /plucky
docker run -t --rm photoprism/develop:photoprism ls -lha /home/user-2086/
total 28K
drwxr-x--- 2 user-2086 photoprism 4.0K Aug  7 13:49 .
drwxr-xr-x 1 root      photoprism  20K Aug  7 13:49 ..

```

Unfortunately I don't know how to test it because the [developer guide](https://docs.photoprism.app/developer-guide/setup/) rely on pre-built base images.

But since these files only contains default values for `bash` and the user profile, I'm pretty sure that they weren’t necessary.

#### Related Issues

- GH-5154

Fixes GH-5154

### Acceptance Criteria

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [x] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [x] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes
- [x] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [x] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+