### PR TITLE
Log information messages every 15 minutes from long running processes

### DIFF
--- a/internal/entity/face.go
+++ b/internal/entity/face.go
@@ -269,7 +269,14 @@ func (m *Face) MatchMarkers(faceIds []string) error {
 		return err
 	}
 
-	for _, marker := range markers {
+	start := time.Now()
+	resultLen := len(markers)
+
+	for i, marker := range markers {
+		if time.Since(start) > time.Duration(time.Minute*15) {
+			log.Infof("faces: matching %d of %d markers", i, resultLen)
+			start = time.Now()
+		}
 		if ok, dist := m.Match(marker.Embeddings()); !ok {
 			// Ignore.
 		} else if _, err = marker.SetFace(m, dist); err != nil {

--- a/internal/photoprism/faces_cluster.go
+++ b/internal/photoprism/faces_cluster.go
@@ -2,6 +2,7 @@ package photoprism
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/dustin/go-humanize/english"
 
@@ -70,7 +71,14 @@ func (w *Faces) Cluster(opt FacesOptions) (added entity.Faces, err error) {
 			results[n-1] = append(results[n-1], embeddings[i])
 		}
 
-		for _, cluster := range results {
+		start := time.Now()
+		resultLen := len(results)
+
+		for i, cluster := range results {
+			if time.Since(start) > time.Duration(time.Minute*15) {
+				log.Infof("cluster: added %d of %d faces", i, resultLen)
+				start = time.Now()
+			}
 			if f := entity.NewFace("", entity.SrcAuto, cluster); f == nil {
 				log.Errorf("faces: face must not be nil - you may have found a bug")
 			} else if f.SkipMatching() {

--- a/internal/photoprism/faces_match.go
+++ b/internal/photoprism/faces_match.go
@@ -243,6 +243,7 @@ func (w *Faces) MatchFaces(faces entity.Faces, force bool, matchedBefore *time.T
 	totalProcessed := 0
 
 	offset := 0
+	start := time.Now()
 
 	for {
 		var markers entity.Markers
@@ -376,7 +377,12 @@ func (w *Faces) MatchFaces(faces entity.Faces, force bool, matchedBefore *time.T
 			break
 		}
 
-		log.Debugf("faces: matched %s", english.Plural(totalProcessed, "marker", "markers"))
+		if time.Since(start) > time.Duration(time.Minute*15) {
+			log.Infof("faces: matched %s", english.Plural(totalProcessed, "marker", "markers"))
+			start = time.Now()
+		} else {
+			log.Debugf("faces: matched %s", english.Plural(totalProcessed, "marker", "markers"))
+		}
 
 		if totalProcessed >= maxMarkers {
 			break

--- a/pkg/vector/alg/dbscan.go
+++ b/pkg/vector/alg/dbscan.go
@@ -3,6 +3,9 @@ package alg
 
 import (
 	"sync"
+	"time"
+
+	"github.com/photoprism/photoprism/internal/event"
 )
 
 type dbscanClusterer struct {
@@ -154,7 +157,12 @@ func (c *dbscanClusterer) run() {
 		ns, nss    = make([]int, 0), make([]int, 0)
 	)
 
+	start := time.Now()
 	for i := 0; i < c.l; i++ {
+		if time.Since(start) > time.Duration(time.Minute*15) {
+			event.Log.Infof("cluster: processing %d of %d", i, c.l)
+			start = time.Now()
+		}
 		if c.v[i] {
 			continue
 		}


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

These changes provide an information logging message at the start of the next loop 15 minutes after the previous logging message, about the progress of certain long running processes within the face indexing and updating processes.
The changed procs are:

- face.MatchMarkers which may process every marker record that has no face_id assigned
- face.Cluster when adding faces may have a large number of faces to save
- faces.MatchFaces which may have a large number of faces to match
- dbscanClusterer.run which is the core clustering routine, which may have a large number of markers to cluster

#### Related Issues

This is related to #5463 as it should provide information on what is happening when a long running high CPU situation occurs when indexing or updating faces.

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [x] Manual testing has been completed with the 15 minute logging time set to 1 second.  Automated tests are not possible with the fixture set as they require a significantly sized database of images to trigger the logging.


### Manual Test Results

```
face.MatchMarkers time based logging at 1s
time="2026-03-09T10:35:53Z" level=info msg="faces: matching 5233 of 20065 markers"
time="2026-03-09T10:35:54Z" level=info msg="faces: matching 10512 of 20065 markers"
time="2026-03-09T10:35:55Z" level=info msg="faces: matching 15620 of 20065 markers"

face.Cluster time based logging at 1s
time="2026-03-09T10:38:31Z" level=info msg="cluster: added 520 of 1153 faces"
time="2026-03-09T10:38:32Z" level=info msg="cluster: added 1000 of 1153 faces"

face.MatchFaces time based logging at 1s
time="2026-03-09T10:38:34Z" level=info msg="faces: matched 500 markers"
time="2026-03-09T10:38:36Z" level=info msg="faces: matched 1,000 markers"
time="2026-03-09T10:38:38Z" level=info msg="faces: matched 1,500 markers"
time="2026-03-09T10:38:39Z" level=info msg="faces: matched 2,000 markers"

dbscanClusterer.run time based logging at 1s
time="2026-03-09T10:37:03Z" level=info msg="cluster: processing 78 of 15582"
time="2026-03-09T10:37:04Z" level=info msg="cluster: processing 154 of 15582"
time="2026-03-09T10:37:05Z" level=info msg="cluster: processing 248 of 15582"
time="2026-03-09T10:37:06Z" level=info msg="cluster: processing 334 of 15582"
time="2026-03-09T10:37:07Z" level=info msg="cluster: processing 419 of 15582"
time="2026-03-09T10:37:08Z" level=info msg="cluster: processing 500 of 15582"
time="2026-03-09T10:37:09Z" level=info msg="cluster: processing 572 of 15582"
```

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->