### PR TITLE
Search: use NATURAL_SORT_KEY for name and title sort order on MariaDB

### DIFF
--- a/internal/entity/search/photos.go
+++ b/internal/entity/search/photos.go
@@ -204,9 +204,17 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		s = s.Where("files.file_diff > 0")
 		s = s.Order(OrderExpr("photos.photo_color ASC, photos.cell_id ASC, files.file_diff, files.photo_id, files.time_index", frm.Reverse))
 	case sortby.Name:
-		s = s.Order(OrderExpr("photos.photo_path ASC, photos.photo_name ASC, files.time_index", frm.Reverse))
+		if entity.DbDialect() == entity.MySQL {
+			s = s.Order(OrderExpr("NATURAL_SORT_KEY(photos.photo_path) ASC, NATURAL_SORT_KEY(photos.photo_name) ASC, files.time_index", frm.Reverse))
+		} else {
+			s = s.Order(OrderExpr("photos.photo_path ASC, photos.photo_name ASC, files.time_index", frm.Reverse))
+		}
 	case sortby.Title:
-		s = s.Order(OrderExpr("photos.photo_title ASC, photos.photo_name ASC, files.time_index", frm.Reverse))
+		if entity.DbDialect() == entity.MySQL {
+			s = s.Order(OrderExpr("NATURAL_SORT_KEY(photos.photo_title) ASC, NATURAL_SORT_KEY(photos.photo_name) ASC, files.time_index", frm.Reverse))
+		} else {
+			s = s.Order(OrderExpr("photos.photo_title ASC, photos.photo_name ASC, files.time_index", frm.Reverse))
+		}
 	case sortby.Random:
 		s = s.Order(sortby.RandomExpr(s.Dialect()))
 	case sortby.Default, sortby.Imported, sortby.Added:


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

Implements natural sort order for file name and title sorting by using MariaDB's NATURAL_SORT_KEY() function, so that numerically named files sort in human-readable order (1, 2, 3... 10, 11 instead of 1, 10, 11, 2, 3).

#### Related Issues

- Fixes: https://github.com/photoprism/photoprism/issues/4912

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [x] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->