### PR TITLE
Benchmarks: Use b.Loop() to simplify the code and enhance performance

### DIFF
--- a/pkg/rnd/auth_test.go
+++ b/pkg/rnd/auth_test.go
@@ -20,7 +20,7 @@ func TestAuthToken(t *testing.T) {
 }
 
 func BenchmarkAuthToken(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		AuthToken()
 	}
 }
@@ -38,7 +38,7 @@ func TestIsAuthToken(t *testing.T) {
 }
 
 func BenchmarkIsAuthToken(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		IsAuthToken("69be27ac5ca305b394046a83f6fda18167ca3d3f2dbe7ac2")
 	}
 }
@@ -52,7 +52,7 @@ func TestAppPassword(t *testing.T) {
 }
 
 func BenchmarkAppPassword(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		AppPassword()
 	}
 }
@@ -93,13 +93,13 @@ func TestIsAppPasswordt(t *testing.T) {
 }
 
 func BenchmarkAppPasswordtVerifyChecksum(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		IsAppPassword("MPkOqm-RtKGOi-ctIvXm-Qv3XhN", true)
 	}
 }
 
 func BenchmarkAppPasswordIgnoreChecksum(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		IsAppPassword("MPkOqm-RtKGOi-ctIvXm-Qv3XhN", false)
 	}
 }
@@ -120,7 +120,7 @@ func TestIsAuthAny(t *testing.T) {
 }
 
 func BenchmarkIsAuthAny(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		IsAuthAny("MPkOqm-RtKGOi-ctIvXm-Qv3XhN")
 	}
 }

--- a/pkg/rnd/client_test.go
+++ b/pkg/rnd/client_test.go
@@ -22,7 +22,7 @@ func TestClientSecret(t *testing.T) {
 }
 
 func BenchmarkClientSecret(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		ClientSecret()
 	}
 }
@@ -42,7 +42,7 @@ func TestIsClientSecret(t *testing.T) {
 }
 
 func BenchmarkIsClientSecret(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		IsClientSecret("69be27ac5ca305b394046a83f6fda181")
 	}
 }

--- a/pkg/rnd/name_test.go
+++ b/pkg/rnd/name_test.go
@@ -21,7 +21,7 @@ func TestName(t *testing.T) {
 }
 
 func BenchmarkName(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		Name()
 	}
 }

--- a/pkg/rnd/token_test.go
+++ b/pkg/rnd/token_test.go
@@ -127,13 +127,13 @@ func TestRandomToken(t *testing.T) {
 }
 
 func BenchmarkGenerateToken4(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		Base36(4)
 	}
 }
 
 func BenchmarkGenerateToken3(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		Base36(3)
 	}
 }

--- a/pkg/rnd/uid_test.go
+++ b/pkg/rnd/uid_test.go
@@ -80,7 +80,7 @@ func TestGenerateUID(t *testing.T) {
 }
 
 func BenchmarkGenerateUID(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		GenerateUID('x')
 	}
 }

--- a/pkg/rnd/uuid_test.go
+++ b/pkg/rnd/uuid_test.go
@@ -15,7 +15,7 @@ func TestUUID(t *testing.T) {
 }
 
 func BenchmarkUUID(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		UUID()
 	}
 }


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

These changes use b.Loop() to simplify the code and improve performance


before:

```shell
go test -run=^$ -bench=. ./pkg/rnd -timeout=1h

goos: darwin
goarch: arm64
pkg: github.com/photoprism/photoprism/pkg/rnd
cpu: Apple M4
BenchmarkAuthToken-10                     	 3860322	       316.9 ns/op
BenchmarkIsAuthToken-10                   	33846873	        37.35 ns/op
BenchmarkAppPassword-10                   	  484153	      2276 ns/op
BenchmarkAppPasswordtVerifyChecksum-10    	27073267	        51.41 ns/op
BenchmarkAppPasswordIgnoreChecksum-10     	49025281	        25.49 ns/op
BenchmarkIsAuthAny-10                     	48148296	        28.98 ns/op
BenchmarkClientSecret-10                  	  236076	      9230 ns/op
BenchmarkIsClientSecret-10                	39943412	        36.55 ns/op
BenchmarkName-10                          	 1000000	      1117 ns/op
BenchmarkGenerateToken4-10                	  312836	      5858 ns/op
BenchmarkGenerateToken3-10                	 1000000	      4132 ns/op
BenchmarkGenerateUID-10                   	   94738	     13703 ns/op
BenchmarkUUID-10                          	 1000000	      2747 ns/op
PASS
ok  	github.com/photoprism/photoprism/pkg/rnd	24.786s
```

after this change:


```shell
go test -run=^$ -bench=. ./pkg/rnd -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/photoprism/photoprism/pkg/rnd
cpu: Apple M4
BenchmarkAuthToken-10                     	 4015228	       274.9 ns/op
BenchmarkIsAuthToken-10                   	41892554	        26.95 ns/op
BenchmarkAppPassword-10                   	  556844	      2095 ns/op
BenchmarkAppPasswordtVerifyChecksum-10    	30354578	        36.54 ns/op
BenchmarkAppPasswordIgnoreChecksum-10     	50194851	        23.11 ns/op
BenchmarkIsAuthAny-10                     	50172729	        22.45 ns/op
BenchmarkClientSecret-10                  	  415639	      2819 ns/op
BenchmarkIsClientSecret-10                	68254532	        17.43 ns/op
BenchmarkName-10                          	 4408628	       271.9 ns/op
BenchmarkGenerateToken4-10                	 2183702	       553.3 ns/op
BenchmarkGenerateToken3-10                	 2877525	       416.5 ns/op
BenchmarkGenerateUID-10                   	  935887	      1269 ns/op
BenchmarkUUID-10                          	 5249840	       228.4 ns/op
PASS
ok  	github.com/photoprism/photoprism/pkg/rnd	15.321s

```

#### Related Issues

- Links to issues that this PR fixes, implements, or is otherwise related to...

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [ ] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [ ] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes
- [ ] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [ ] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->