### PR TITLE
fix: People: Import Adobe's XMP Face region metadata

### DIFF
--- a/internal/entity/file.go
+++ b/internal/entity/file.go
@@ -806,9 +806,72 @@ func (m *File) AddFace(f face.Face, subjUid string) {
 		return
 	}
 
-	// Append marker if it doesn't conflict with existing marker.
-	if markers := m.Markers(); !markers.Contains(*marker) {
-		markers.AppendWithEmbedding(*marker)
+	if markers := m.Markers(); markers != nil {
+		matchIndex := -1
+		matchOverlap := 0
+		matchEmbeddings := false
+
+		for i := range *markers {
+			existing := &(*markers)[i]
+
+			if existing.MarkerType != MarkerFace || existing.MarkerInvalid {
+				continue
+			}
+
+			overlap := existing.OverlapPercent(*marker)
+
+			if overlap <= face.OverlapThresholdFloor {
+				continue
+			}
+
+			hasEmbeddings := existing.Embeddings().One()
+
+			if matchIndex == -1 || (hasEmbeddings && !matchEmbeddings) || (hasEmbeddings == matchEmbeddings && overlap > matchOverlap) {
+				matchIndex = i
+				matchOverlap = overlap
+				matchEmbeddings = hasEmbeddings
+			}
+		}
+
+		if matchIndex == -1 {
+			markers.AppendWithEmbedding(*marker)
+			return
+		}
+
+		existing := &(*markers)[matchIndex]
+
+		if existing.Embeddings().One() {
+			return
+		}
+
+		existing.MarkerSrc = marker.MarkerSrc
+		existing.MarkerReview = marker.MarkerReview
+		existing.X = marker.X
+		existing.Y = marker.Y
+		existing.W = marker.W
+		existing.H = marker.H
+		existing.Q = marker.Q
+		existing.Size = marker.Size
+		existing.Score = marker.Score
+		existing.Thumb = marker.Thumb
+		existing.LandmarksJSON = marker.LandmarksJSON
+
+		if err := existing.SetEmbeddings(marker.Embeddings()); err != nil {
+			log.Errorf("faces: %s while merging marker %s", err, clean.Log(existing.MarkerUID))
+			return
+		}
+
+		if existing.SubjSrc != SrcAuto && (existing.MarkerName != "" || existing.SubjUID != "") {
+			if err := existing.SyncSubject(true); err != nil {
+				log.Errorf("faces: %s while merging marker %s", err, clean.Log(existing.MarkerUID))
+			}
+		}
+
+		if !existing.Unsaved() {
+			if err := existing.Save(); err != nil {
+				log.Errorf("faces: %s while saving merged marker %s", err, clean.Log(existing.MarkerUID))
+			}
+		}
 	}
 }
 

--- a/internal/entity/file_test.go
+++ b/internal/entity/file_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/photoprism/photoprism/internal/ai/face"
 	"github.com/photoprism/photoprism/internal/config/customize"
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/clean"
 	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/photoprism/photoprism/pkg/http/header"
@@ -573,6 +574,33 @@ func TestFile_AddFaces(t *testing.T) {
 		file.AddFaces(faces)
 
 		assert.Equal(t, 0, len(*file.Markers()))
+	})
+	t.Run("MergeExistingImportedMarker", func(t *testing.T) {
+		file := &File{FileUID: "fs6sg6bp4sjk3kda", FileHash: "246b3897eec9ef75e35fbf0bbc4c83c55ca41e31", FileType: "jpg", FileWidth: 1000, FileName: "FacesTest", PhotoID: 1000003, FilePrimary: true}
+
+		imported := NewMarker(*file, crop.NewArea("face", 0.1, 0.05, 0.3, 0.3), "", SrcXmp, MarkerFace, 300, 100)
+		imported.MarkerName = "Gopher"
+		imported.SubjSrc = SrcXmp
+
+		file.Markers().Append(*imported)
+
+		faces := face.Faces{face.Face{
+			Rows:       1000,
+			Cols:       1000,
+			Score:      65,
+			Area:       face.NewArea("face", 200, 250, 300),
+			Embeddings: face.Embeddings{face.RandomEmbedding()},
+		}}
+
+		file.AddFaces(faces)
+
+		if assert.Len(t, *file.Markers(), 1) {
+			marker := (*file.Markers())[0]
+			assert.Equal(t, SrcImage, marker.MarkerSrc)
+			assert.Equal(t, "Gopher", marker.MarkerName)
+			assert.Equal(t, SrcXmp, marker.SubjSrc)
+			assert.True(t, marker.Embeddings().One())
+		}
 	})
 }
 

--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -74,6 +74,7 @@ type Data struct {
 	Views            int           `meta:"-"`
 	Albums           []string      `meta:"-"`
 	Warning          string        `meta:"Warning" report:"-"`
+	FaceRegions      FaceRegions   `report:"-"`
 	Error            error         `meta:"-"`
 	json             map[string]string
 	exif             map[string]string

--- a/internal/meta/testdata/adobe-face.xmp
+++ b/internal/meta/testdata/adobe-face.xmp
@@ -1,0 +1,25 @@
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 6.0-c002 79.164352, 2020/01/30-15:50:38        ">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description
+      rdf:about=""
+      xmlns:mwg-rs="http://www.metadataworkinggroup.com/schemas/regions/"
+      xmlns:stArea="http://ns.adobe.com/xmp/sType/Area#">
+      <mwg-rs:Regions rdf:parseType="Resource">
+        <mwg-rs:RegionList>
+          <rdf:Bag>
+            <rdf:li rdf:parseType="Resource">
+              <mwg-rs:Name>Gopher</mwg-rs:Name>
+              <mwg-rs:Type>Face</mwg-rs:Type>
+              <mwg-rs:Area stArea:x="0.25" stArea:y="0.20" stArea:w="0.30" stArea:h="0.30" stArea:unit="normalized"/>
+            </rdf:li>
+            <rdf:li rdf:parseType="Resource">
+              <mwg-rs:Name>Ignored Label</mwg-rs:Name>
+              <mwg-rs:Type>Pet</mwg-rs:Type>
+              <mwg-rs:Area stArea:x="0.50" stArea:y="0.50" stArea:w="0.20" stArea:h="0.20" stArea:unit="normalized"/>
+            </rdf:li>
+          </rdf:Bag>
+        </mwg-rs:RegionList>
+      </mwg-rs:Regions>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>

--- a/internal/meta/xmp.go
+++ b/internal/meta/xmp.go
@@ -75,6 +75,7 @@ func (data *Data) XMP(fileName string) (err error) {
 		data.AddKeywords(doc.Keywords())
 	}
 
+	data.FaceRegions = doc.FaceRegions()
 	data.Favorite = doc.Favorite()
 
 	return nil

--- a/internal/meta/xmp_document.go
+++ b/internal/meta/xmp_document.go
@@ -197,9 +197,43 @@ type XmpDocument struct {
 					Li   string `xml:"li"` // Gopher
 				} `xml:"Bag" json:"bag"`
 			} `xml:"PersonInImage" json:"personinimage"`
+			Regions struct {
+				Text       string `xml:",chardata" json:"text,omitempty"`
+				RegionList struct {
+					Text string `xml:",chardata" json:"text,omitempty"`
+					Bag  struct {
+						Text string `xml:",chardata" json:"text,omitempty"`
+						Li   []struct {
+							Text string `xml:",chardata" json:"text,omitempty"`
+							Name string `xml:"Name"`
+							Type string `xml:"Type"`
+							Area struct {
+								Text string `xml:",chardata" json:"text,omitempty"`
+								X    string `xml:"http://ns.adobe.com/xmp/sType/Area# x,attr"`
+								Y    string `xml:"http://ns.adobe.com/xmp/sType/Area# y,attr"`
+								W    string `xml:"http://ns.adobe.com/xmp/sType/Area# w,attr"`
+								H    string `xml:"http://ns.adobe.com/xmp/sType/Area# h,attr"`
+								Unit string `xml:"http://ns.adobe.com/xmp/sType/Area# unit,attr"`
+							} `xml:"Area"`
+						} `xml:"li" json:"li"`
+					} `xml:"Bag" json:"bag"`
+				} `xml:"RegionList" json:"regionlist"`
+			} `xml:"Regions" json:"regions"`
 		} `xml:"Description" json:"description"`
 	} `xml:"RDF" json:"rdf"`
 }
+
+// FaceRegion represents a normalized face region found in XMP metadata.
+type FaceRegion struct {
+	Name string
+	X    float32
+	Y    float32
+	W    float32
+	H    float32
+}
+
+// FaceRegions represents a list of face regions found in XMP metadata.
+type FaceRegions []FaceRegion
 
 // Load parses an XMP file and populates document values with its contents.
 func (doc *XmpDocument) Load(filename string) error {
@@ -283,6 +317,54 @@ func (doc *XmpDocument) Keywords() string {
 	s := doc.RDF.Description.Subject.Seq.Li
 
 	return strings.Join(s, ", ")
+}
+
+// FaceRegions returns normalized face regions found in the XMP document.
+func (doc *XmpDocument) FaceRegions() (result FaceRegions) {
+	for _, region := range doc.RDF.Description.Regions.RegionList.Bag.Li {
+		if region.Type != "" && !strings.EqualFold(region.Type, "face") {
+			continue
+		} else if !strings.EqualFold(region.Area.Unit, "normalized") {
+			continue
+		}
+
+		w := float32(txt.Float64(region.Area.W))
+		h := float32(txt.Float64(region.Area.H))
+		x := float32(txt.Float64(region.Area.X)) - w/2
+		y := float32(txt.Float64(region.Area.Y)) - h/2
+
+		if x < 0 {
+			w += x
+			x = 0
+		}
+
+		if y < 0 {
+			h += y
+			y = 0
+		}
+
+		if x+w > 1 {
+			w = 1 - x
+		}
+
+		if y+h > 1 {
+			h = 1 - y
+		}
+
+		if w <= 0 || h <= 0 {
+			continue
+		}
+
+		result = append(result, FaceRegion{
+			Name: SanitizeString(region.Name),
+			X:    x,
+			Y:    y,
+			W:    w,
+			H:    h,
+		})
+	}
+
+	return result
 }
 
 // Favorite returns a favorite status in the XMP document.

--- a/internal/meta/xmp_test.go
+++ b/internal/meta/xmp_test.go
@@ -87,4 +87,19 @@ func TestXMP(t *testing.T) {
 		assert.True(t, data.TakenAtLocal.IsZero())
 		assert.Equal(t, "UTC", data.TimeZone)
 	})
+	t.Run("AdobeFaceRegions", func(t *testing.T) {
+		data, err := XMP("testdata/adobe-face.xmp")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if assert.Len(t, data.FaceRegions, 1) {
+			assert.Equal(t, "Gopher", data.FaceRegions[0].Name)
+			assert.InDelta(t, 0.10, data.FaceRegions[0].X, 0.0001)
+			assert.InDelta(t, 0.05, data.FaceRegions[0].Y, 0.0001)
+			assert.InDelta(t, 0.30, data.FaceRegions[0].W, 0.0001)
+			assert.InDelta(t, 0.30, data.FaceRegions[0].H, 0.0001)
+		}
+	})
 }

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -10,11 +10,13 @@ import (
 	"github.com/jinzhu/gorm"
 
 	"github.com/photoprism/photoprism/internal/ai/classify"
+	"github.com/photoprism/photoprism/internal/ai/face"
 	"github.com/photoprism/photoprism/internal/ai/vision"
 	"github.com/photoprism/photoprism/internal/entity"
 	"github.com/photoprism/photoprism/internal/entity/query"
 	"github.com/photoprism/photoprism/internal/event"
 	"github.com/photoprism/photoprism/internal/meta"
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/clean"
 	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/photoprism/photoprism/pkg/media"
@@ -494,6 +496,18 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			// Update externally marked as favorite.
 			if data.Favorite {
 				_ = photo.SetFavorite(data.Favorite)
+			}
+
+			markerFile := &file
+
+			if primaryFile.ID > 0 {
+				markerFile = &primaryFile
+			} else if !file.FilePrimary {
+				markerFile = nil
+			}
+
+			if err = importXmpFaceRegions(markerFile, data.FaceRegions); err != nil {
+				log.Errorf("index: %s in %s (import face regions)", err, logName)
 			}
 		} else {
 			log.Warn(dataErr.Error())
@@ -1098,4 +1112,86 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 	}
 
 	return result
+}
+
+// importXmpFaceRegions merges XMP face regions into the specified file markers.
+func importXmpFaceRegions(file *entity.File, regions meta.FaceRegions) error {
+	if file == nil || len(regions) == 0 {
+		return nil
+	}
+
+	markers := file.Markers()
+
+	if markers == nil {
+		return fmt.Errorf("failed loading markers for file %s", clean.Log(file.FileUID))
+	}
+
+	for _, region := range regions {
+		area := crop.NewArea("face", region.X, region.Y, region.W, region.H)
+		marker := entity.NewMarker(*file, area, "", entity.SrcXmp, entity.MarkerFace, int(float32(file.FileWidth)*region.W), 100)
+
+		if marker == nil {
+			continue
+		}
+
+		matchIndex := -1
+		matchOverlap := 0
+		matchEmbeddings := false
+
+		for i := range *markers {
+			existing := &(*markers)[i]
+
+			if existing.MarkerType != entity.MarkerFace || existing.MarkerInvalid {
+				continue
+			}
+
+			overlap := existing.OverlapPercent(*marker)
+
+			if overlap <= face.OverlapThresholdFloor {
+				continue
+			}
+
+			hasEmbeddings := existing.Embeddings().One()
+
+			if matchIndex == -1 || (hasEmbeddings && !matchEmbeddings) || (hasEmbeddings == matchEmbeddings && overlap > matchOverlap) {
+				matchIndex = i
+				matchOverlap = overlap
+				matchEmbeddings = hasEmbeddings
+			}
+		}
+
+		if matchIndex >= 0 {
+			if region.Name == "" {
+				continue
+			}
+
+			existing := &(*markers)[matchIndex]
+			changed, err := existing.SetName(region.Name, entity.SrcXmp)
+
+			if err != nil {
+				return err
+			} else if changed {
+				if err = existing.Save(); err != nil {
+					return err
+				}
+			}
+
+			continue
+		}
+
+		if region.Name != "" {
+			if _, err := marker.SetName(region.Name, entity.SrcXmp); err != nil {
+				return err
+			}
+		}
+
+		markers.Append(*marker)
+	}
+
+	if markers.Unsaved() {
+		_, err := file.SaveMarkers()
+		return err
+	}
+
+	return nil
 }

--- a/internal/photoprism/index_related_test.go
+++ b/internal/photoprism/index_related_test.go
@@ -1,13 +1,19 @@
 package photoprism
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/photoprism/photoprism/internal/ai/face"
 	"github.com/photoprism/photoprism/internal/config"
+	"github.com/photoprism/photoprism/internal/entity"
 	"github.com/photoprism/photoprism/internal/entity/query"
+	"github.com/photoprism/photoprism/internal/thumb/crop"
+	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/photoprism/photoprism/pkg/rnd"
 )
 
@@ -136,6 +142,65 @@ func TestIndexRelated(t *testing.T) {
 			assert.Contains(t, photo.Details.Keywords, "wiese")
 			assert.Equal(t, "2021-03-24 12:07:29 +0000 UTC", photo.TakenAt.String())
 			assert.Equal(t, "xmp", photo.TakenSrc)
+		}
+	})
+	t.Run("AdobeFaceRegionMerge", func(t *testing.T) {
+		cfg := newIndexRelatedTestConfig(t, "index-related-adobe-face")
+
+		testToken := rnd.Base36(8)
+		testPath := filepath.Join(cfg.OriginalsPath(), testToken)
+		require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+
+		sourceJpeg, err := NewMediaFile("testdata/apple-test-2.jpg")
+		require.NoError(t, err)
+		require.NoError(t, sourceJpeg.Copy(filepath.Join(testPath, "adobe-face.jpg"), false))
+
+		mainFile, err := NewMediaFile(filepath.Join(testPath, "adobe-face.jpg"))
+		require.NoError(t, err)
+
+		related, err := mainFile.RelatedFiles(true)
+		require.NoError(t, err)
+
+		convert := NewConvert(cfg)
+		opt := IndexOptionsAll(cfg)
+		opt.Convert = false
+		opt.DetectFaces = false
+		opt.DetectNsfw = false
+		opt.GenerateLabels = false
+
+		result := IndexRelated(related, NewIndex(cfg, convert, NewFiles(), NewPhotos()), opt)
+		require.True(t, result.Success())
+
+		primaryFile, err := query.FileByUID(result.FileUID)
+		require.NoError(t, err)
+
+		marker := entity.NewMarker(*primaryFile, crop.NewArea("face", 0.1, 0.05, 0.3, 0.3), "", entity.SrcImage, entity.MarkerFace, int(float32(primaryFile.FileWidth)*0.3), 65)
+		require.NotNil(t, marker)
+		require.NoError(t, marker.SetEmbeddings(face.Embeddings{face.RandomEmbedding()}))
+		require.NoError(t, marker.Save())
+
+		xmpData, err := os.ReadFile(filepath.Join("..", "meta", "testdata", "adobe-face.xmp"))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(testPath, "adobe-face.xmp"), xmpData, fs.ModeFile))
+
+		mainFile, err = NewMediaFile(filepath.Join(testPath, "adobe-face.jpg"))
+		require.NoError(t, err)
+
+		related, err = mainFile.RelatedFiles(true)
+		require.NoError(t, err)
+
+		result = IndexRelated(related, NewIndex(cfg, convert, NewFiles(), NewPhotos()), opt)
+		require.True(t, result.Success())
+
+		markers, err := entity.FindMarkers(primaryFile.FileUID)
+		require.NoError(t, err)
+
+		if assert.Len(t, markers, 1) {
+			assert.Equal(t, entity.SrcImage, markers[0].MarkerSrc)
+			assert.Equal(t, "Gopher", markers[0].MarkerName)
+			assert.Equal(t, entity.SrcXmp, markers[0].SubjSrc)
+			assert.True(t, markers[0].Embeddings().One())
+			assert.NotEmpty(t, markers[0].FaceID)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Automated fix for **People: Import Adobe's XMP Face region metadata**.

Closes https://github.com/photoprism/photoprism/issues/554

## Changes
```
 internal/entity/file.go                   | 69 +++++++++++++++++++++-
 internal/entity/file_test.go              | 28 +++++++++
 internal/meta/data.go                     |  1 +
 internal/meta/testdata/adobe-face.xmp     | 25 ++++++++
 internal/meta/xmp.go                      |  1 +
 internal/meta/xmp_document.go             | 82 ++++++++++++++++++++++++++
 internal/meta/xmp_test.go                 | 15 +++++
 internal/photoprism/index_mediafile.go    | 96 +++++++++++++++++++++++++++++++
 internal/photoprism/index_related_test.go | 65 +++++++++++++++++++++
 9 files changed, 379 insertions(+), 3 deletions(-)
```

## Bounty
$55 on [IssueHunt](https://oss.issuehunt.io)

---
🤖 Generated with [Codex CLI](https://github.com/openai/codex) via bounty-hunter pipeline