### PR TITLE
fix: save sidecar YAML after vision worker updates metadata

### DIFF
--- a/internal/workers/vision.go
+++ b/internal/workers/vision.go
@@ -270,6 +270,13 @@ func (w *Vision) Start(filter string, count int, models []string, customSrc stri
 			if saveErr := m.SaveVision(); saveErr == nil {
 				updated++
 			}
+
+			// Save sidecar YAML backup if enabled.
+			if w.conf.SidecarYaml() {
+				if yamlErr := m.SaveSidecarYaml(w.conf.OriginalsPath(), w.conf.SidecarPath()); yamlErr != nil {
+					log.Errorf("vision: %s (save yaml sidecar)", yamlErr)
+				}
+			}
 		}
 
 		if mutex.VisionWorker.Canceled() {


### PR DESCRIPTION
### Description

Add missing `SaveSidecarYaml()` call in the vision worker. When the vision worker updates photo metadata (labels, caption), the changes are saved to the database via `SaveVision()` but the sidecar YAML backup files are never written. This means users with `--sidecar-yaml` enabled don't get YAML backups of vision-detected metadata.

The fix adds a `SaveSidecarYaml()` call inside the `if changed` block, following the same pattern used by the indexer in `index_mediafile.go`. It checks the `SidecarYaml()` config flag before writing and logs errors with the existing `vision:` prefix.

#### Related Issues

- Fixes #5493

### Acceptance Criteria

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [ ] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes
- [ ] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [ ] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+

Note: This is a one-line logic fix (missing function call), not new functionality. The underlying `SaveSidecarYaml` method is already tested in `internal/entity/photo_yaml_test.go`. No UI, database schema, or config changes are involved.