### PR TITLE
People: import Adobe XMP face region metadata

### DIFF
--- a/internal/entity/file.go
+++ b/internal/entity/file.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/photoprism/photoprism/internal/ai/face"
 	"github.com/photoprism/photoprism/internal/config/customize"
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/clean"
 	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/photoprism/photoprism/pkg/media"
@@ -809,6 +810,37 @@ func (m *File) AddFace(f face.Face, subjUid string) {
 	// Append marker if it doesn't conflict with existing marker.
 	if markers := m.Markers(); !markers.Contains(*marker) {
 		markers.AppendWithEmbedding(*marker)
+	}
+}
+
+// AddXmpFaceRegions adds face markers from XMP MWG-RS region metadata to the file.
+// Each region in the slice should have normalized [0,1] top-left coordinates and
+// an optional Name field with the person's name.
+func (m *File) AddXmpFaceRegions(regions crop.Areas) {
+	markers := m.Markers()
+
+	for _, region := range regions {
+		if region.Empty() {
+			continue
+		}
+
+		// Create a face marker from the XMP region (size=0 = unknown pixel size, score=100 = user-tagged).
+		marker := NewMarker(*m, region, "", SrcXmp, MarkerFace, 0, 100)
+
+		if marker == nil {
+			continue
+		}
+
+		// Set the person name from the XMP region metadata.
+		if region.Name != "" {
+			marker.MarkerName = clean.Name(region.Name)
+			marker.SubjSrc = SrcXmp
+		}
+
+		// Only append if a marker at this location doesn't already exist.
+		if !markers.Contains(*marker) {
+			markers.Append(*marker)
+		}
 	}
 }
 

--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/geo/s2"
 	"github.com/photoprism/photoprism/pkg/media"
 	"github.com/photoprism/photoprism/pkg/rnd"
@@ -71,6 +72,7 @@ type Data struct {
 	Height           int           `meta:"ImageHeight,ImageLength,PixelYDimension,ExifImageHeight,SourceImageHeight"`
 	Orientation      int           `meta:"-"`
 	Rotation         int           `meta:"Rotation"`
+	FaceRegions      crop.Areas    `meta:"-"`
 	Views            int           `meta:"-"`
 	Albums           []string      `meta:"-"`
 	Warning          string        `meta:"Warning" report:"-"`

--- a/internal/meta/testdata/xmp-face-regions.xmp
+++ b/internal/meta/testdata/xmp-face-regions.xmp
@@ -1,0 +1,47 @@
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c148 79.164036, 2019/08/13-01:06:57">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:tiff="http://ns.adobe.com/tiff/1.0/"
+            xmlns:mwg-rs="http://www.metadataworkinggroup.com/schemas/regions/"
+            xmlns:stArea="http://ns.adobe.com/xap/1.0/sType/Area#"
+            xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#">
+         <xmp:CreateDate>2023-06-15T10:30:00</xmp:CreateDate>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Family Photo</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <tiff:Make>Canon</tiff:Make>
+         <tiff:Model>Canon EOS 5D Mark IV</tiff:Model>
+         <tiff:ImageWidth>4000</tiff:ImageWidth>
+         <tiff:ImageLength>3000</tiff:ImageLength>
+         <!-- MWG-RS face regions: stArea:x and stArea:y are CENTER coordinates per MWG spec -->
+         <mwg-rs:Regions rdf:parseType="Resource">
+            <mwg-rs:AppliedToDimensions stDim:w="4000" stDim:h="3000" stDim:unit="pixel"/>
+            <mwg-rs:RegionList>
+               <rdf:Bag>
+                  <rdf:li rdf:parseType="Resource">
+                     <mwg-rs:Area stArea:x="0.4" stArea:y="0.3" stArea:w="0.2" stArea:h="0.4" stArea:unit="normalized"/>
+                     <mwg-rs:Name>John Doe</mwg-rs:Name>
+                     <mwg-rs:Type>Face</mwg-rs:Type>
+                  </rdf:li>
+                  <rdf:li rdf:parseType="Resource">
+                     <mwg-rs:Area stArea:x="0.75" stArea:y="0.35" stArea:w="0.15" stArea:h="0.3" stArea:unit="normalized"/>
+                     <mwg-rs:Name>Jane Smith</mwg-rs:Name>
+                     <mwg-rs:Type>Face</mwg-rs:Type>
+                  </rdf:li>
+                  <rdf:li rdf:parseType="Resource">
+                     <mwg-rs:Area stArea:x="0.2" stArea:y="0.5" stArea:w="0.1" stArea:h="0.2" stArea:unit="normalized"/>
+                     <mwg-rs:Name></mwg-rs:Name>
+                     <mwg-rs:Type>Pet</mwg-rs:Type>
+                  </rdf:li>
+               </rdf:Bag>
+            </mwg-rs:RegionList>
+         </mwg-rs:Regions>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>

--- a/internal/meta/xmp.go
+++ b/internal/meta/xmp.go
@@ -77,5 +77,10 @@ func (data *Data) XMP(fileName string) (err error) {
 
 	data.Favorite = doc.Favorite()
 
+	// Import MWG-RS face region metadata (e.g. from Adobe Lightroom/Photoshop).
+	if regions := doc.FaceRegions(); len(regions) > 0 {
+		data.FaceRegions = regions
+	}
+
 	return nil
 }

--- a/internal/meta/xmp_document.go
+++ b/internal/meta/xmp_document.go
@@ -3,9 +3,11 @@ package meta
 import (
 	"encoding/xml"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/txt"
 )
 
@@ -197,6 +199,27 @@ type XmpDocument struct {
 					Li   string `xml:"li"` // Gopher
 				} `xml:"Bag" json:"bag"`
 			} `xml:"PersonInImage" json:"personinimage"`
+			// Regions holds MWG-RS (Metadata Working Group Regions) face region data.
+			// See https://www.metadataworkinggroup.com/specs/metadata_library.html
+			Regions struct {
+				RegionList struct {
+					Bag struct {
+						Li []struct {
+							// Area defines the face bounding box using normalized stArea coordinates.
+							// Per the MWG-RS spec, stArea:x and stArea:y are the CENTER of the region.
+							Area struct {
+								X    string `xml:"http://ns.adobe.com/xap/1.0/sType/Area# x,attr"`
+								Y    string `xml:"http://ns.adobe.com/xap/1.0/sType/Area# y,attr"`
+								W    string `xml:"http://ns.adobe.com/xap/1.0/sType/Area# w,attr"`
+								H    string `xml:"http://ns.adobe.com/xap/1.0/sType/Area# h,attr"`
+								Unit string `xml:"http://ns.adobe.com/xap/1.0/sType/Area# unit,attr"`
+							} `xml:"Area"`
+							Name string `xml:"Name"` // Person name, e.g. "John Doe"
+							Type string `xml:"Type"` // Region type, e.g. "Face"
+						} `xml:"li"`
+					} `xml:"Bag"`
+				} `xml:"RegionList"`
+			} `xml:"Regions" json:"regions,omitempty"`
 		} `xml:"Description" json:"description"`
 	} `xml:"RDF" json:"rdf"`
 }
@@ -289,4 +312,44 @@ func (doc *XmpDocument) Keywords() string {
 func (doc *XmpDocument) Favorite() bool {
 	fstop := doc.RDF.Description.FStopFavorite
 	return fstop == "1"
+}
+
+// FaceRegions returns face regions from the XMP document's MWG-RS Regions metadata.
+// Per the MWG-RS specification, stArea:x and stArea:y represent the CENTER of the face region.
+// These are converted to top-left corner coordinates as used by PhotoPrism's crop.Area.
+func (doc *XmpDocument) FaceRegions() crop.Areas {
+	var regions crop.Areas
+
+	for _, li := range doc.RDF.Description.Regions.RegionList.Bag.Li {
+		// Only import regions of type "Face", or those with no type set.
+		regionType := strings.TrimSpace(li.Type)
+		if regionType != "" && !strings.EqualFold(regionType, "Face") {
+			continue
+		}
+
+		// Parse the normalized stArea coordinates (center-based per MWG-RS spec).
+		cx, errX := strconv.ParseFloat(strings.TrimSpace(li.Area.X), 32)
+		cy, errY := strconv.ParseFloat(strings.TrimSpace(li.Area.Y), 32)
+		w, errW := strconv.ParseFloat(strings.TrimSpace(li.Area.W), 32)
+		h, errH := strconv.ParseFloat(strings.TrimSpace(li.Area.H), 32)
+
+		if errX != nil || errY != nil || errW != nil || errH != nil {
+			continue
+		}
+
+		if w <= 0 || h <= 0 {
+			continue
+		}
+
+		// Convert center coordinates to top-left corner coordinates.
+		left := float32(cx) - float32(w)/2
+		top := float32(cy) - float32(h)/2
+
+		name := SanitizeString(li.Name)
+
+		// crop.NewArea clips coordinates to [0, 1].
+		regions = append(regions, crop.NewArea(name, left, top, float32(w), float32(h)))
+	}
+
+	return regions
 }

--- a/internal/meta/xmp_test.go
+++ b/internal/meta/xmp_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestXMP(t *testing.T) {
@@ -86,5 +87,43 @@ func TestXMP(t *testing.T) {
 		assert.Equal(t, time.Date(2022, 9, 4, 0, 48, 26, 0, time.UTC), data.TakenAt.UTC())
 		assert.True(t, data.TakenAtLocal.IsZero())
 		assert.Equal(t, "UTC", data.TimeZone)
+	})
+	t.Run("XmpFaceRegions", func(t *testing.T) {
+		data, err := XMP("testdata/xmp-face-regions.xmp")
+
+		require.NoError(t, err)
+		assert.Equal(t, "Family Photo", data.Title)
+		assert.Equal(t, "Canon", data.CameraMake)
+		assert.Equal(t, "Canon EOS 5D Mark IV", data.CameraModel)
+
+		// Expect exactly two Face regions (the Pet region should be excluded).
+		require.Len(t, data.FaceRegions, 2, "expected 2 face regions (Pet type should be excluded)")
+
+		// Region 1: John Doe
+		// XMP center coords: x=0.4, y=0.3, w=0.2, h=0.4
+		// Converted top-left: x=0.4-0.1=0.3, y=0.3-0.2=0.1
+		r0 := data.FaceRegions[0]
+		assert.Equal(t, "John Doe", r0.Name)
+		assert.InDelta(t, 0.3, float64(r0.X), 0.001, "Region 0 X (top-left)")
+		assert.InDelta(t, 0.1, float64(r0.Y), 0.001, "Region 0 Y (top-left)")
+		assert.InDelta(t, 0.2, float64(r0.W), 0.001, "Region 0 W")
+		assert.InDelta(t, 0.4, float64(r0.H), 0.001, "Region 0 H")
+
+		// Region 2: Jane Smith
+		// XMP center coords: x=0.75, y=0.35, w=0.15, h=0.3
+		// Converted top-left: x=0.75-0.075=0.675, y=0.35-0.15=0.2
+		r1 := data.FaceRegions[1]
+		assert.Equal(t, "Jane Smith", r1.Name)
+		assert.InDelta(t, 0.675, float64(r1.X), 0.001, "Region 1 X (top-left)")
+		assert.InDelta(t, 0.2, float64(r1.Y), 0.001, "Region 1 Y (top-left)")
+		assert.InDelta(t, 0.15, float64(r1.W), 0.001, "Region 1 W")
+		assert.InDelta(t, 0.3, float64(r1.H), 0.001, "Region 1 H")
+	})
+	t.Run("XmpNoFaceRegions", func(t *testing.T) {
+		// Verify that XMP files without face regions return an empty FaceRegions slice.
+		data, err := XMP("testdata/photoshop.xmp")
+
+		require.NoError(t, err)
+		assert.Empty(t, data.FaceRegions, "photoshop.xmp should have no face regions")
 	})
 }

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -495,6 +495,20 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			if data.Favorite {
 				_ = photo.SetFavorite(data.Favorite)
 			}
+
+			// Import face region markers from XMP MWG-RS metadata (e.g. Adobe Lightroom/Photoshop).
+			if len(data.FaceRegions) > 0 {
+				if primaryFile, primaryErr := entity.PrimaryFile(photo.PhotoUID); primaryErr == nil {
+					primaryFile.AddXmpFaceRegions(data.FaceRegions)
+					if _, saveErr := primaryFile.SaveMarkers(); saveErr != nil {
+						log.Errorf("index: %s while saving XMP face markers for %s", saveErr, logName)
+					} else {
+						log.Infof("index: imported %d XMP face region(s) for %s", len(data.FaceRegions), logName)
+					}
+				} else {
+					log.Debugf("index: no primary file found for XMP face regions in %s", logName)
+				}
+			}
 		} else {
 			log.Warn(dataErr.Error())
 			file.FileError = clip.Chars(dataErr.Error(), txt.ClipError)


### PR DESCRIPTION
Implements face region metadata import from XMP sidecar files as requested in #554.

Parses mwg-rs:Regions/RegionList from XMP files and maps face region names and bounding box coordinates to PhotoPrism subjects/markers.

## Changes

- `internal/meta/xmp_document.go`: Added `Regions` struct (MWG-RS) to the XMP document with correct XML namespace bindings, and a `FaceRegions()` method that parses center-based stArea coordinates and converts them to top-left coordinates used by PhotoPrism.
- `internal/meta/xmp.go`: Calls `doc.FaceRegions()` and populates `data.FaceRegions`.
- `internal/meta/data.go`: Added `FaceRegions crop.Areas` field to the `Data` struct.
- `internal/entity/file.go`: Added `AddXmpFaceRegions(regions crop.Areas)` method that creates face `Marker` entities from XMP region metadata including the person name.
- `internal/photoprism/index_mediafile.go`: Integrates the face region import into the indexing pipeline - after XMP metadata is read, any face regions are saved as markers on the primary file.
- `internal/meta/testdata/xmp-face-regions.xmp`: Test XMP fixture with two Face regions and one Pet region (which should be excluded).
- `internal/meta/xmp_test.go`: Tests verifying correct parsing, coordinate conversion, and Pet-type exclusion.