### PR TITLE
fix: OIDC automatic redirect not working on direct links

### DIFF
--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -83,7 +83,13 @@ export default [
       if ($session.loginRequired()) {
         next();
       } else {
-        next({ name: $session.getDefaultRoute() });
+        const redirectUrl = $session.getLoginRedirectUrl();
+        $session.clearLoginRedirectUrl();
+        if (redirectUrl && redirectUrl !== "/") {
+          window.location = redirectUrl;
+        } else {
+          next({ name: $session.getDefaultRoute() });
+        }
       }
     },
   },

--- a/frontend/src/common/session.js
+++ b/frontend/src/common/session.js
@@ -305,6 +305,7 @@ export default class Session {
     this.authToken = null;
     this.provider = "";
     this.scope = "";
+    this.loginRedirect = false;
 
     // "session.id" is the SHA256 hash of the auth token.
     this.clearNamespacedKey(this.storageKey + ".id");
@@ -324,6 +325,7 @@ export default class Session {
     this.clearLegacyKey("session.scope");
     this.clearLegacyKey("authError");
     this.clearLegacyKey("session.error");
+    this.clearNamespacedKey(this.storageKey + ".loginRedirect");
 
     delete $api.defaults.headers.common[RequestHeader];
   }
@@ -473,15 +475,26 @@ export default class Session {
   }
 
   getLoginRedirectUrl(defaultUrl) {
+    if (this.loginRedirect) {
+      return this.loginRedirect;
+    }
+
+    // Fall back to stored value (survives page reload during OIDC flow).
+    const stored = this.storage.getItem(this.storageKey + ".loginRedirect");
+    if (stored) {
+      return stored;
+    }
+
     if (!defaultUrl) {
       defaultUrl = "/";
     }
 
-    return this.loginRedirect ? this.loginRedirect : defaultUrl;
+    return defaultUrl;
   }
 
   clearLoginRedirectUrl() {
     this.loginRedirect = false;
+    this.clearNamespacedKey(this.storageKey + ".loginRedirect");
 
     return this;
   }
@@ -492,6 +505,7 @@ export default class Session {
     }
 
     this.loginRedirect = url;
+    this.storage.setItem(this.storageKey + ".loginRedirect", url);
 
     return this;
   }

--- a/frontend/src/page/auth/login.vue
+++ b/frontend/src/page/auth/login.vue
@@ -271,6 +271,8 @@ export default {
     if (authError) {
       this.$notify.error(authError);
       getAppStorage().removeItem("session.error");
+    } else if (this.config.ext?.oidc?.enabled && this.config.ext?.oidc?.redirect) {
+      this.onOidcLogin();
     }
   },
   mounted() {

--- a/frontend/tests/vitest/common/session.test.js
+++ b/frontend/tests/vitest/common/session.test.js
@@ -495,6 +495,51 @@ describe("common/session", () => {
     expect(rawStorage.getItem(namespaced + "session.user")).toBe(null);
   });
 
+  it("should persist login redirect url to storage", () => {
+    const storage = new StorageShim();
+    const session = new Session(storage, $config);
+
+    session.setLoginRedirectUrl("/albums/abc123/my-album");
+    expect(session.loginRedirect).toBe("/albums/abc123/my-album");
+    expect(storage.getItem("session.loginRedirect")).toBe("/albums/abc123/my-album");
+    expect(session.getLoginRedirectUrl()).toBe("/albums/abc123/my-album");
+  });
+
+  it("should read login redirect url from storage when memory is cleared", () => {
+    const storage = new StorageShim();
+    const session = new Session(storage, $config);
+
+    session.setLoginRedirectUrl("/albums/abc123/my-album");
+
+    // Simulate page reload: clear in-memory value but keep storage.
+    session.loginRedirect = false;
+
+    expect(session.getLoginRedirectUrl()).toBe("/albums/abc123/my-album");
+  });
+
+  it("should clear login redirect url from storage", () => {
+    const storage = new StorageShim();
+    const session = new Session(storage, $config);
+
+    session.setLoginRedirectUrl("/albums/abc123/my-album");
+    session.clearLoginRedirectUrl();
+
+    expect(session.loginRedirect).toBe(false);
+    expect(storage.getItem("session.loginRedirect")).toBeNull();
+    expect(session.getLoginRedirectUrl()).toBe("/");
+  });
+
+  it("should clear login redirect url on reset", () => {
+    const storage = new StorageShim();
+    const session = new Session(storage, $config);
+
+    session.setLoginRedirectUrl("/albums/abc123/my-album");
+    session.reset();
+
+    expect(storage.getItem("session.loginRedirect")).toBeNull();
+    expect(session.getLoginRedirectUrl()).toBe("/");
+  });
+
   it("should test redeem token", async () => {
     const storage = new StorageShim();
     const session = new Session(storage, $config);


### PR DESCRIPTION
### Description

Fixes #5506

`loginRedirect` in `session.js` was stored only in a JS variable, so the OIDC flow's full page reload (via `auth.gohtml`) wiped it. Users who visited a direct link like `/library/albums/{id}/view` ended up at the default route after OIDC auth instead of their original URL.

Also, the login page didn't auto-redirect to the OIDC provider for deep links. The root path worked because `routes_static.go` handles it server-side, but SPA-routed paths hit `login.vue` which showed the normal form.

Changes:
- `session.js`: persist `loginRedirect` to sessionStorage so it survives page reloads. Clear it on logout/reset.
- `login.vue`: auto-call `onOidcLogin()` in `created()` when `oidc.enabled && oidc.redirect` is true (skip if `session.error` is set to avoid loops on auth failure).
- `routes.js`: when an already-authenticated user hits `/login` (returning from OIDC callback), check for a stored redirect URL and navigate there instead of `getDefaultRoute()`.
- `session.test.js`: added tests for redirect URL persistence across set/get/clear/reset.

#### Related Issues

- Fixes #5506

### Acceptance Criteria

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [x] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes
- [x] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [ ] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+