### PR TITLE
Import MWG XMP face regions from sidecar files

### DIFF
--- a/internal/entity/file.go
+++ b/internal/entity/file.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/photoprism/photoprism/internal/ai/face"
 	"github.com/photoprism/photoprism/internal/config/customize"
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/clean"
 	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/photoprism/photoprism/pkg/media"
@@ -809,6 +810,41 @@ func (m *File) AddFace(f face.Face, subjUid string) {
 	// Append marker if it doesn't conflict with existing marker.
 	if markers := m.Markers(); !markers.Contains(*marker) {
 		markers.AppendWithEmbedding(*marker)
+	}
+}
+
+// AddFaceRegions adds face markers from image metadata.
+func (m *File) AddFaceRegions(regions crop.Areas) {
+	if m.FileUID == "" || m.FileHash == "" {
+		return
+	}
+
+	for _, area := range regions {
+		if area.Empty() {
+			continue
+		}
+
+		marker := Marker{
+			FileUID:       m.FileUID,
+			MarkerType:    MarkerFace,
+			MarkerSrc:     SrcXmp,
+			MarkerName:    area.Name,
+			MarkerReview:  area.Name == "",
+			MarkerInvalid: false,
+			SubjSrc:       SrcXmp,
+			FaceDist:      -1,
+			X:             area.X,
+			Y:             area.Y,
+			W:             area.W,
+			H:             area.H,
+			Size:          int(float32(m.FileWidth) * area.W),
+			Thumb:         area.Thumb(m.FileHash),
+			MatchedAt:     nil,
+		}
+
+		if markers := m.Markers(); !markers.Contains(marker) {
+			markers.Append(marker)
+		}
 	}
 }
 

--- a/internal/entity/file_test.go
+++ b/internal/entity/file_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/photoprism/photoprism/internal/ai/face"
 	"github.com/photoprism/photoprism/internal/config/customize"
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/clean"
 	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/photoprism/photoprism/pkg/http/header"
@@ -574,6 +575,28 @@ func TestFile_AddFaces(t *testing.T) {
 
 		assert.Equal(t, 0, len(*file.Markers()))
 	})
+}
+
+func TestFile_AddFaceRegions(t *testing.T) {
+	file := &File{FileUID: "fs6sg6bp4sjk3kdx", FileHash: "246b3897eec9ef75e35fbf0bbc4c83c55ca41e31", FileType: "jpg", FileWidth: 720, FileName: "RegionsTest", PhotoID: 1000003, FilePrimary: true}
+
+	file.AddFaceRegions(crop.Areas{
+		crop.NewArea("Ryan Gosling", 0.2802765, 0.125, 0.436419, 0.485614),
+	})
+
+	if assert.Len(t, *file.Markers(), 1) {
+		marker := (*file.Markers())[0]
+
+		assert.Equal(t, MarkerFace, marker.MarkerType)
+		assert.Equal(t, SrcXmp, marker.MarkerSrc)
+		assert.Equal(t, SrcXmp, marker.SubjSrc)
+		assert.Equal(t, "Ryan Gosling", marker.MarkerName)
+		assert.Equal(t, false, marker.MarkerReview)
+		assert.InDelta(t, 0.2802765, marker.X, 0.000001)
+		assert.InDelta(t, 0.125, marker.Y, 0.000001)
+		assert.InDelta(t, 0.436419, marker.W, 0.000001)
+		assert.InDelta(t, 0.485614, marker.H, 0.000001)
+	}
 }
 
 func TestFile_ValidFaceCount(t *testing.T) {

--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/geo/s2"
 	"github.com/photoprism/photoprism/pkg/media"
 	"github.com/photoprism/photoprism/pkg/rnd"
@@ -38,6 +39,7 @@ type Data struct {
 	Title            string        `meta:"Title,Headline" xmp:"dc:title" dc:"title,title.Alt"`
 	Caption          string        `meta:"Description,ImageDescription,Caption,Caption-Abstract" xmp:"Description,Description.Alt"`
 	Subject          string        `meta:"Subject,PersonInImage,ObjectName,HierarchicalSubject,CatalogSets" xmp:"Subject"`
+	FaceRegions      crop.Areas    `meta:"-"`
 	Keywords         Keywords      `meta:"Keywords"`
 	Favorite         bool          `meta:"Favorite"`
 	Notes            string        `meta:"Comment,UserComment"`

--- a/internal/meta/testdata/mwg-regions.xmp
+++ b/internal/meta/testdata/mwg-regions.xmp
@@ -1,0 +1,51 @@
+<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="XMP Core 4.4.0-Exiv2">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+   xmlns:mwg-rs="http://www.metadataworkinggroup.com/schemas/regions/"
+   xmlns:stArea="http://ns.adobe.com/xmp/sType/Area#"
+   xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#">
+   <mwg-rs:Regions rdf:parseType="Resource">
+    <mwg-rs:AppliedToDimensions
+     stDim:w="200"
+     stDim:h="100"
+     stDim:unit="pixel"/>
+    <mwg-rs:RegionList>
+     <rdf:Bag>
+      <rdf:li>
+       <rdf:Description mwg-rs:Name="Ryan Gosling" mwg-rs:Type="Face">
+        <mwg-rs:Area
+         stArea:x="0.498486"
+         stArea:y="0.367807"
+         stArea:w="0.436419"
+         stArea:h="0.485614"
+         stArea:unit="normalized"/>
+       </rdf:Description>
+      </rdf:li>
+      <rdf:li>
+       <rdf:Description mwg-rs:Name="Pixel Face" mwg-rs:Type="Face">
+        <mwg-rs:Area
+         stArea:x="100"
+         stArea:y="80"
+         stArea:w="40"
+         stArea:h="20"
+         stArea:unit="pixel"/>
+       </rdf:Description>
+      </rdf:li>
+      <rdf:li>
+       <rdf:Description mwg-rs:Name="Not a face" mwg-rs:Type="Pet">
+        <mwg-rs:Area
+         stArea:x="0.1"
+         stArea:y="0.1"
+         stArea:w="0.2"
+         stArea:h="0.2"
+         stArea:unit="normalized"/>
+       </rdf:Description>
+      </rdf:li>
+     </rdf:Bag>
+    </mwg-rs:RegionList>
+   </mwg-rs:Regions>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>

--- a/internal/meta/xmp.go
+++ b/internal/meta/xmp.go
@@ -75,6 +75,10 @@ func (data *Data) XMP(fileName string) (err error) {
 		data.AddKeywords(doc.Keywords())
 	}
 
+	if faceRegions := doc.FaceRegions(); len(faceRegions) != 0 {
+		data.FaceRegions = faceRegions
+	}
+
 	data.Favorite = doc.Favorite()
 
 	return nil

--- a/internal/meta/xmp_document.go
+++ b/internal/meta/xmp_document.go
@@ -3,11 +3,38 @@ package meta
 import (
 	"encoding/xml"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/txt"
 )
+
+type xmpRegions struct {
+	AppliedToDimensions struct {
+		W    string `xml:"w,attr" json:"w,omitempty"`
+		H    string `xml:"h,attr" json:"h,omitempty"`
+		Unit string `xml:"unit,attr" json:"unit,omitempty"`
+	} `xml:"AppliedToDimensions" json:"appliedToDimensions"`
+	RegionList struct {
+		Bag struct {
+			Li []struct {
+				Description struct {
+					Name string `xml:"Name,attr" json:"name,omitempty"`
+					Type string `xml:"Type,attr" json:"type,omitempty"`
+					Area struct {
+						X    string `xml:"x,attr" json:"x,omitempty"`
+						Y    string `xml:"y,attr" json:"y,omitempty"`
+						W    string `xml:"w,attr" json:"w,omitempty"`
+						H    string `xml:"h,attr" json:"h,omitempty"`
+						Unit string `xml:"unit,attr" json:"unit,omitempty"`
+					} `xml:"Area" json:"area"`
+				} `xml:"Description" json:"description"`
+			} `xml:"li" json:"li"`
+		} `xml:"Bag" json:"bag"`
+	} `xml:"RegionList" json:"regionList"`
+}
 
 // XmpDocument represents an XMP sidecar file.
 type XmpDocument struct {
@@ -197,6 +224,7 @@ type XmpDocument struct {
 					Li   string `xml:"li"` // Gopher
 				} `xml:"Bag" json:"bag"`
 			} `xml:"PersonInImage" json:"personinimage"`
+			Regions xmpRegions `xml:"Regions" json:"regions"`
 		} `xml:"Description" json:"description"`
 	} `xml:"RDF" json:"rdf"`
 }
@@ -289,4 +317,61 @@ func (doc *XmpDocument) Keywords() string {
 func (doc *XmpDocument) Favorite() bool {
 	fstop := doc.RDF.Description.FStopFavorite
 	return fstop == "1"
+}
+
+// FaceRegions returns face areas found in MWG region metadata.
+func (doc *XmpDocument) FaceRegions() crop.Areas {
+	mwg := doc.RDF.Description.Regions
+	regions := mwg.RegionList.Bag.Li
+	result := make(crop.Areas, 0, len(regions))
+	dimW, dimH, hasDim := xmpDimensions(mwg.AppliedToDimensions.W, mwg.AppliedToDimensions.H, mwg.AppliedToDimensions.Unit)
+
+	for _, region := range regions {
+		desc := region.Description
+
+		if !strings.EqualFold(desc.Type, "Face") {
+			continue
+		}
+
+		if area, ok := xmpRegionArea(desc.Area.X, desc.Area.Y, desc.Area.W, desc.Area.H, desc.Area.Unit, dimW, dimH, hasDim); ok {
+			area.Name = SanitizeString(desc.Name)
+			result = append(result, area)
+		}
+	}
+
+	return result
+}
+
+func xmpRegionArea(xVal, yVal, wVal, hVal, unit string, dimW, dimH float32, hasDim bool) (crop.Area, bool) {
+	x, okX := xmpFloat(xVal)
+	y, okY := xmpFloat(yVal)
+	w, okW := xmpFloat(wVal)
+	h, okH := xmpFloat(hVal)
+
+	if !okX || !okY || !okW || !okH || w <= 0 || h <= 0 {
+		return crop.Area{}, false
+	}
+
+	switch {
+	case strings.EqualFold(unit, "normalized"):
+	case strings.EqualFold(unit, "pixel") && hasDim:
+		x, y, w, h = x/dimW, y/dimH, w/dimW, h/dimH
+	default:
+		return crop.Area{}, false
+	}
+
+	return crop.NewArea("", x-(w/2), y-(h/2), w, h), true
+}
+
+func xmpDimensions(wVal, hVal, unit string) (float32, float32, bool) {
+	w, okW := xmpFloat(wVal)
+	h, okH := xmpFloat(hVal)
+
+	return w, h, okW && okH && w > 0 && h > 0 && strings.EqualFold(unit, "pixel")
+}
+
+func xmpFloat(s string) (float32, bool) {
+	f, err := strconv.ParseFloat(strings.TrimSpace(s), 32)
+
+	return float32(f), err == nil
 }

--- a/internal/meta/xmp_test.go
+++ b/internal/meta/xmp_test.go
@@ -87,4 +87,24 @@ func TestXMP(t *testing.T) {
 		assert.True(t, data.TakenAtLocal.IsZero())
 		assert.Equal(t, "UTC", data.TimeZone)
 	})
+	t.Run("MwgRegions", func(t *testing.T) {
+		data, err := XMP("testdata/mwg-regions.xmp")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if assert.Len(t, data.FaceRegions, 2) {
+			assert.Equal(t, "Ryan Gosling", data.FaceRegions[0].Name)
+			assert.InDelta(t, 0.2802765, data.FaceRegions[0].X, 0.000001)
+			assert.InDelta(t, 0.125, data.FaceRegions[0].Y, 0.000001)
+			assert.InDelta(t, 0.436419, data.FaceRegions[0].W, 0.000001)
+			assert.InDelta(t, 0.485614, data.FaceRegions[0].H, 0.000001)
+			assert.Equal(t, "Pixel Face", data.FaceRegions[1].Name)
+			assert.InDelta(t, 0.4, data.FaceRegions[1].X, 0.000001)
+			assert.InDelta(t, 0.7, data.FaceRegions[1].Y, 0.000001)
+			assert.InDelta(t, 0.2, data.FaceRegions[1].W, 0.000001)
+			assert.InDelta(t, 0.2, data.FaceRegions[1].H, 0.000001)
+		}
+	})
 }

--- a/internal/photoprism/index_faces.go
+++ b/internal/photoprism/index_faces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/photoprism/photoprism/internal/ai/vision"
 	"github.com/photoprism/photoprism/internal/entity"
 	"github.com/photoprism/photoprism/internal/thumb"
+	"github.com/photoprism/photoprism/internal/thumb/crop"
 	"github.com/photoprism/photoprism/pkg/clean"
 )
 
@@ -67,6 +68,35 @@ func ApplyDetectedFaces(file *entity.File, faces face.Faces) (saved bool, count 
 	}
 
 	file.AddFaces(faces)
+
+	savedMarkers, saveErr := file.SaveMarkers()
+
+	if saveErr != nil {
+		return false, 0, saveErr
+	}
+
+	if savedMarkers == 0 {
+		return false, 0, nil
+	}
+
+	if count, err = file.UpdatePhotoFaceCount(); err != nil {
+		return true, count, err
+	}
+
+	return true, count, nil
+}
+
+// ApplyFaceRegions persists metadata face regions on the given file and updates face counts.
+func ApplyFaceRegions(file *entity.File, regions crop.Areas) (saved bool, count int, err error) {
+	if file == nil {
+		return false, 0, fmt.Errorf("faces: file is nil")
+	}
+
+	if len(regions) == 0 {
+		return false, 0, nil
+	}
+
+	file.AddFaceRegions(regions)
 
 	savedMarkers, saveErr := file.SaveMarkers()
 

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -495,6 +495,22 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			if data.Favorite {
 				_ = photo.SetFavorite(data.Favorite)
 			}
+
+			if len(data.FaceRegions) > 0 {
+				markerFile := &primaryFile
+
+				if markerFile.FileUID == "" && file.FilePrimary {
+					markerFile = &file
+				}
+
+				if markerFile.FileUID != "" {
+					if saved, count, faceErr := ApplyFaceRegions(markerFile, data.FaceRegions); faceErr != nil {
+						log.Warnf("index: %s while importing XMP face regions from %s", faceErr, logName)
+					} else if saved {
+						photo.PhotoFaces = count
+					}
+				}
+			}
 		} else {
 			log.Warn(dataErr.Error())
 			file.FileError = clip.Chars(dataErr.Error(), txt.ClipError)


### PR DESCRIPTION
# Import MWG XMP face regions from sidecar files

## Summary

Adds support for pulling face regions out of MWG XMP sidecars, including the `mwg-rs:Regions` / `mwg-rs:RegionList` metadata written by Adobe and similar tools.

I kept this separate from the existing face-detection path. XMP regions are converted into crop areas and stored as `SrcXmp` markers while the sidecar is indexed; the normal face merge logic is left alone.

## Changes

- Parse `mwg-rs:RegionList` face entries from XMP sidecars
- Convert MWG's center-based rectangles to PhotoPrism's top-left crop format
- Handle normalized coordinates and pixel coordinates when `AppliedToDimensions` is present
- Skip regions that are not type `Face`
- Store imported regions as `SrcXmp` face markers through a small helper, without modifying `File.AddFace`

## Tests

```text
go test ./internal/meta -run TestXMP/MwgRegions -count=1
go test ./internal/meta -count=1
go test ./internal/entity -run TestFile_AddFaceRegions -count=1
go test ./internal/photoprism -run 'TestApplyFaceRegions|TestIndex' -count=1
git diff --check
```

On macOS, the entity and photoprism package tests needed Homebrew `libtensorflow` headers plus the usual `CPATH` / `LIBRARY_PATH` setup before the TensorFlow bindings would compile. Once that was in place, they passed cleanly.

## Notes

This is deliberately small so it does not interfere with the normal face detection flow. Existing behavior is unchanged unless an XMP sidecar contains MWG face regions.

Fixes #554.
