### PR TITLE
Config: show config returns incorrect information #5285

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,6 +180,10 @@ func NewConfig(ctx *cli.Context) *Config {
 		}
 	}
 
+	if c.options.DatabaseDriver != SQLite3 && c.options.DatabaseDriver != "sqlite" && (c.options.DatabaseDSN != "" || c.options.Deprecated.DatabaseDsn != "") {
+		log.Warn("config: database-dsn has been configured which is not recommended")
+	}
+
 	return c
 }
 

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -337,7 +337,19 @@ func (o *Options) Load(fileName string) error {
 		return err
 	}
 
-	return yaml.Unmarshal(yamlConfig, o)
+	beforeDSN := o.DatabaseDSN
+	beforeDepDsn := o.Deprecated.DatabaseDsn
+	err = yaml.Unmarshal(yamlConfig, o)
+	if err == nil {
+		// If a DSN value has become populated (or changed), then remove the base values as the DSN wins.
+		if (o.DatabaseDSN != "" && o.DatabaseDSN != beforeDSN) || (o.Deprecated.DatabaseDsn != "" && o.Deprecated.DatabaseDsn != beforeDepDsn) {
+			o.DatabaseName = ""
+			o.DatabaseUser = ""
+			o.DatabasePassword = ""
+			o.DatabaseServer = ""
+		}
+	}
+	return err
 }
 
 // ApplyCliContext uses options from the CLI to setup configuration overrides

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -337,19 +337,7 @@ func (o *Options) Load(fileName string) error {
 		return err
 	}
 
-	beforeDSN := o.DatabaseDSN
-	beforeDepDsn := o.Deprecated.DatabaseDsn
-	err = yaml.Unmarshal(yamlConfig, o)
-	if err == nil {
-		// If a DSN value has become populated (or changed), then remove the base values as the DSN wins.
-		if (o.DatabaseDSN != "" && o.DatabaseDSN != beforeDSN) || (o.Deprecated.DatabaseDsn != "" && o.Deprecated.DatabaseDsn != beforeDepDsn) {
-			o.DatabaseName = ""
-			o.DatabaseUser = ""
-			o.DatabasePassword = ""
-			o.DatabaseServer = ""
-		}
-	}
-	return err
+	return yaml.Unmarshal(yamlConfig, o)
 }
 
 // ApplyCliContext uses options from the CLI to setup configuration overrides

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -44,7 +44,7 @@ func TestOptions_Load(t *testing.T) {
 		assert.NotEmpty(t, o.DatabaseDSN)
 		assert.Equal(t, 81, o.HttpPort)
 	})
-	t.Run("ChangeDSN", func(t *testing.T) {
+	t.Run("SetDSNFromFile", func(t *testing.T) {
 		o := NewOptions(CliTestContext())
 		o.DatabaseDSN = ""
 		o.DatabaseDriver = "sqlite"
@@ -65,19 +65,10 @@ func TestOptions_Load(t *testing.T) {
 		assert.Equal(t, "http://localhost:2343/", o.SiteUrl)
 		assert.Equal(t, "mysql", o.DatabaseDriver)
 		assert.Equal(t, "acceptance:accpass@tcp(mariadb:12345)/accdb?charset=utf8mb4,utf8&parseTime=true", o.Deprecated.DatabaseDsn)
-		assert.Empty(t, o.DatabaseName)
-		assert.Empty(t, o.DatabaseServer)
-		assert.Empty(t, o.DatabaseUser)
-		assert.Empty(t, o.DatabasePassword)
-
-		c := &Config{
-			options: o,
-		}
-
-		assert.Equal(t, "accdb", c.DatabaseName())
-		assert.Equal(t, "mariadb:12345", c.DatabaseServer())
-		assert.Equal(t, "acceptance", c.DatabaseUser())
-		assert.Equal(t, "accpass", c.DatabasePassword())
+		assert.Equal(t, "photoprism", o.DatabaseName)
+		assert.Equal(t, "photoprism", o.DatabasePassword)
+		assert.Equal(t, "mariadb:4001", o.DatabaseServer)
+		assert.Equal(t, "root", o.DatabaseUser)
 	})
 }
 

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -24,24 +24,61 @@ func TestNewOptions(t *testing.T) {
 	assert.False(t, c.ReadOnly)
 }
 
-func TestOptions_SetOptionsFromFile(t *testing.T) {
-	c := NewOptions(CliTestContext())
+func TestOptions_Load(t *testing.T) {
+	t.Run("SetOptionsFromFile", func(t *testing.T) {
+		o := NewOptions(CliTestContext())
 
-	err := c.Load("testdata/config.yml")
+		err := o.Load("testdata/config.yml")
 
-	assert.Nil(t, err)
+		assert.Nil(t, err)
 
-	assert.False(t, c.Debug)
-	assert.False(t, c.ReadOnly)
-	assert.Equal(t, "/srv/photoprism", c.AssetsPath)
-	assert.Equal(t, "/srv/photoprism/cache", c.CachePath)
-	assert.Equal(t, "/srv/photoprism/photos/originals", c.OriginalsPath)
-	assert.Equal(t, "/srv/photoprism/photos/import", c.ImportPath)
-	assert.Equal(t, "/srv/photoprism/temp", c.TempPath)
-	assert.Equal(t, "1h34m9s", c.WakeupInterval.String())
-	assert.NotEmpty(t, c.DatabaseDriver)
-	assert.NotEmpty(t, c.DatabaseDSN)
-	assert.Equal(t, 81, c.HttpPort)
+		assert.False(t, o.Debug)
+		assert.False(t, o.ReadOnly)
+		assert.Equal(t, "/srv/photoprism", o.AssetsPath)
+		assert.Equal(t, "/srv/photoprism/cache", o.CachePath)
+		assert.Equal(t, "/srv/photoprism/photos/originals", o.OriginalsPath)
+		assert.Equal(t, "/srv/photoprism/photos/import", o.ImportPath)
+		assert.Equal(t, "/srv/photoprism/temp", o.TempPath)
+		assert.Equal(t, "1h34m9s", o.WakeupInterval.String())
+		assert.NotEmpty(t, o.DatabaseDriver)
+		assert.NotEmpty(t, o.DatabaseDSN)
+		assert.Equal(t, 81, o.HttpPort)
+	})
+	t.Run("ChangeDSN", func(t *testing.T) {
+		o := NewOptions(CliTestContext())
+		o.DatabaseDSN = ""
+		o.DatabaseDriver = "sqlite"
+		o.DatabaseName = "photoprism"
+		o.DatabasePassword = "photoprism"
+		o.DatabaseServer = "mariadb:4001"
+		o.DatabaseUser = "root"
+
+		err := o.Load("testdata/dsnoptions.yml")
+
+		assert.Nil(t, err)
+
+		assert.True(t, o.DisableBackups)
+		assert.Equal(t, uint64(2), o.FilesQuota)
+		assert.Equal(t, "019a0ec6-e01e-7170-b22f-c962af0c93a5", o.NodeUUID)
+		assert.Equal(t, "./storage/acceptance/originals", o.OriginalsPath)
+		assert.Equal(t, "./storage/acceptance/import", o.ImportPath)
+		assert.Equal(t, "http://localhost:2343/", o.SiteUrl)
+		assert.Equal(t, "mysql", o.DatabaseDriver)
+		assert.Equal(t, "acceptance:accpass@tcp(mariadb:12345)/accdb?charset=utf8mb4,utf8&parseTime=true", o.Deprecated.DatabaseDsn)
+		assert.Empty(t, o.DatabaseName)
+		assert.Empty(t, o.DatabaseServer)
+		assert.Empty(t, o.DatabaseUser)
+		assert.Empty(t, o.DatabasePassword)
+
+		c := &Config{
+			options: o,
+		}
+
+		assert.Equal(t, "accdb", c.DatabaseName())
+		assert.Equal(t, "mariadb:12345", c.DatabaseServer())
+		assert.Equal(t, "acceptance", c.DatabaseUser())
+		assert.Equal(t, "accpass", c.DatabasePassword())
+	})
 }
 
 func TestOptions_ExpandFilenames(t *testing.T) {

--- a/internal/config/report.go
+++ b/internal/config/report.go
@@ -13,14 +13,6 @@ import (
 func (c *Config) Report() (rows [][]string, cols []string) {
 	cols = []string{"Name", "Value"}
 
-	var dbKey string
-
-	if c.DatabaseDriver() == SQLite3 {
-		dbKey = "database-dsn"
-	} else {
-		dbKey = "database-name"
-	}
-
 	rows = [][]string{
 		// Authentication.
 		{"auth-mode", fmt.Sprintf("%s", c.AuthMode())},
@@ -222,7 +214,21 @@ func (c *Config) Report() (rows [][]string, cols []string) {
 
 		// Database.
 		{"database-driver", c.DatabaseDriver()},
-		{dbKey, c.DatabaseName()},
+	}...)
+
+	if c.DatabaseDriver() == SQLite3 {
+		rows = append(rows, [][]string{
+			{"database-dsn", c.DatabaseDSN()},
+		}...)
+	} else {
+		rows = append(rows, [][]string{
+			{"database-dsn", strings.ReplaceAll(c.DatabaseDSN(), ":"+c.DatabasePassword(), ":******")},
+			{"database-name", c.DatabaseName()},
+		}...)
+
+	}
+
+	rows = append(rows, [][]string{
 		{"database-server", c.DatabaseServer()},
 		{"database-host", c.DatabaseHost()},
 		{"database-port", c.DatabasePortString()},

--- a/internal/config/report.go
+++ b/internal/config/report.go
@@ -221,11 +221,21 @@ func (c *Config) Report() (rows [][]string, cols []string) {
 			{"database-dsn", c.DatabaseDSN()},
 		}...)
 	} else {
-		rows = append(rows, [][]string{
-			{"database-dsn", strings.ReplaceAll(c.DatabaseDSN(), ":"+c.DatabasePassword(), ":******")},
-			{"database-name", c.DatabaseName()},
-		}...)
-
+		// Create a config to enable generation of the dsn, so it can be compared to what is configured
+		nc := &Config{options: &Options{DatabaseDriver: c.DatabaseDriver(), DatabaseServer: c.DatabaseServer(), DatabaseUser: c.DatabaseUser(), DatabasePassword: c.DatabasePassword(), DatabaseName: c.DatabaseName()}}
+		if nc.DatabaseDSN() == c.DatabaseDSN() {
+			rows = append(rows, [][]string{
+				{"database-name", c.DatabaseName()},
+			}...)
+		} else {
+			// Create a config to allow extraction of the password to allow it to be obfuscated
+			dc := &Config{options: &Options{DatabaseDriver: c.DatabaseDriver(), DatabaseDSN: c.DatabaseDSN()}}
+			rows = append(rows, [][]string{
+				{"database-dsn", strings.ReplaceAll(c.DatabaseDSN(), ":"+dc.DatabasePassword(), ":"+strings.Repeat("*", utf8.RuneCountInString(dc.DatabasePassword())))},
+				{"database-dsn warning", "database-dsn overides the following database settings"},
+				{"database-name", c.DatabaseName()},
+			}...)
+		}
 	}
 
 	rows = append(rows, [][]string{

--- a/internal/config/report_test.go
+++ b/internal/config/report_test.go
@@ -31,7 +31,8 @@ func TestConfig_Report(t *testing.T) {
 			case "database-dsn":
 				assert.Contains(t, row[1], "storage/testdata/test.db")
 				found = found + ",database-dsn"
-
+			case "database-dsn warning":
+				assert.Fail(t, "database-dsn warning should not appear")
 			}
 		}
 		assert.Contains(t, found, "database-driver")
@@ -54,8 +55,11 @@ func TestConfig_Report(t *testing.T) {
 				assert.Contains(t, row[1], MySQL)
 				found = found + ",database-driver"
 			case "database-dsn":
-				assert.Contains(t, row[1], "foo:******@tcp(honeypot:1234)/baz?charset=utf8mb4,utf8&parseTime=true")
+				assert.Contains(t, row[1], "foo:***@tcp(honeypot:1234)/baz?charset=utf8mb4,utf8&parseTime=true")
 				found = found + ",database-dsn"
+			case "database-dsn warning":
+				assert.Contains(t, row[1], "database-dsn overides the following database settings")
+				found = found + ",database-dsn warning"
 			case "database-name":
 				assert.Contains(t, row[1], "baz")
 				found = found + ",database-name"
@@ -73,6 +77,7 @@ func TestConfig_Report(t *testing.T) {
 		}
 		assert.Contains(t, found, "database-driver")
 		assert.Contains(t, found, "database-dsn")
+		assert.Contains(t, found, "database-dsn warning")
 		assert.Contains(t, found, "database-name")
 		assert.Contains(t, found, "database-server")
 		assert.Contains(t, found, "database-user")

--- a/internal/config/report_test.go
+++ b/internal/config/report_test.go
@@ -7,7 +7,75 @@ import (
 )
 
 func TestConfig_Report(t *testing.T) {
-	m := NewConfig(CliTestContext())
-	r, _ := m.Report()
-	assert.GreaterOrEqual(t, len(r), 1)
+	t.Run("Success", func(t *testing.T) {
+		m := NewConfig(CliTestContext())
+		r, _ := m.Report()
+		assert.GreaterOrEqual(t, len(r), 1)
+	})
+	t.Run("SQLiteDSN", func(t *testing.T) {
+		m := NewConfig(CliTestContext())
+		m.options.DatabaseDriver = SQLite3
+		m.options.DatabaseDSN = "storage/testdata/test.db"
+		m.options.DatabaseName = ""
+		m.options.DatabaseUser = ""
+		m.options.DatabasePassword = ""
+		m.options.DatabaseServer = ""
+		r, _ := m.Report()
+		assert.GreaterOrEqual(t, len(r), 1)
+		found := ""
+		for _, row := range r {
+			switch row[0] {
+			case "database-driver":
+				assert.Contains(t, row[1], SQLite3)
+				found = found + ",database-driver"
+			case "database-dsn":
+				assert.Contains(t, row[1], "storage/testdata/test.db")
+				found = found + ",database-dsn"
+
+			}
+		}
+		assert.Contains(t, found, "database-driver")
+		assert.Contains(t, found, "database-dsn")
+	})
+	t.Run("MariaDBDSN", func(t *testing.T) {
+		m := NewConfig(CliTestContext())
+		m.options.DatabaseDriver = MySQL
+		m.options.DatabaseDSN = "foo:b@r@tcp(honeypot:1234)/baz?charset=utf8mb4,utf8&parseTime=true"
+		m.options.DatabaseName = ""
+		m.options.DatabaseUser = ""
+		m.options.DatabasePassword = ""
+		m.options.DatabaseServer = ""
+		r, _ := m.Report()
+		assert.GreaterOrEqual(t, len(r), 1)
+		found := ""
+		for _, row := range r {
+			switch row[0] {
+			case "database-driver":
+				assert.Contains(t, row[1], MySQL)
+				found = found + ",database-driver"
+			case "database-dsn":
+				assert.Contains(t, row[1], "foo:******@tcp(honeypot:1234)/baz?charset=utf8mb4,utf8&parseTime=true")
+				found = found + ",database-dsn"
+			case "database-name":
+				assert.Contains(t, row[1], "baz")
+				found = found + ",database-name"
+			case "database-server":
+				assert.Contains(t, row[1], "honeypot:1234")
+				found = found + ",database-server"
+			case "database-user":
+				assert.Contains(t, row[1], "foo")
+				found = found + ",database-user"
+			case "database-password":
+				assert.Contains(t, row[1], "***")
+				found = found + ",database-password"
+
+			}
+		}
+		assert.Contains(t, found, "database-driver")
+		assert.Contains(t, found, "database-dsn")
+		assert.Contains(t, found, "database-name")
+		assert.Contains(t, found, "database-server")
+		assert.Contains(t, found, "database-user")
+		assert.Contains(t, found, "database-password")
+	})
 }

--- a/internal/config/testdata/dsnoptions.yml
+++ b/internal/config/testdata/dsnoptions.yml
@@ -1,0 +1,14 @@
+BackupPath: ./storage/acceptance/backup
+DatabaseDriver: mysql
+DatabaseDsn: acceptance:accpass@tcp(mariadb:12345)/accdb?charset=utf8mb4,utf8&parseTime=true
+DisableBackups: true
+FilesQuota: 2
+HttpPort: 2343
+ImportPath: ./storage/acceptance/import
+NodeUUID: 019a0ec6-e01e-7170-b22f-c962af0c93a5
+OriginalsPath: ./storage/acceptance/originals
+SiteUrl: http://localhost:2343/
+StoragePath: ./storage/acceptance
+UploadNSFW: false
+UsageInfo: true
+Workers: 1


### PR DESCRIPTION
### Description

These changes fix show config returns incorrect information.
It does this by updating the options.Load to empty the database option fields DatabaseName, DatabaseServer, DatabaseUser, DatabasePassword if the DatabaseDSN (or DatabaseDsn) has been set in the yaml file to a value different to that which was already in the options.
The show config underlying report has been changed to return a password obfuscated version of the DSN as well as the fields that were already being returned.

#### Related Issues

- #5285

### Acceptance Criteria

- [X] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [X] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work

### Show Config output

For an options.yml file that contains the following:
```
DatabaseDriver: mysql
DatabaseDsn: acceptance:accpass@tcp(mariadb:12345)/accdb?charset=utf8mb4,utf8&parseTime=true
```
The show config command will return the following:
```
│ database-driver         │ mysql                                                                                       │
│ database-dsn            │ acceptance:******@tcp(mariadb:12345)/accdb?charset=utf8mb4,utf8&parseTime=true              │
│ database-name           │ accdb                                                                                       │
│ database-server         │ mariadb:12345                                                                               │
│ database-host           │ mariadb                                                                                     │
│ database-port           │ 12345                                                                                       │
│ database-user           │ acceptance                                                                                  │
│ database-password       │ *******                                                                                     │

```