### PR TITLE
Discover: add On This Day memories tab

### DIFF
--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -605,6 +605,13 @@ export default [
     props: { tab: 3 },
   },
   {
+    name: "discover_memories",
+    path: "/discover/memories",
+    component: Discover,
+    meta: { title: $gettext("Discover"), requiresAuth: true, background: "background" },
+    props: { tab: 4 },
+  },
+  {
     path: "/:pathMatch(.*)*",
     redirect: "/albums",
   },

--- a/frontend/src/page/discover.vue
+++ b/frontend/src/page/discover.vue
@@ -17,6 +17,10 @@
         {{ $gettext(`Random`) }}
       </v-tab>
 
+      <v-tab id="tab-discover-memories" ripple @click="changePath('/discover/memories')">
+        {{ $gettext(`Memories`) }}
+      </v-tab>
+
       <v-tabs-window v-model="active">
         <v-tabs-window-item>
           <p-tab-discover-colors></p-tab-discover-colors>
@@ -33,6 +37,10 @@
         <v-tabs-window-item>
           <p-tab-discover-todo></p-tab-discover-todo>
         </v-tabs-window-item>
+
+        <v-tabs-window-item>
+          <p-tab-discover-memories></p-tab-discover-memories>
+        </v-tabs-window-item>
       </v-tabs-window>
     </v-tabs>
   </div>
@@ -40,12 +48,14 @@
 
 <script>
 import tabColors from "page/discover/colors.vue";
+import tabMemories from "page/discover/memories.vue";
 import tabTodo from "page/discover/todo.vue";
 
 export default {
   name: "PPageDiscover",
   components: {
     "p-tab-discover-colors": tabColors,
+    "p-tab-discover-memories": tabMemories,
     "p-tab-discover-todo": tabTodo,
   },
   props: {

--- a/frontend/src/page/discover/memories.vue
+++ b/frontend/src/page/discover/memories.vue
@@ -1,0 +1,184 @@
+<template>
+  <div class="p-tab p-tab-discover-memories">
+    <div class="pa-2 text-center">
+      <p class="text-subtitle-1 pb-2">
+        {{ $gettext("On This Day") }}
+      </p>
+
+      <p class="text-body-1 pb-6">
+        {{ memoryDateLabel }}
+      </p>
+
+      <div v-if="loading" class="py-8">
+        <v-progress-circular color="primary" indeterminate></v-progress-circular>
+      </div>
+
+      <v-alert v-else-if="error" color="warning" variant="outlined" icon="mdi-alert-outline" class="mx-auto mb-6 text-start memories-alert">
+        {{ $gettext("Something went wrong, try again") }}
+      </v-alert>
+
+      <v-alert v-else-if="memoryGroups.length === 0" color="surface-variant" variant="outlined" icon="mdi-image-off-outline" class="mx-auto mb-6 text-start memories-alert">
+        {{ $gettext("No pictures found") }}
+      </v-alert>
+
+      <template v-else>
+        <div class="d-flex justify-center mb-6">
+          <v-btn color="button" rounded variant="flat" :to="{ name: 'browse', query: browseQuery() }">
+            {{ $gettext("Browse Pictures") }}
+          </v-btn>
+        </div>
+
+        <v-row class="text-start">
+          <v-col v-for="group in memoryGroups" :key="group.year" cols="12" sm="6" lg="4">
+            <v-card class="memory-card clickable" :to="{ name: 'browse', query: browseQuery(group.year) }" variant="tonal" color="surface-variant">
+              <v-card-text class="pb-2">
+                <div class="d-flex align-center justify-space-between">
+                  <div class="text-h6">{{ group.year }}</div>
+                  <v-chip size="small" color="primary" variant="tonal">
+                    {{ group.count }}
+                  </v-chip>
+                </div>
+              </v-card-text>
+
+              <div class="memory-preview-grid px-4 pb-4">
+                <div v-for="photo in group.preview" :key="photo.UID" class="memory-preview" :style="`background-image: url(${photo.thumbnailUrl('tile_500')})`"></div>
+              </div>
+            </v-card>
+          </v-col>
+        </v-row>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script>
+import { DateTime } from "luxon";
+import { Photo } from "model/photo";
+
+export default {
+  name: "PTabDiscoverMemories",
+  data() {
+    return {
+      loading: true,
+      error: false,
+      memoryDate: DateTime.local().startOf("day"),
+      memoryGroups: [],
+    };
+  },
+  computed: {
+    memoryDateLabel() {
+      return this.memoryDate.toLocaleString({ month: "long", day: "numeric" });
+    },
+  },
+  created() {
+    this.loadMemories();
+  },
+  methods: {
+    browseQuery(year) {
+      const query = {
+        month: this.memoryDate.month,
+        day: this.memoryDate.day,
+        order: "oldest",
+      };
+
+      if (year) {
+        query.year = year;
+      }
+
+      return query;
+    },
+    buildGroups(models) {
+      const groups = new Map();
+      const currentYear = this.memoryDate.year;
+
+      models.forEach((model) => {
+        const year = Number(model?.Year);
+
+        if (!Number.isInteger(year) || year <= 0 || year >= currentYear) {
+          return;
+        }
+
+        if (!groups.has(year)) {
+          groups.set(year, {
+            year,
+            count: 0,
+            preview: [],
+          });
+        }
+
+        const group = groups.get(year);
+        group.count += 1;
+
+        if (group.preview.length < 4) {
+          group.preview.push(model);
+        }
+      });
+
+      return Array.from(groups.values()).sort((a, b) => b.year - a.year);
+    },
+    async loadMemories() {
+      const params = {
+        count: 200,
+        day: this.memoryDate.day,
+        merged: true,
+        month: this.memoryDate.month,
+        order: "oldest",
+      };
+
+      if (this.$config.getSettings()?.features?.private) {
+        params.public = "true";
+      }
+
+      const memories = [];
+      let offset = 0;
+
+      try {
+        for (let page = 0; page < 25; page++) {
+          const response = await Photo.search({ ...params, offset });
+          const models = Array.isArray(response.models) ? response.models : [];
+          const total = Number.isFinite(response.count) ? response.count : models.length;
+          const responseOffset = Number.isFinite(response.offset) ? response.offset : offset;
+          const limit = Number.isFinite(response.limit) && response.limit > 0 ? response.limit : models.length;
+
+          memories.push(...models);
+
+          if (!models.length || limit <= 0 || memories.length >= total) {
+            break;
+          }
+
+          offset = responseOffset + limit;
+        }
+
+        this.memoryGroups = this.buildGroups(memories);
+      } catch {
+        this.error = true;
+      } finally {
+        this.loading = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.memories-alert {
+  max-width: 720px;
+}
+
+.memory-card {
+  height: 100%;
+}
+
+.memory-preview-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.memory-preview {
+  aspect-ratio: 1;
+  background-position: center;
+  background-size: cover;
+  border-radius: 12px;
+}
+</style>

--- a/frontend/src/page/photos.vue
+++ b/frontend/src/page/photos.vue
@@ -112,6 +112,7 @@ export default {
     const lens = query["lens"] ? parseInt(query["lens"]) : 0;
     const year = query["year"] ? parseInt(query["year"]) : 0;
     const month = query["month"] ? parseInt(query["month"]) : 0;
+    const day = query["day"] ? parseInt(query["day"]) : 0;
     const color = query["color"] ? query["color"] : "";
     const label = query["label"] ? query["label"] : "";
     const latlng = query["latlng"] ? query["latlng"] : "";
@@ -125,6 +126,7 @@ export default {
       latlng: latlng,
       year: year,
       month: month,
+      day: day,
       color: color,
       order: order,
       reverse: this.sortReverse(),
@@ -214,6 +216,7 @@ export default {
       this.filter.lens = query["lens"] ? parseInt(query["lens"]) : 0;
       this.filter.year = query["year"] ? parseInt(query["year"]) : 0;
       this.filter.month = query["month"] ? parseInt(query["month"]) : 0;
+      this.filter.day = query["day"] ? parseInt(query["day"]) : 0;
       this.filter.color = query["color"] ? query["color"] : "";
       this.filter.label = query["label"] ? query["label"] : "";
       this.filter.latlng = query["latlng"] ? query["latlng"] : "";

--- a/frontend/tests/vitest/page/discover.memories.test.js
+++ b/frontend/tests/vitest/page/discover.memories.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import PMemories from "page/discover/memories.vue";
+
+describe("page/discover/memories.vue", () => {
+  it("groups past memories by year and limits previews", () => {
+    const groups = PMemories.methods.buildGroups.call(
+      {
+        memoryDate: { year: 2026 },
+      },
+      [
+        { UID: "a", Year: 2025 },
+        { UID: "b", Year: 2024 },
+        { UID: "c", Year: 2025 },
+        { UID: "d", Year: 2026 },
+        { UID: "e", Year: 2025 },
+        { UID: "f", Year: 0 },
+        { UID: "g", Year: 2025 },
+        { UID: "h", Year: 2025 },
+      ]
+    );
+
+    expect(groups.map((group) => group.year)).toEqual([2025, 2024]);
+    expect(groups[0].count).toBe(5);
+    expect(groups[0].preview.map((photo) => photo.UID)).toEqual(["a", "c", "e", "g"]);
+  });
+
+  it("builds browse queries with month, day, and optional year", () => {
+    const stub = {
+      memoryDate: { month: 5, day: 14 },
+    };
+
+    expect(PMemories.methods.browseQuery.call(stub)).toEqual({
+      month: 5,
+      day: 14,
+      order: "oldest",
+    });
+
+    expect(PMemories.methods.browseQuery.call(stub, 2024)).toEqual({
+      month: 5,
+      day: 14,
+      order: "oldest",
+      year: 2024,
+    });
+  });
+});

--- a/frontend/tests/vitest/page/photos.filters.test.js
+++ b/frontend/tests/vitest/page/photos.filters.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import PPagePhotos from "page/photos.vue";
+
+function createConfig() {
+  return {
+    allow: vi.fn(() => true),
+    deny: vi.fn(() => false),
+    getSettings: vi.fn(() => ({
+      features: {
+        edit: true,
+        places: true,
+        private: false,
+        review: false,
+      },
+    })),
+  };
+}
+
+describe("page/photos.vue day filters", () => {
+  it("reads the day query into the initial filter state", () => {
+    const data = PPagePhotos.data.call({
+      $clipboard: {
+        selection: [],
+      },
+      $route: {
+        name: "browse",
+        query: {
+          day: "14",
+          month: "5",
+          year: "2024",
+        },
+      },
+      $config: createConfig(),
+      getViewType: () => "cards",
+      sortOrder: () => "newest",
+      sortReverse: () => false,
+    });
+
+    expect(data.filter.day).toBe(14);
+    expect(data.filter.month).toBe(5);
+    expect(data.filter.year).toBe(2024);
+  });
+
+  it("preserves the day filter when building route queries", () => {
+    const replace = vi.fn();
+    const stub = {
+      filter: {
+        camera: 0,
+        color: "",
+        country: "",
+        day: 14,
+        label: "",
+        latlng: "",
+        lens: 0,
+        month: 5,
+        order: "oldest",
+        q: "",
+        reverse: false,
+        year: 2024,
+      },
+      loading: false,
+      settings: {
+        view: "cards",
+      },
+      updateFilter: PPagePhotos.methods.updateFilter,
+      $route: {
+        query: {},
+      },
+      $router: {
+        replace,
+      },
+    };
+
+    const changed = PPagePhotos.methods.updateQuery.call(stub);
+
+    expect(changed).toBe(true);
+    expect(replace).toHaveBeenCalledWith({
+      query: {
+        view: "cards",
+        year: 2024,
+        month: 5,
+        day: 14,
+        order: "oldest",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Memories tab to Discover that shows media from the same month/day in past years
- group the memories by year with preview thumbnails and deep links into Browse
- preserve `day` route filters in the photo browser so Discover links stay navigable
- add Vitest coverage for memories grouping and day query propagation

Fixes #720

## Testing
- `npm run test --workspace frontend -- tests/vitest/page/discover.memories.test.js tests/vitest/page/photos.filters.test.js`
- `.\node_modules\.bin\eslint.cmd --cache --rule "linebreak-style: off" --rule "prettier/prettier: off" frontend/src/page/discover.vue frontend/src/page/discover/memories.vue frontend/src/page/photos.vue frontend/src/app/routes.js frontend/tests/vitest/page/discover.memories.test.js frontend/tests/vitest/page/photos.filters.test.js`