### PR TITLE
feat: add duplicate file filter and Duplicates view (#1308)

### DIFF
--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -303,6 +303,22 @@ export default [
     },
   },
   {
+    name: "duplicates",
+    path: "/duplicates",
+    component: Photos,
+    meta: { title: $gettext("Duplicates"), requiresAuth: true },
+    props: { staticFilter: { duplicate: "true" } },
+    beforeEnter: (to, from, next) => {
+      if ($session.loginRequired()) {
+        next({ name: loginRoute });
+      } else if ($config.deny("photos", "delete")) {
+        next({ name: $session.getDefaultRoute() });
+      } else {
+        next();
+      }
+    },
+  },
+  {
     name: "archive",
     path: "/archive",
     component: Photos,

--- a/frontend/src/component/navigation.vue
+++ b/frontend/src/component/navigation.vue
@@ -158,6 +158,12 @@
                   <span v-show="config.count.documents > 0" class="nav-count-item">{{ config.count.documents }}</span>
                 </v-list-item>
 
+                <v-list-item v-if="canManagePhotos" to="/duplicates" variant="text" class="nav-duplicates" @click.stop="">
+                  <v-list-item-title :class="`nav-menu-item menu-item`">
+                    {{ $gettext(`Duplicates`) }}
+                  </v-list-item-title>
+                </v-list-item>
+
                 <v-list-item v-if="canManagePhotos" v-show="$config.feature('review')" to="/review" variant="text" class="nav-review" @click.stop="">
                   <v-list-item-title :class="`nav-menu-item menu-item`">
                     {{ $gettext(`Review`) }}

--- a/internal/entity/search/photos.go
+++ b/internal/entity/search/photos.go
@@ -354,6 +354,12 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		case terms["favorites"]:
 			frm.Query = strings.ReplaceAll(frm.Query, "favorites", "")
 			frm.Favorite = "true"
+		case terms["duplicates"]:
+			frm.Query = strings.ReplaceAll(frm.Query, "duplicates", "")
+			frm.Duplicate = true
+		case terms["duplicate"]:
+			frm.Query = strings.ReplaceAll(frm.Query, "duplicate", "")
+			frm.Duplicate = true
 		case terms["stacks"]:
 			frm.Query = strings.ReplaceAll(frm.Query, "stacks", "")
 			frm.Stack = true
@@ -785,6 +791,11 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 	// Find stacks only.
 	if frm.Stack {
 		s = s.Where("photos.id IN (SELECT a.photo_id FROM files a JOIN files b ON a.id != b.id AND a.photo_id = b.photo_id AND a.file_type = b.file_type WHERE a.file_type='jpg')")
+	}
+
+	// Find photos that have exact file duplicates (tracked in the duplicates table).
+	if frm.Duplicate {
+		s = s.Where("files.file_hash IN (SELECT file_hash FROM duplicates WHERE file_hash <> '')")
 	}
 
 	// Find photos in albums or not in an album, unless search results are limited to a scope.

--- a/internal/form/search_photos.go
+++ b/internal/form/search_photos.go
@@ -28,6 +28,7 @@ type SearchPhotos struct {
 	Stack       bool      `form:"stack" notes:"Finds content with more than one media file"`
 	Unstacked   bool      `form:"unstacked" notes:"Finds content with a file that has been removed"`
 	Stackable   bool      `form:"stackable" notes:"Finds content that can be stacked with additional files"`
+	Duplicate   bool      `form:"duplicate" notes:"Finds content that has exact file duplicates"`
 	Photo       bool      `form:"photo" notes:"Finds regular photos and images, as well as RAW and Live Photos"`
 	Image       bool      `form:"image" notes:"Finds regular photos and images only"`
 	Raw         bool      `form:"raw" notes:"Finds RAW images only"`


### PR DESCRIPTION
## Summary

Implements a duplicate search filter and a **Duplicates** navigation view so users can find and manage photos that have exact file duplicates already tracked in the duplicates table.

Closes #1308

---

## Backend changes (Go)

### internal/form/search_photos.go

Added a new boolean filter field:

`go
Duplicate bool orm:"duplicate" notes:"Finds content that has exact file duplicates"
`

This enables the filter via the REST API:
`
GET /api/v1/photos?duplicate=true
`

### internal/entity/search/photos.go

1. **Natural-language query terms** - users can now type duplicates (or duplicate) in the search bar and the filter is applied automatically (same pattern used by stacks, ideos, aw, etc.).

2. **DB WHERE clause** - when rm.Duplicate is 	rue, results are restricted to files whose ile_hash appears in the duplicates table:

`go
s = s.Where("files.file_hash IN (SELECT file_hash FROM duplicates WHERE file_hash <> '')")
`

The duplicates table is already populated during indexing by entity.AddDuplicate / entity.PurgeDuplicate.

---

## Frontend changes (Vue.js)

### rontend/src/app/routes.js

New route /duplicates backed by the existing Photos page component with a static filter of { duplicate: "true" }. Access is guarded by the photos:delete permission (same as the Archive view) to prevent read-only/visitor accounts from seeing the view.

### rontend/src/component/navigation.vue

Added a **Duplicates** menu item in the search section, visible to users with canManagePhotos, linking to /duplicates. Positioned above the existing **Review** item.

---

## Notes

- No database migrations are required; the duplicates table already exists.
- No new API endpoints are needed; the existing /api/v1/photos endpoint handles the new filter.
- The delete workflow (selecting duplicates and using the existing bulk-delete action) works out of the box via the standard photo selection clipboard already present on the Photos page.

> CLA signature is pending and will be cleared by the account owner.