### PR TITLE
Frontend: Refactor menu suppression logic in chip-selector

### DIFF
--- a/frontend/src/component/input/chip-selector.vue
+++ b/frontend/src/component/input/chip-selector.vue
@@ -136,6 +136,18 @@ export default {
     },
   },
   methods: {
+    suppressMenuTemporarily(callback) {
+      this.suppressMenuOpen = true;
+
+      if (typeof callback === "function") {
+        callback();
+      }
+
+      window.setTimeout(() => {
+        this.suppressMenuOpen = false;
+      }, 250);
+    },
+
     normalizeTitle(text) {
       const input = text == null ? "" : String(text);
       if (typeof this.normalizeTitleForCompare === "function") {
@@ -237,19 +249,21 @@ export default {
 
     onComboboxChange(value) {
       if (value && typeof value === "object" && value.title) {
-        this.newItemTitle = value;
-        this.addNewItem();
-        this.menuOpen = false;
-        // Immediately clear the input, remove focus and restore placeholder
-        this.$nextTick(() => {
-          this.newItemTitle = "";
-          if (this.$refs.inputField) {
-            this.$refs.inputField.blur();
-            // Force the combobox to reset completely
-            setTimeout(() => {
-              this.newItemTitle = null;
-            }, 10);
-          }
+        this.suppressMenuTemporarily(() => {
+          this.newItemTitle = value;
+          this.addNewItem();
+          this.menuOpen = false;
+          // Immediately clear the input, remove focus and restore placeholder
+          this.$nextTick(() => {
+            this.newItemTitle = "";
+            if (this.$refs.inputField) {
+              this.$refs.inputField.blur();
+              // Force the combobox to reset completely
+              setTimeout(() => {
+                this.newItemTitle = null;
+              }, 10);
+            }
+          });
         });
       } else {
         this.newItemTitle = value;
@@ -353,12 +367,10 @@ export default {
     },
 
     onEnter() {
-      this.suppressMenuOpen = true;
-      this.menuOpen = false;
-      this.addNewItem();
-      window.setTimeout(() => {
-        this.suppressMenuOpen = false;
-      }, 250);
+      this.suppressMenuTemporarily(() => {
+        this.menuOpen = false;
+        this.addNewItem();
+      });
     },
 
     onMenuUpdate(val) {

--- a/frontend/src/component/input/chip-selector.vue
+++ b/frontend/src/component/input/chip-selector.vue
@@ -48,7 +48,8 @@
         hide-no-data
         return-object
         class="chip-selector__input"
-        @keydown.enter.prevent="onEnter"
+        :menu-props="menuProps"
+        @keydown.enter.stop.prevent="onEnter"
         @blur="addNewItem"
         @update:model-value="onComboboxChange"
       >
@@ -109,6 +110,9 @@ export default {
   data() {
     return {
       newItemTitle: null,
+      menuProps: {
+        disableInitialFocus: true,
+      },
     };
   },
   computed: {
@@ -235,17 +239,7 @@ export default {
       if (value && typeof value === "object" && value.title) {
         this.newItemTitle = value;
         this.addNewItem();
-        // Immediately clear the input, remove focus and restore placeholder
-        this.$nextTick(() => {
-          this.newItemTitle = "";
-          if (this.$refs.inputField) {
-            this.$refs.inputField.blur();
-            // Force the combobox to reset completely
-            setTimeout(() => {
-              this.newItemTitle = null;
-            }, 10);
-          }
-        });
+        this.newItemTitle = null;
       } else {
         this.newItemTitle = value;
       }
@@ -323,7 +317,7 @@ export default {
           this.$emit("update:items", updatedItems);
         }
 
-        this.resetInputField();
+        this.newItemTitle = null;
         return;
       }
 
@@ -341,22 +335,6 @@ export default {
 
     onEnter() {
       this.addNewItem();
-      if (this.$refs.inputField) {
-        this.$refs.inputField.blur();
-      }
-    },
-    resetInputField() {
-      this.$nextTick(() => {
-        this.newItemTitle = "";
-        if (this.$refs.inputField) {
-          this.$refs.inputField.blur();
-          setTimeout(() => {
-            this.newItemTitle = null;
-          }, 10);
-        } else {
-          this.newItemTitle = null;
-        }
-      });
     },
   },
 };

--- a/frontend/src/component/input/chip-selector.vue
+++ b/frontend/src/component/input/chip-selector.vue
@@ -38,6 +38,7 @@
       <v-combobox
         ref="inputField"
         v-model="newItemTitle"
+        v-model:menu="menuOpen"
         :placeholder="computedInputPlaceholder"
         :persistent-placeholder="true"
         :items="availableItems"
@@ -113,6 +114,7 @@ export default {
       menuProps: {
         disableInitialFocus: true,
       },
+      menuOpen: false,
     };
   },
   computed: {
@@ -240,6 +242,7 @@ export default {
         this.newItemTitle = value;
         this.addNewItem();
         this.newItemTitle = null;
+        this.menuOpen = false;
       } else {
         this.newItemTitle = value;
       }
@@ -335,6 +338,9 @@ export default {
 
     onEnter() {
       this.addNewItem();
+      this.$nextTick(() => {
+        this.menuOpen = false;
+      });
     },
   },
 };


### PR DESCRIPTION
Improve the closing behavior of the label and album chip selector autocomplete in the batch edit dialog so that the dropdown reliably closes after selecting an item or clicking outside.
