### PR TITLE
Search: Add memories route

### DIFF
--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -48,6 +48,21 @@ const c = window.__CONFIG__;
 const siteTitle = c.siteTitle ? c.siteTitle : c.name;
 const loginRoute = "login";
 
+function memoriesFilter() {
+  const today = new Date();
+  const month = today.getMonth() + 1;
+  const day = today.getDate();
+  const pad = (value) => value.toString().padStart(2, "0");
+
+  return {
+    photo: "true",
+    month: month.toString(),
+    day: day.toString(),
+    before: `${today.getFullYear() - 1}-${pad(month)}-${pad(day)}`,
+    order: "oldest",
+  };
+}
+
 export default [
   {
     name: "home",
@@ -177,6 +192,13 @@ export default [
     component: Photos,
     meta: { title: $gettext("Photos"), requiresAuth: true },
     props: { staticFilter: { photo: "true" } },
+  },
+  {
+    name: "memories",
+    path: "/memories",
+    component: Photos,
+    meta: { title: $gettext("Memories"), requiresAuth: true },
+    props: () => ({ staticFilter: memoriesFilter() }),
   },
   {
     name: "moments",

--- a/frontend/src/component/navigation.vue
+++ b/frontend/src/component/navigation.vue
@@ -125,6 +125,12 @@
                   </v-list-item-title>
                 </v-list-item>
 
+                <v-list-item :to="{ name: 'memories' }" variant="text" class="nav-memories" @click.stop="">
+                  <v-list-item-title :class="`nav-menu-item menu-item`">
+                    {{ $gettext(`Memories`) }}
+                  </v-list-item-title>
+                </v-list-item>
+
                 <v-list-item
                   v-show="isSponsor"
                   :to="{ name: 'browse', query: { q: 'vectors' } }"

--- a/frontend/tests/vitest/app/routes.test.js
+++ b/frontend/tests/vitest/app/routes.test.js
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("page/photos.vue", () => ({ default: {} }));
+vi.mock("page/albums.vue", () => ({ default: {} }));
+vi.mock("page/album/photos.vue", () => ({ default: {} }));
+vi.mock("page/places.vue", () => ({ default: {} }));
+vi.mock("page/library/browse.vue", () => ({ default: {} }));
+vi.mock("page/library/errors.vue", () => ({ default: {} }));
+vi.mock("page/labels.vue", () => ({ default: {} }));
+vi.mock("page/people.vue", () => ({ default: {} }));
+vi.mock("page/library.vue", () => ({ default: {} }));
+vi.mock("page/settings.vue", () => ({ default: {} }));
+vi.mock("page/admin.vue", () => ({ default: {} }));
+vi.mock("page/cluster.vue", () => ({ default: {} }));
+vi.mock("page/auth/login.vue", () => ({ default: {} }));
+vi.mock("page/discover.vue", () => ({ default: {} }));
+vi.mock("page/about/about.vue", () => ({ default: {} }));
+vi.mock("page/about/license.vue", () => ({ default: {} }));
+vi.mock("page/help.vue", () => ({ default: {} }));
+vi.mock("page/connect.vue", () => ({ default: {} }));
+
+vi.mock("app/session", () => ({
+  $config: {
+    deny: vi.fn(() => false),
+  },
+  $session: {
+    getDefaultRoute: vi.fn(() => "photos"),
+    loginRequired: vi.fn(() => false),
+  },
+}));
+
+describe("app/routes", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("configures memories to show photos from this day in previous years", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-11T12:00:00Z"));
+
+    const { default: routes } = await import("app/routes");
+    const route = routes.find((item) => item.name === "memories");
+    const props = route.props();
+
+    expect(route.path).toBe("/memories");
+    expect(props.staticFilter).toEqual({
+      photo: "true",
+      month: "5",
+      day: "11",
+      before: "2025-05-11",
+      order: "oldest",
+    });
+  });
+});


### PR DESCRIPTION
Fixes #720

## Summary
- add a `/memories` route that reuses the existing Photos page with a static filter
- filter to photos from today's month/day in previous years
- add a Search navigation entry for Memories

## Validation
- `npm --workspace frontend run lint`
- `npm --workspace frontend run test -- tests/vitest/app/routes.test.js`

## Notes
- The filter uses `month`, `day`, and `before` with the same day last year so current-year photos from today are excluded.
- The local branch is `/tmp/codex-bounties/photoprism`, branch `memories-720`, commit `be91ea904`.
