### PR TITLE
Add 5-star photo rating (fixes #713)

### DIFF
--- a/frontend/src/component/photo/edit/details.vue
+++ b/frontend/src/component/photo/edit/details.vue
@@ -382,6 +382,26 @@
             </v-col>
           </v-row>
         </div>
+        <v-row dense class="mt-2">
+          <v-col cols="12">
+            <div class="d-flex align-center">
+              <span class="text-caption text-secondary mr-3">{{ $gettext("Rating") }}</span>
+              <v-btn
+                v-for="star in 5"
+                :key="star"
+                :icon="star <= view.model.Rating ? 'mdi-star' : 'mdi-star-outline'"
+                :color="star <= view.model.Rating ? 'warning' : undefined"
+                :disabled="disabled"
+                density="compact"
+                variant="text"
+                size="small"
+                :title="star + ' ' + $gettext('Stars')"
+                class="input-rating pa-0"
+                @click.stop="setRating(star === view.model.Rating ? 0 : star)"
+              ></v-btn>
+            </div>
+          </v-col>
+        </v-row>
       </div>
       <div v-if="!disabled" class="form-actions form-actions--sticky">
         <div class="action-buttons">
@@ -617,6 +637,11 @@ export default {
     },
     openPhoto() {
       this.$lightbox.openModels(Thumb.fromPhotos([this.view.model]), 0);
+    },
+    setRating(rating) {
+      if (this.view.model && this.view.model.setRating) {
+        this.view.model.setRating(rating);
+      }
     },
     save(close) {
       if (this.invalidDate) {

--- a/frontend/src/component/sidebar/info.vue
+++ b/frontend/src/component/sidebar/info.vue
@@ -32,6 +32,24 @@
       ></v-textarea -->
         </v-list-item>
         <v-divider v-if="model.Title || model.Caption" class="my-4"></v-divider>
+        <v-list-item v-if="canRate" class="metadata__item metadata__rating px-1 py-2">
+          <div v-tooltip="$gettext('Rating')" class="d-flex align-center gap-1">
+            <v-icon icon="mdi-star-outline" size="18" class="text-secondary mr-1"></v-icon>
+            <v-btn
+              v-for="star in 5"
+              :key="star"
+              :icon="star <= model.Rating ? 'mdi-star' : 'mdi-star-outline'"
+              :color="star <= model.Rating ? 'warning' : 'secondary'"
+              density="compact"
+              size="small"
+              variant="text"
+              :title="star + ' ' + $gettext('Stars')"
+              :aria-label="star + ' ' + $gettext('Stars')"
+              class="pa-0"
+              @click.stop="setRating(star === model.Rating ? 0 : star)"
+            ></v-btn>
+          </div>
+        </v-list-item>
         <v-list-item v-tooltip="$gettext(`Taken`)" :title="formatTime(model)" prepend-icon="mdi-calendar" class="metadata__item">
           <!-- template #append>
             <v-icon icon="mdi-pencil" size="20"></v-icon>
@@ -89,6 +107,7 @@ export default {
     return {
       actions: [],
       featPlaces: this.$config.feature("places"),
+      canRate: this.$config.allow("photos", "manage"),
     };
   },
   computed: {
@@ -99,6 +118,11 @@ export default {
   methods: {
     close() {
       this.$emit("close");
+    },
+    setRating(rating) {
+      if (this.model && this.model.setRating) {
+        this.model.setRating(rating);
+      }
     },
     formatTime(model) {
       if (!model || !model.TakenAtLocal) {

--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -55,6 +55,7 @@ export class Photo extends RestModel {
       CaptionSrc: "",
       Resolution: 0,
       Quality: 0,
+      Rating: 0,
       Faces: 0,
       Lat: 0.0,
       Lng: 0.0,
@@ -1098,6 +1099,11 @@ export class Photo extends RestModel {
       elements.forEach((el) => el.classList.remove("is-favorite"));
       return $api.delete(this.getEntityResource() + "/like");
     }
+  }
+
+  setRating(rating) {
+    this.Rating = Math.min(5, Math.max(0, rating));
+    return $api.post(this.getEntityResource() + "/rating", { Rating: this.Rating });
   }
 
   togglePrivate() {

--- a/internal/api/reactions.go
+++ b/internal/api/reactions.go
@@ -12,6 +12,11 @@ import (
 	"github.com/photoprism/photoprism/pkg/react"
 )
 
+// ratingRequest is used to parse the rating value from a JSON request body.
+type ratingRequest struct {
+	Rating int `json:"Rating"`
+}
+
 // LikePhoto flags a photo as favorite.
 //
 //	@Summary	flags a photo as favorite
@@ -103,6 +108,54 @@ func DislikePhoto(router *gin.RouterGroup) {
 			SaveSidecarYaml(&m)
 			PublishPhotoEvent(StatusUpdated, id, c)
 		}
+
+		c.JSON(http.StatusOK, gin.H{"photo": m})
+	})
+}
+
+// RatePhoto sets the star rating (0-5) for a photo.
+//
+//	@Summary	sets the star rating (0-5) for a photo
+//	@Id			RatePhoto
+//	@Tags		Photos
+//	@Accept		json
+//	@Produce	json
+//	@Success	200					{object}	gin.H
+//	@Failure	400,401,403,404,500	{object}	i18n.Response
+//	@Param		uid					path		string			true	"photo uid"
+//	@Param		rating				body		ratingRequest	true	"star rating 0-5"
+//	@Router		/api/v1/photos/{uid}/rating [post]
+func RatePhoto(router *gin.RouterGroup) {
+	router.POST("/photos/:uid/rating", func(c *gin.Context) {
+		s := Auth(c, acl.ResourcePhotos, acl.ActionUpdate)
+
+		if s.Abort(c) {
+			return
+		}
+
+		id := clean.UID(c.Param("uid"))
+		m, err := query.PhotoByUID(id)
+
+		if err != nil {
+			AbortEntityNotFound(c)
+			return
+		}
+
+		var req ratingRequest
+
+		if err = c.BindJSON(&req); err != nil {
+			AbortBadRequest(c)
+			return
+		}
+
+		if err = m.SetRating(req.Rating); err != nil {
+			log.Errorf("photo: %s", err.Error())
+			AbortSaveFailed(c)
+			return
+		}
+
+		SaveSidecarYaml(&m)
+		PublishPhotoEvent(StatusUpdated, id, c)
 
 		c.JSON(http.StatusOK, gin.H{"photo": m})
 	})

--- a/internal/entity/migrate/dialect_mysql.go
+++ b/internal/entity/migrate/dialect_mysql.go
@@ -231,4 +231,10 @@ var DialectMySQL = Migrations{
 		Stage:      "main",
 		Statements: []string{"UPDATE photos SET indexed_at = checked_at WHERE indexed_at IS NULL;"},
 	},
+	{
+		ID:         "20260318-000001",
+		Dialect:    "mysql",
+		Stage:      "main",
+		Statements: []string{"ALTER TABLE photos ADD COLUMN IF NOT EXISTS photo_rating TINYINT NOT NULL DEFAULT 0;", "UPDATE photos SET photo_rating = 0 WHERE photo_rating IS NULL;"},
+	},
 }

--- a/internal/entity/migrate/dialect_sqlite3.go
+++ b/internal/entity/migrate/dialect_sqlite3.go
@@ -147,4 +147,10 @@ var DialectSQLite3 = Migrations{
 		Stage:      "main",
 		Statements: []string{"UPDATE photos SET indexed_at = checked_at WHERE indexed_at IS NULL;"},
 	},
+	{
+		ID:         "20260318-000001",
+		Dialect:    "sqlite3",
+		Stage:      "main",
+		Statements: []string{"ALTER TABLE photos ADD COLUMN photo_rating TINYINT NOT NULL DEFAULT 0;", "UPDATE photos SET photo_rating = 0 WHERE photo_rating IS NULL;"},
+	},
 }

--- a/internal/entity/migrate/mysql/20260318-000001.sql
+++ b/internal/entity/migrate/mysql/20260318-000001.sql
@@ -1,0 +1,2 @@
+ALTER TABLE photos ADD COLUMN IF NOT EXISTS photo_rating TINYINT NOT NULL DEFAULT 0;
+UPDATE photos SET photo_rating = 0 WHERE photo_rating IS NULL;

--- a/internal/entity/migrate/sqlite3/20260318-000001.sql
+++ b/internal/entity/migrate/sqlite3/20260318-000001.sql
@@ -1,0 +1,2 @@
+ALTER TABLE photos ADD COLUMN photo_rating TINYINT NOT NULL DEFAULT 0;
+UPDATE photos SET photo_rating = 0 WHERE photo_rating IS NULL;

--- a/internal/entity/photo.go
+++ b/internal/entity/photo.go
@@ -82,6 +82,7 @@ type Photo struct {
 	PhotoFNumber     float32       `gorm:"type:FLOAT;" json:"FNumber" yaml:"FNumber,omitempty"`
 	PhotoFocalLength int           `json:"FocalLength" yaml:"FocalLength,omitempty"`
 	PhotoQuality     int           `gorm:"type:SMALLINT" json:"Quality" yaml:"Quality,omitempty"`
+	PhotoRating      int           `gorm:"type:TINYINT;default:0" json:"Rating" yaml:"Rating,omitempty"`
 	PhotoFaces       int           `json:"Faces,omitempty" yaml:"Faces,omitempty"`
 	PhotoResolution  int           `gorm:"type:SMALLINT" json:"Resolution" yaml:"-"`
 	PhotoDuration    time.Duration `json:"Duration,omitempty" yaml:"Duration,omitempty"`
@@ -1228,6 +1229,19 @@ func (m *Photo) SetFavorite(favorite bool) error {
 	}
 
 	return nil
+}
+
+// SetRating updates the user star rating (0-5) of a photo.
+func (m *Photo) SetRating(rating int) error {
+	if rating < 0 {
+		rating = 0
+	} else if rating > 5 {
+		rating = 5
+	}
+
+	m.PhotoRating = rating
+
+	return m.Updates(Values{"photo_rating": m.PhotoRating})
 }
 
 // SetStack updates the stack flag of a photo.

--- a/internal/entity/search/photos.go
+++ b/internal/entity/search/photos.go
@@ -475,6 +475,10 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		} else if frm.Quality != 0 && frm.Private == false {
 			s = s.Where("photos.photo_quality >= ?", frm.Quality)
 		}
+
+		if frm.Rating > 0 {
+			s = s.Where("photos.photo_rating >= ?", frm.Rating)
+		}
 	}
 
 	// Filter private pictures.

--- a/internal/entity/search/photos_geo.go
+++ b/internal/entity/search/photos_geo.go
@@ -600,6 +600,10 @@ func UserPhotosGeo(frm form.SearchPhotosGeo, sess *entity.Session) (results GeoR
 		} else if frm.Quality != 0 && frm.Private == false {
 			s = s.Where("photos.photo_quality >= ?", frm.Quality)
 		}
+
+		if frm.Rating > 0 {
+			s = s.Where("photos.photo_rating >= ?", frm.Rating)
+		}
 	}
 
 	// Filter private pictures.

--- a/internal/entity/search/photos_results.go
+++ b/internal/entity/search/photos_results.go
@@ -45,6 +45,7 @@ type Photo struct {
 	PhotoExposure    string        `json:"Exposure" select:"photos.photo_exposure"`
 	PhotoFaces       int           `json:"Faces,omitempty" select:"photos.photo_faces"`
 	PhotoQuality     int           `json:"Quality" select:"photos.photo_quality"`
+	PhotoRating      int           `json:"Rating" select:"photos.photo_rating"`
 	PhotoResolution  int           `json:"Resolution" select:"photos.photo_resolution"`
 	PhotoDuration    time.Duration `json:"Duration,omitempty" select:"photos.photo_duration"`
 	PhotoColor       int16         `json:"Color" select:"photos.photo_color"`

--- a/internal/form/photo.go
+++ b/internal/form/photo.go
@@ -42,6 +42,7 @@ type Photo struct {
 	DescriptionSrc   string    `json:"DescriptionSrc"`
 	Details          Details   `json:"Details"`
 	PhotoStack       int8      `json:"Stack"`
+	PhotoRating      int       `json:"Rating"`
 	PhotoFavorite    bool      `json:"Favorite"`
 	PhotoPrivate     bool      `json:"Private"`
 	PhotoScan        bool      `json:"Scan"`

--- a/internal/form/search_photos.go
+++ b/internal/form/search_photos.go
@@ -89,6 +89,7 @@ type SearchPhotos struct {
 	Album       string    `form:"album" example:"album:berlin" notes:"Album UID or name, supports * wildcards"`                                                                          // Album UIDs or name
 	Albums      string    `form:"albums" example:"albums:\"South Africa & Birds\"" notes:"Album names, combinable with & or |"`                                                          // Multi search with and/or
 	Quality     int       `form:"quality" notes:"Minimum quality score (1-7)"`                                                                                                           // Photo quality score
+	Rating      int       `form:"rating" notes:"Minimum user star rating (1-5)"`                                                                                                         // Minimum user star rating
 	Added       time.Time `form:"added" example:"added:\"2006-01-02T15:04:05Z\"" time_format:"2006-01-02T15:04:05Z07:00" notes:"Finds content added at or after this time"`              // Pictures added at or after this time
 	Updated     time.Time `form:"updated" example:"updated:\"2006-01-02T15:04:05Z\"" time_format:"2006-01-02T15:04:05Z07:00" notes:"Finds content updated at or after this time"`        // Pictures updated at or after this time
 	Edited      time.Time `form:"edited" example:"edited:\"2006-01-02T15:04:05Z\"" time_format:"2006-01-02T15:04:05Z07:00" notes:"Finds content edited at or after this time"`           // Pictures edited at or after this time

--- a/internal/form/search_photos_geo.go
+++ b/internal/form/search_photos_geo.go
@@ -50,6 +50,7 @@ type SearchPhotosGeo struct {
 	Private     bool      `form:"private" notes:"Finds private content only (except when public:true)"`
 	Review      bool      `form:"review" notes:"Finds content in review"`
 	Quality     int       `form:"quality" notes:"Minimum quality score (1-7)"`
+	Rating      int       `form:"rating" notes:"Minimum user star rating (1-5)"`
 	Face        string    `form:"face" notes:"Find pictures with a specific face ID, you can also specify yes, no, new, or a face type"`
 	Faces       string    `form:"faces" example:"faces:yes faces:3" notes:"Minimum number of detected faces (yes means 1)"` // Find or exclude faces if detected.
 	Near        string    `form:"near" example:"near:pqbcf5j446s0futy" notes:"Finds nearby pictures (UID)"`

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -119,6 +119,7 @@ func registerRoutes(router *gin.Engine, conf *config.Config) {
 	api.ApprovePhoto(APIv1)
 	api.LikePhoto(APIv1)
 	api.DislikePhoto(APIv1)
+	api.RatePhoto(APIv1)
 	api.AddPhotoLabel(APIv1)
 	api.RemovePhotoLabel(APIv1)
 	api.UpdatePhotoLabel(APIv1)


### PR DESCRIPTION
## Summary

Implements the 5-star photo rating feature requested in issue #713.

### Backend Changes

- **`internal/entity/photo.go`**: Added `PhotoRating int` field (`TINYINT`, 0–5) with GORM tag and YAML/JSON serialization
- **`internal/entity/photo.go`**: Added `SetRating(rating int) error` method with clamping (same pattern as `SetFavorite`)
- **`internal/api/reactions.go`**: New `RatePhoto` handler — `POST /api/v1/photos/:uid/rating` accepting `{"Rating": 1–5}`, saves sidecar YAML and publishes update event
- **`internal/server/routes.go`**: Registered the new `RatePhoto` route
- **`internal/entity/search/photos.go`** and **`photos_geo.go`**: Added `rating:N` filter (minimum rating)
- **`internal/entity/search/photos_results.go`**: Included `photo_rating` in search result SELECT
- **`internal/form/photo.go`**: Added `PhotoRating int` to photo edit form
- **`internal/form/search_photos.go`** and **`search_photos_geo.go`**: Added `Rating int` filter field

### Database Migrations

- **`internal/entity/migrate/dialect_sqlite3.go`** + `.sql`: `ALTER TABLE photos ADD COLUMN photo_rating TINYINT NOT NULL DEFAULT 0`
- **`internal/entity/migrate/dialect_mysql.go`** + `.sql`: Same with `ADD COLUMN IF NOT EXISTS`

### Frontend Changes

- **`frontend/src/model/photo.js`**: Added `Rating: 0` default and `setRating(rating)` method that calls `POST /api/v1/photos/:uid/rating`
- **`frontend/src/component/photo/edit/details.vue`**: Star rating widget (5 clickable stars, click again to clear) in the photo edit dialog
- **`frontend/src/component/sidebar/info.vue`**: Star rating widget in the sidebar info panel (shown to users with `photos:manage` permission)

## Test plan

- [ ] Open a photo in the edit dialog — 5 stars appear below the quality section
- [ ] Click a star to set rating 1–5; click same star again to clear (set to 0)
- [ ] Rating persists after page reload (stored in DB and sidecar YAML)
- [ ] Search filter `rating:3` returns only photos with ≥ 3 stars
- [ ] Sidebar info panel shows star rating for photos you can manage
- [ ] DB migration runs cleanly on both SQLite3 and MySQL