### PR TITLE
Docker: Ensure that cmd.sh terminates its child processes when the parent script closes

### DIFF
--- a/scripts/dist/cmd.sh
+++ b/scripts/dist/cmd.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # clean up child processes via trap
-trap 'ps -p $$ -o pgid= | xargs pgrep -g | xargs kill ;exit' EXIT
+trap 'ps -p $$ -o pgid= | xargs pgrep -A -g | xargs kill ;exit' EXIT
 
 # regular expressions
 re='^[0-9]+$'

--- a/scripts/dist/cmd.sh
+++ b/scripts/dist/cmd.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# clean up child processes via trap
+trap 'ps -p $$ -o pgid= | xargs pgrep -g | xargs kill ;exit' EXIT
+
 # regular expressions
 re='^[0-9]+$'
 


### PR DESCRIPTION
### Description

These changes improves the closing of the PhotoPrism bash command shell, so that s6 can stop PhotoPrism within the container.  

The following command will stop the PhotoPrism web service, leaving the container up.
```
docker exec -ti photoprism /package/admin/s6/command/s6-svc -d /run/service/photoprism
```
The following command will start the PhotoPrism web service, leaving the container up.
```
docker exec -ti photoprism /package/admin/s6/command/s6-svc -u /run/service/photoprism
```
or if using Kubernetes, the following will stop the PhotoPrism web service (change the pod id to match yours):
```
kubectl exec -n photoprism-app photoprism-66c9c7cc59-96qhs  --  /package/admin/s6/command/s6-svc -d /run/service/photoprism
```

### Acceptance Criteria

- [x] Feature has been tested in container
- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work

### Testing Evidence

Please note that testing was conducted on Kubernetes, so I haven't tested the docker commands above, which are based on https://docs.photoprism.app/getting-started/docker/#examples 

The shutdown of PhotoPrism below was triggered from the kubectl command above.
The startup of PhotoPrism below was triggered from a kubectl command (the -d changed to a -u).
Prior to this fix, PhotoPrism would not shut down.
```
time="2025-08-24T10:22:34Z" level=info msg="server: listening on 0.0.0.0:2342 [8.981383ms]"
time="2025-08-24T10:22:51Z" level=info msg="shutting down workers"
Terminated
Terminated
time="2025-08-24T10:22:51Z" level=info msg="shutting down..."
time="2025-08-24T10:22:51Z" level=info msg="server: shutting down"
time="2025-08-24T10:22:51Z" level=info msg="server: shutdown complete"
started 250821-postgres as uid 1000 (amd64-prod)
init: account with the user id 1000 already exists
Problems? Our Troubleshooting Checklists help you quickly diagnose and solve them:
https://docs.photoprism.app/getting-started/troubleshooting/
file umask....: "0002" (u=rwx,g=rwx,o=rx)
home directory: /photoprism
assets path...: /opt/photoprism/assets
storage path..: /photoprism/storage
config path...: default
cache path....: default
backup path...: /photoprism/storage/backups
import path...: /photoprism/import
originals path: /photoprism/originals
running as uid 1000
/opt/photoprism/bin/photoprism start
time="2025-08-24T10:24:17Z" level=info msg="server: started as pid 1887"
time="2025-08-24T10:24:17Z" level=info msg="webdav: shared /originals/"
time="2025-08-24T10:24:17Z" level=info msg="webdav: shared /import/"
time="2025-08-24T10:24:17Z" level=info msg="server: disabled auto tls"
time="2025-08-24T10:24:17Z" level=info msg="server: listening on 0.0.0.0:2342 [7.384532ms]"
```