### PR TITLE
Build: Skip cgroupfs-mount when missing from apt index (Ubuntu 26.04)

### DIFF
--- a/scripts/dist/install-docker.sh
+++ b/scripts/dist/install-docker.sh
@@ -20,7 +20,18 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.
 
 # Install Docker with Compose Plugin.
 sudo apt-get update
-sudo apt-get -qq install docker-ce docker-ce-cli docker-ce-rootless-extras containerd.io docker-buildx-plugin docker-compose-plugin cgroupfs-mount libltdl7 pigz
+
+# "cgroupfs-mount" was retired upstream once systemd took over cgroup v2 setup
+# and is no longer shipped on Ubuntu 26.04 (resolute) / Debian trixie+. Only
+# include the package when the active apt index actually lists it; otherwise
+# the install line aborts with "E: Package 'cgroupfs-mount' has no installation
+# candidate" before Docker itself is installed.
+EXTRA_PKGS=""
+if apt-cache show cgroupfs-mount >/dev/null 2>&1; then
+  EXTRA_PKGS="cgroupfs-mount"
+fi
+
+sudo apt-get -qq install docker-ce docker-ce-cli docker-ce-rootless-extras containerd.io docker-buildx-plugin docker-compose-plugin $EXTRA_PKGS libltdl7 pigz
 
 # Add docker-compose alias for Compose Plugin.
 if [ ! -f "/bin/docker-compose" ]; then


### PR DESCRIPTION
## Summary

- `scripts/dist/install-docker.sh` aborted on Ubuntu 26.04 ("resolute") and Debian trixie+ because those releases dropped the `cgroupfs-mount` package — modern systemd handles cgroup v2 mounting natively.
- The install line failed with `E: Package 'cgroupfs-mount' has no installation candidate` before Docker itself was installed.
- Probe the apt index with `apt-cache show` and include the package only when it actually exists. Older distros that still ship it are unaffected.

## Test plan

- [x] `bash -n` syntax check passes.
- [x] Re-ran the patched script on a fresh Ubuntu 26.04 box (raven) — Docker 29.4.1 + Compose v5.1.3 installed, `docker run hello-world` succeeds.
- [ ] Smoke-run on an Ubuntu 24.04 LTS host where `cgroupfs-mount` *is* in the index, to confirm the package still gets installed (no behaviour change for that path).