### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/pkg/fs/duf/util.go
+++ b/pkg/fs/duf/util.go
@@ -11,7 +11,7 @@ import (
 // parseCommaSeparatedValues parses comma separated string into a map.
 func parseCommaSeparatedValues(values string) FilterValues {
 	m := make(FilterValues)
-	for _, v := range strings.Split(values, ",") {
+	for v := range strings.SplitSeq(values, ",") {
 		v = strings.TrimSpace(v)
 		if len(v) == 0 {
 			continue

--- a/pkg/http/dns/domain.go
+++ b/pkg/http/dns/domain.go
@@ -22,8 +22,8 @@ func IsDomain(d string) bool {
 	if IsLocalSuffix(d) {
 		return false
 	}
-	parts := strings.Split(d, ".")
-	for _, p := range parts {
+	parts := strings.SplitSeq(d, ".")
+	for p := range parts {
 		if !IsLabel(p) {
 			return false
 		}


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901



#### Related Issues

- Links to issues that this PR fixes, implements, or is otherwise related to...

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [ ] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [ ] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes
- [ ] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [ ] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->