### PR TITLE
Setup: Fix typo “enviconment” in compose config examples

### DIFF
--- a/setup/docker/arm64/compose.yaml
+++ b/setup/docker/arm64/compose.yaml
@@ -143,7 +143,7 @@ services:
     ## Never store database files on an unreliable device such as a USB flash drive, an SD card, or a shared network folder:
     volumes:
       - "./database:/var/lib/mysql" # DO NOT REMOVE
-    ## See https://link.photoprism.app/mariadb-enviconment-variables:
+    ## See https://link.photoprism.app/mariadb-environment-variables:
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_INITDB_SKIP_TZINFO: "1"

--- a/setup/docker/compose.yaml
+++ b/setup/docker/compose.yaml
@@ -144,7 +144,7 @@ services:
     ## Never store database files on an unreliable device such as a USB flash drive, an SD card, or a shared network folder:
     volumes:
       - "./database:/var/lib/mysql" # DO NOT REMOVE
-    ## See https://link.photoprism.app/mariadb-enviconment-variables:
+    ## See https://link.photoprism.app/mariadb-environment-variables:
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_INITDB_SKIP_TZINFO: "1"

--- a/setup/docker/nvidia/compose.yaml
+++ b/setup/docker/nvidia/compose.yaml
@@ -144,7 +144,7 @@ services:
     ## Never store database files on an unreliable device such as a USB flash drive, an SD card, or a shared network folder:
     volumes:
       - "./database:/var/lib/mysql" # DO NOT REMOVE
-    ## See https://link.photoprism.app/mariadb-enviconment-variables:
+    ## See https://link.photoprism.app/mariadb-environment-variables:
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_INITDB_SKIP_TZINFO: "1"

--- a/setup/podman/docker-compose.yml
+++ b/setup/podman/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     command: --innodb-buffer-pool-size=2G --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120
     volumes:
       - "./database:/var/lib/mysql" # DO NOT REMOVE
-    ## See https://link.photoprism.app/mariadb-enviconment-variables:
+    ## See https://link.photoprism.app/mariadb-environment-variables:
     environment:
       MARIADB_AUTO_UPGRADE: "1"
       MARIADB_INITDB_SKIP_TZINFO: "1"


### PR DESCRIPTION
### Description

These changes fix a typo on a link.

:warning: This will require an update on link.photoprism.app because the new link doesn’t work yet:

- https://link.photoprism.app/mariadb-enviconment-variables :heavy_check_mark:
- https://link.photoprism.app/mariadb-environment-variables :negative_squared_cross_mark:

Both links should work, for the old and new URLs.

#### Related Issues

- Links to issues that this PR fixes, implements, or is otherwise related to...

### Acceptance Criteria

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [x] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [x] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes
- [x] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [x] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+