### PR TITLE
Scripts: Update FFmpeg installation script

### DIFF
--- a/scripts/dist/Makefile
+++ b/scripts/dist/Makefile
@@ -16,10 +16,10 @@ install-https:
 	@/scripts/install-https.sh
 ffmpeg: install-ffmpeg
 install-ffmpeg:
-	@/scripts/install-ffmpeg.sh /opt/ffmpeg release
-ffmpeg-latest: install-ffmpeg-latest
-install-ffmpeg-latest:
-	@/scripts/install-ffmpeg.sh /opt/ffmpeg-latest latest
+	@/scripts/install-ffmpeg.sh /opt/ffmpeg latest
+ffmpeg-master: install-ffmpeg-master
+install-ffmpeg-master:
+	@/scripts/install-ffmpeg.sh /opt/ffmpeg master
 mariadb: mariadb-client
 mariadb-client: install-mariadb-client
 install-mariadb-client:

--- a/scripts/dist/install-ffmpeg.sh
+++ b/scripts/dist/install-ffmpeg.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
 
-# Installs the static FFmpeg build available at https://johnvansickle.com/ffmpeg/.
+# Installs a static FFmpeg build from johnvansickle.com.
 # bash <(curl -s https://raw.githubusercontent.com/photoprism/photoprism/develop/scripts/dist/install-ffmpeg.sh)
+
 
 PATH="/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/scripts:$PATH"
 
-# Show usage information if first argument is --help.
 if [[ ${1} == "--help" ]]; then
-  echo "Installs the release or latest static build of FFmpeg from the internet." 1>&2
+  echo "Installs a static FFmpeg build from johnvansickle.com." 1>&2
   echo "Usage: ${0##*/} [destdir] [version]" 1>&2
+  echo "" 1>&2
+  echo "Arguments:" 1>&2
+  echo "  destdir   Installation directory (default: /opt/ffmpeg)" 1>&2
+  echo "  version   FFmpeg version to install (default: release)" 1>&2
+  echo "" 1>&2
+  echo "Supported versions:" 1>&2
+  echo "  release   Latest stable release, currently 7.0.2 (default)" 1>&2
+  echo "  latest    Latest git master build (recommended)" 1>&2
+  echo "  6.0.1     Specific version from old-releases (6.0.1, 6.0, 5.1.1, ...)" 1>&2
   exit 0
 fi
 
-# You can provide a custom installation directory as the first argument.
 DESTDIR=$(realpath "${1:-/opt/ffmpeg}")
-
-# In addition, you can specify a custom version as the second argument.
 FFMPEG_VERSION=${2:-release}
 
 # Determine target architecture.
@@ -31,15 +37,12 @@ case $DESTARCH in
   amd64 | AMD64 | x86_64 | x86-64)
     DESTARCH=amd64
     ;;
-
   arm64 | ARM64 | aarch64)
     DESTARCH=arm64
     ;;
-
   arm | ARM | aarch | armv7l | armhf)
     DESTARCH=armhf
     ;;
-
   *)
     echo "Unsupported Machine Architecture: \"$DESTARCH\"" 1>&2
     exit 1
@@ -51,32 +54,63 @@ esac
 
 echo "Installing FFmpeg..."
 
-if [[ $FFMPEG_VERSION == "latest" ]] && [[ $DESTARCH == "amd64" ]]; then
-  # https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz
-  ARCHIVE="ffmpeg-master-${FFMPEG_VERSION}-linux64-gpl.tar.xz"
-  URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${ARCHIVE}"
-elif [[ $FFMPEG_VERSION == "latest" ]] && [[ $DESTARCH == "arm64" ]]; then
-  # https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz
-  ARCHIVE="ffmpeg-master-${FFMPEG_VERSION}-linuxarm64-gpl.tar.xz"
-  URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${ARCHIVE}"
+# Determine download URL.
+# - "latest" → https://johnvansickle.com/ffmpeg/builds/ (git master)
+# - "release" → https://johnvansickle.com/ffmpeg/releases/
+# - specific version → https://johnvansickle.com/ffmpeg/old-releases/
+if [[ $FFMPEG_VERSION == "latest" ]]; then
+  ARCHIVE="ffmpeg-git-${DESTARCH}-static.tar.xz"
+  URL="https://johnvansickle.com/ffmpeg/builds/${ARCHIVE}"
+elif [[ $FFMPEG_VERSION == "release" ]]; then
+  ARCHIVE="ffmpeg-release-${DESTARCH}-static.tar.xz"
+  URL="https://johnvansickle.com/ffmpeg/releases/${ARCHIVE}"
 else
   ARCHIVE="ffmpeg-${FFMPEG_VERSION}-${DESTARCH}-static.tar.xz"
-  URL="https://johnvansickle.com/ffmpeg/releases/${ARCHIVE}"
-  DESTDIR="${DESTDIR}/bin"
+  URL="https://johnvansickle.com/ffmpeg/old-releases/${ARCHIVE}"
 fi
 
-echo "--------------------------------------------------------------------------------"
+DESTDIR="${DESTDIR}/bin"
+
 echo "VERSION: $FFMPEG_VERSION"
 echo "ARCHIVE: $ARCHIVE"
 echo "DESTDIR: $DESTDIR"
-echo "--------------------------------------------------------------------------------"
 
-echo "Extracting \"$URL\" to \"$DESTDIR\"."
+echo ""
+echo "Extracting \"$URL\" to \"$DESTDIR\"..."
 sudo mkdir -p "${DESTDIR}"
-curl -fsSL "$URL" | sudo tar --strip-components=1 --overwrite --mode=755 -x --xz -C "$DESTDIR"
+
+if ! curl -fsSL "$URL" | sudo tar --strip-components=1 --overwrite --mode=755 -x --xz -C "$DESTDIR"; then
+  echo "Error: Failed to download or extract FFmpeg archive." 1>&2
+  echo "Please check that the version '${FFMPEG_VERSION}' exists and try again." 1>&2
+  exit 1
+fi
+
 sudo chown -R root:root "${DESTDIR}"
 
-# Create a symbolic link to the static ffmpeg binary.
-sudo ln -sf "${DESTDIR}/bin/ffmpeg" /usr/local/bin/ffmpeg
+FFMPEG_BIN="${DESTDIR}/ffmpeg"
+FFPROBE_BIN="${DESTDIR}/ffprobe"
 
+if [[ ! -x "${FFMPEG_BIN}" ]]; then
+  echo "Error: Could not find ffmpeg binary in ${DESTDIR}" 1>&2
+  exit 1
+fi
+
+# Create symbolic links.
+sudo ln -sf "${FFMPEG_BIN}" /usr/local/bin/ffmpeg
+sudo ln -sf "${FFPROBE_BIN}" /usr/local/bin/ffprobe
+
+# Verify installation.
+if command -v /usr/local/bin/ffmpeg &> /dev/null; then
+  echo ""
+  echo "FFmpeg installed successfully:"
+  /usr/local/bin/ffmpeg -version | head -1
+  echo ""
+  echo "Symlinks:"
+  echo "  /usr/local/bin/ffmpeg -> ${FFMPEG_BIN}"
+  echo "  /usr/local/bin/ffprobe -> ${FFPROBE_BIN}"
+else
+  echo "Warning: FFmpeg installation could not be verified." 1>&2
+fi
+
+echo ""
 echo "Done."

--- a/scripts/dist/install-ffmpeg.sh
+++ b/scripts/dist/install-ffmpeg.sh
@@ -1,27 +1,30 @@
 #!/usr/bin/env bash
 
-# Installs a static FFmpeg build from BtbN/FFmpeg-Builds or johnvansickle.com.
+# Installs a static FFmpeg build from BtbN/FFmpeg-Builds.
 # bash <(curl -s https://raw.githubusercontent.com/photoprism/photoprism/develop/scripts/dist/install-ffmpeg.sh) [destdir] [version]
 
 PATH="/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/scripts:$PATH"
 
+BTBN_REPO="BtbN/FFmpeg-Builds"
+BTBN_BASE="https://github.com/${BTBN_REPO}/releases/download/latest"
+BTBN_API="https://api.github.com/repos/${BTBN_REPO}/releases/latest"
+
 if [[ ${1} == "--help" ]]; then
-  echo "Installs a static FFmpeg build." 1>&2
+  echo "Installs a static FFmpeg build from BtbN/FFmpeg-Builds." 1>&2
   echo "Usage: ${0##*/} [destdir] [version]" 1>&2
   echo "" 1>&2
   echo "Arguments:" 1>&2
   echo "  destdir   Installation directory (default: /opt/ffmpeg)" 1>&2
-  echo "  version   FFmpeg version to install (default: release)" 1>&2
+  echo "  version   FFmpeg version to install (default: latest)" 1>&2
   echo "" 1>&2
   echo "Supported versions:" 1>&2
-  echo "  latest    Latest git master from BtbN (amd64/arm64 only, recommended)" 1>&2
-  echo "  release   Latest stable release from johnvansickle.com (default)" 1>&2
-  echo "  6.0.1     Specific version from johnvansickle.com old-releases" 1>&2
+  echo "  latest    Latest stable release from BtbN (default)" 1>&2
+  echo "  master    Latest nightly build from BtbN" 1>&2
   exit 0
 fi
 
 DESTDIR=$(realpath "${1:-/opt/ffmpeg}")
-FFMPEG_VERSION=${2:-release}
+FFMPEG_VERSION=${2:-latest}
 
 # Determine target architecture.
 if [[ $PHOTOPRISM_ARCH ]]; then
@@ -35,90 +38,73 @@ DESTARCH=${BUILD_ARCH:-$SYSTEM_ARCH}
 case $DESTARCH in
   amd64 | AMD64 | x86_64 | x86-64)
     DESTARCH=amd64
+    BTBN_ARCH="linux64"
     ;;
   arm64 | ARM64 | aarch64)
     DESTARCH=arm64
-    ;;
-  arm | ARM | aarch | armv7l | armhf)
-    DESTARCH=armhf
+    BTBN_ARCH="linuxarm64"
     ;;
   *)
-    echo "Unsupported Machine Architecture: \"$DESTARCH\"" 1>&2
+    echo "Unsupported architecture: \"$DESTARCH\" (BtbN builds are available for amd64 and arm64 only)" 1>&2
     exit 1
     ;;
 esac
 
 echo "Installing FFmpeg..."
 
-# Determine download URL and source.
-# - "latest" → BtbN/FFmpeg-Builds (amd64/arm64 only)
-# - "release" → johnvansickle.com/ffmpeg/releases/
-# - specific version → johnvansickle.com/ffmpeg/old-releases/
-USE_BTBN=false
+# Determine download URL.
+# - "master" → nightly build (ffmpeg-master-latest-*)
+# - "latest" → latest stable release (ffmpeg-nX.Y-latest-*)
+case $FFMPEG_VERSION in
+  master)
+    ARCHIVE="ffmpeg-master-latest-${BTBN_ARCH}-gpl.tar.xz"
+    URL="${BTBN_BASE}/${ARCHIVE}"
+    ;;
+  latest)
+    # Discover the highest stable version from BtbN release assets.
+    # Asset names follow the pattern: ffmpeg-n8.0-latest-linux64-gpl-8.0.tar.xz
+    ARCHIVE=$(curl -sSf "$BTBN_API" \
+      | grep -oE "ffmpeg-n[0-9]+\.[0-9]+-latest-${BTBN_ARCH}-gpl-[0-9]+\.[0-9]+\.tar\.xz" \
+      | sort -rV \
+      | head -1)
 
-if [[ $FFMPEG_VERSION == "latest" ]]; then
-  case $DESTARCH in
-    amd64)
-      USE_BTBN=true
-      ARCHIVE="ffmpeg-master-latest-linux64-gpl.tar.xz"
-      URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${ARCHIVE}"
-      ;;
-    arm64)
-      USE_BTBN=true
-      ARCHIVE="ffmpeg-master-latest-linuxarm64-gpl.tar.xz"
-      URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${ARCHIVE}"
-      ;;
-    *)
-      echo "BtbN builds not available for ${DESTARCH}, using johnvansickle.com release instead." 1>&2
-      FFMPEG_VERSION="release"
-      ;;
-  esac
-fi
+    if [[ -z $ARCHIVE ]]; then
+      echo "Error: Could not determine latest stable FFmpeg version from BtbN." 1>&2
+      echo "Please check your network connection and try again." 1>&2
+      exit 1
+    fi
 
-if [[ $USE_BTBN == false ]]; then
-  if [[ $FFMPEG_VERSION == "release" ]]; then
-    ARCHIVE="ffmpeg-release-${DESTARCH}-static.tar.xz"
-    URL="https://johnvansickle.com/ffmpeg/releases/${ARCHIVE}"
-  else
-    ARCHIVE="ffmpeg-${FFMPEG_VERSION}-${DESTARCH}-static.tar.xz"
-    URL="https://johnvansickle.com/ffmpeg/old-releases/${ARCHIVE}"
-  fi
-fi
-
-DESTDIR="${DESTDIR}/bin"
+    URL="${BTBN_BASE}/${ARCHIVE}"
+    ;;
+  *)
+    echo "Error: Unsupported version '${FFMPEG_VERSION}'." 1>&2
+    echo "Use 'latest' for the latest stable release or 'master' for nightly builds." 1>&2
+    exit 1
+    ;;
+esac
 
 echo "VERSION: $FFMPEG_VERSION"
 echo "ARCHIVE: $ARCHIVE"
 echo "DESTDIR: $DESTDIR"
-if [[ $USE_BTBN == true ]]; then
-  echo "SOURCE:  BtbN/FFmpeg-Builds"
-else
-  echo "SOURCE:  johnvansickle.com"
-fi
-
+echo "SOURCE:  BtbN/FFmpeg-Builds"
 echo ""
 echo "Downloading from: $URL"
 sudo mkdir -p "${DESTDIR}"
 
 if ! curl -fsSL "$URL" | sudo tar --strip-components=1 --overwrite --mode=755 -x --xz -C "$DESTDIR"; then
   echo "Error: Failed to download or extract FFmpeg archive." 1>&2
-  echo "Please check that the version '${FFMPEG_VERSION}' exists and try again." 1>&2
+  echo "Please check your network connection and try again." 1>&2
   exit 1
 fi
 
 sudo chown -R root:root "${DESTDIR}"
 
-# Locate ffmpeg binary (BtbN: bin/, JVS: root).
-if [[ -x "${DESTDIR}/bin/ffmpeg" ]]; then
-  FFMPEG_BIN="${DESTDIR}/bin/ffmpeg"
-  FFPROBE_BIN="${DESTDIR}/bin/ffprobe"
-else
-  FFMPEG_BIN="${DESTDIR}/ffmpeg"
-  FFPROBE_BIN="${DESTDIR}/ffprobe"
-fi
+# Locate ffmpeg binary (BtbN archives contain a bin/ subdirectory).
+FFMPEG_BIN="${DESTDIR}/bin/ffmpeg"
+FFPROBE_BIN="${DESTDIR}/bin/ffprobe"
 
 if [[ ! -x "${FFMPEG_BIN}" ]]; then
-  echo "Error: Could not find ffmpeg binary in ${DESTDIR}" 1>&2
+  echo "Error: Could not find ffmpeg binary in ${DESTDIR}/bin" 1>&2
   exit 1
 fi
 

--- a/scripts/dist/install-ffmpeg.sh
+++ b/scripts/dist/install-ffmpeg.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # Installs a static FFmpeg build from johnvansickle.com.
-# bash <(curl -s https://raw.githubusercontent.com/photoprism/photoprism/develop/scripts/dist/install-ffmpeg.sh)
-
+# bash <(curl -s https://raw.githubusercontent.com/photoprism/photoprism/develop/scripts/dist/install-ffmpeg.sh) [destdir] [version]
 
 PATH="/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/scripts:$PATH"
 
@@ -16,7 +15,7 @@ if [[ ${1} == "--help" ]]; then
   echo "" 1>&2
   echo "Supported versions:" 1>&2
   echo "  release   Latest stable release, currently 7.0.2 (default)" 1>&2
-  echo "  latest    Latest git master build (recommended)" 1>&2
+  echo "  latest    Latest git master build" 1>&2
   echo "  6.0.1     Specific version from old-releases (6.0.1, 6.0, 5.1.1, ...)" 1>&2
   exit 0
 fi

--- a/scripts/dist/install-ffmpeg.sh
+++ b/scripts/dist/install-ffmpeg.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# Installs a static FFmpeg build from johnvansickle.com.
+# Installs a static FFmpeg build from BtbN/FFmpeg-Builds or johnvansickle.com.
 # bash <(curl -s https://raw.githubusercontent.com/photoprism/photoprism/develop/scripts/dist/install-ffmpeg.sh) [destdir] [version]
 
 PATH="/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/scripts:$PATH"
 
 if [[ ${1} == "--help" ]]; then
-  echo "Installs a static FFmpeg build from johnvansickle.com." 1>&2
+  echo "Installs a static FFmpeg build." 1>&2
   echo "Usage: ${0##*/} [destdir] [version]" 1>&2
   echo "" 1>&2
   echo "Arguments:" 1>&2
@@ -14,9 +14,9 @@ if [[ ${1} == "--help" ]]; then
   echo "  version   FFmpeg version to install (default: release)" 1>&2
   echo "" 1>&2
   echo "Supported versions:" 1>&2
-  echo "  release   Latest stable release, currently 7.0.2 (default)" 1>&2
-  echo "  latest    Latest git master build" 1>&2
-  echo "  6.0.1     Specific version from old-releases (6.0.1, 6.0, 5.1.1, ...)" 1>&2
+  echo "  latest    Latest git master from BtbN (amd64/arm64 only, recommended)" 1>&2
+  echo "  release   Latest stable release from johnvansickle.com (default)" 1>&2
+  echo "  6.0.1     Specific version from johnvansickle.com old-releases" 1>&2
   exit 0
 fi
 
@@ -48,24 +48,41 @@ case $DESTARCH in
     ;;
 esac
 
-# shellcheck source=/dev/null
-. /etc/os-release
-
 echo "Installing FFmpeg..."
 
-# Determine download URL.
-# - "latest" → https://johnvansickle.com/ffmpeg/builds/ (git master)
-# - "release" → https://johnvansickle.com/ffmpeg/releases/
-# - specific version → https://johnvansickle.com/ffmpeg/old-releases/
+# Determine download URL and source.
+# - "latest" → BtbN/FFmpeg-Builds (amd64/arm64 only)
+# - "release" → johnvansickle.com/ffmpeg/releases/
+# - specific version → johnvansickle.com/ffmpeg/old-releases/
+USE_BTBN=false
+
 if [[ $FFMPEG_VERSION == "latest" ]]; then
-  ARCHIVE="ffmpeg-git-${DESTARCH}-static.tar.xz"
-  URL="https://johnvansickle.com/ffmpeg/builds/${ARCHIVE}"
-elif [[ $FFMPEG_VERSION == "release" ]]; then
-  ARCHIVE="ffmpeg-release-${DESTARCH}-static.tar.xz"
-  URL="https://johnvansickle.com/ffmpeg/releases/${ARCHIVE}"
-else
-  ARCHIVE="ffmpeg-${FFMPEG_VERSION}-${DESTARCH}-static.tar.xz"
-  URL="https://johnvansickle.com/ffmpeg/old-releases/${ARCHIVE}"
+  case $DESTARCH in
+    amd64)
+      USE_BTBN=true
+      ARCHIVE="ffmpeg-master-latest-linux64-gpl.tar.xz"
+      URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${ARCHIVE}"
+      ;;
+    arm64)
+      USE_BTBN=true
+      ARCHIVE="ffmpeg-master-latest-linuxarm64-gpl.tar.xz"
+      URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${ARCHIVE}"
+      ;;
+    *)
+      echo "BtbN builds not available for ${DESTARCH}, using johnvansickle.com release instead." 1>&2
+      FFMPEG_VERSION="release"
+      ;;
+  esac
+fi
+
+if [[ $USE_BTBN == false ]]; then
+  if [[ $FFMPEG_VERSION == "release" ]]; then
+    ARCHIVE="ffmpeg-release-${DESTARCH}-static.tar.xz"
+    URL="https://johnvansickle.com/ffmpeg/releases/${ARCHIVE}"
+  else
+    ARCHIVE="ffmpeg-${FFMPEG_VERSION}-${DESTARCH}-static.tar.xz"
+    URL="https://johnvansickle.com/ffmpeg/old-releases/${ARCHIVE}"
+  fi
 fi
 
 DESTDIR="${DESTDIR}/bin"
@@ -73,9 +90,14 @@ DESTDIR="${DESTDIR}/bin"
 echo "VERSION: $FFMPEG_VERSION"
 echo "ARCHIVE: $ARCHIVE"
 echo "DESTDIR: $DESTDIR"
+if [[ $USE_BTBN == true ]]; then
+  echo "SOURCE:  BtbN/FFmpeg-Builds"
+else
+  echo "SOURCE:  johnvansickle.com"
+fi
 
 echo ""
-echo "Extracting \"$URL\" to \"$DESTDIR\"..."
+echo "Downloading from: $URL"
 sudo mkdir -p "${DESTDIR}"
 
 if ! curl -fsSL "$URL" | sudo tar --strip-components=1 --overwrite --mode=755 -x --xz -C "$DESTDIR"; then
@@ -86,8 +108,14 @@ fi
 
 sudo chown -R root:root "${DESTDIR}"
 
-FFMPEG_BIN="${DESTDIR}/ffmpeg"
-FFPROBE_BIN="${DESTDIR}/ffprobe"
+# Locate ffmpeg binary (BtbN: bin/, JVS: root).
+if [[ -x "${DESTDIR}/bin/ffmpeg" ]]; then
+  FFMPEG_BIN="${DESTDIR}/bin/ffmpeg"
+  FFPROBE_BIN="${DESTDIR}/bin/ffprobe"
+else
+  FFMPEG_BIN="${DESTDIR}/ffmpeg"
+  FFPROBE_BIN="${DESTDIR}/ffprobe"
+fi
 
 if [[ ! -x "${FFMPEG_BIN}" ]]; then
   echo "Error: Could not find ffmpeg binary in ${DESTDIR}" 1>&2


### PR DESCRIPTION
Refactors the FFmpeg installation script to exclusively use johnvansickle.com for all builds, properly supporting specific versions via the old-releases directory. This update also enhances error handling during download and extraction, adds a symlink for ffprobe, and includes post-install verification to ensure binaries are correctly configured.