### PR TITLE
Albums: Add memory album type for "on this day" moments

### DIFF
--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -218,6 +218,19 @@ export default [
     meta: { collectionTitle: "Calendar", collectionRoute: "calendar", requiresAuth: true },
   },
   {
+    name: "memories",
+    path: "/memories",
+    component: Albums,
+    meta: { title: $gettext("Memories"), requiresAuth: true },
+    props: { view: "memory", defaultOrder: "newest", staticFilter: { type: "memory" } },
+  },
+  {
+    name: "memory",
+    path: "/memories/:album/:slug",
+    component: AlbumPhotos,
+    meta: { collectionTitle: $gettext("Memories"), collectionRoute: "memories", requiresAuth: true },
+  },
+  {
     name: "folders",
     path: "/folders",
     component: Albums,

--- a/internal/entity/album.go
+++ b/internal/entity/album.go
@@ -28,6 +28,7 @@ const (
 	AlbumMoment = "moment"
 	AlbumMonth  = "month"
 	AlbumState  = "state"
+	AlbumMemory = "memory"
 )
 
 var (
@@ -36,6 +37,7 @@ var (
 	DefaultOrderMoment = sortby.Oldest
 	DefaultOrderState  = sortby.Newest
 	DefaultOrderMonth  = sortby.Oldest
+	DefaultOrderMemory = sortby.Oldest
 )
 
 var (
@@ -350,6 +352,54 @@ func FindMonthAlbum(year, month int) *Album {
 	}
 
 	if UnscopedDb().First(&m, "album_year = ? AND album_month = ? AND album_type = ?", year, month, AlbumMonth).Error != nil {
+		return nil
+	}
+
+	return &m
+}
+
+// NewMemoryAlbum creates an automatically generated "on this day" album for a given month and day.
+func NewMemoryAlbum(albumTitle, albumSlug string, month, day int) *Album {
+	albumTitle = strings.TrimSpace(albumTitle)
+	albumSlug = strings.TrimSpace(albumSlug)
+
+	if albumTitle == "" || albumSlug == "" || month < 1 || month > 12 || day < 1 || day > 31 {
+		return nil
+	}
+
+	f := form.SearchPhotos{
+		Month:  strconv.Itoa(month),
+		Day:    strconv.Itoa(day),
+		Public: true,
+	}
+
+	now := Now()
+
+	result := &Album{
+		AlbumOrder:  DefaultOrderMemory,
+		AlbumType:   AlbumMemory,
+		AlbumSlug:   txt.Clip(albumSlug, txt.ClipSlug),
+		AlbumFilter: f.Serialize(),
+		AlbumMonth:  month,
+		AlbumDay:    day,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	result.SetTitle(albumTitle)
+
+	return result
+}
+
+// FindMemoryAlbum returns the memory album for the given month and day, or nil if none exists.
+func FindMemoryAlbum(month, day int) *Album {
+	m := Album{}
+
+	if month < 1 || month > 12 || day < 1 || day > 31 {
+		return nil
+	}
+
+	if UnscopedDb().First(&m, "album_month = ? AND album_day = ? AND album_type = ?", month, day, AlbumMemory).Error != nil {
 		return nil
 	}
 

--- a/internal/entity/query/moments.go
+++ b/internal/entity/query/moments.go
@@ -305,6 +305,51 @@ func MomentsLabels(threshold int, public bool) (results Moments, err error) {
 	return results, nil
 }
 
+// MemoryMoment represents a day-of-year (month + day) that has photos spanning at least two calendar years.
+type MemoryMoment struct {
+	Month      int `json:"Month"`
+	Day        int `json:"Day"`
+	YearCount  int `json:"YearCount"`
+	PhotoCount int `json:"PhotoCount"`
+}
+
+// Title returns a human-readable title for the memory album, e.g. "January 15".
+func (m MemoryMoment) Title() string {
+	t := time.Date(2000, time.Month(m.Month), m.Day, 0, 0, 0, 0, time.UTC)
+	return t.Format("January 2")
+}
+
+// Slug returns a URL-friendly identifier for the memory album, e.g. "january-15".
+func (m MemoryMoment) Slug() string {
+	return txt.Slug(m.Title())
+}
+
+// MomentsMemories returns day-of-year groups (month + day) that have photos from at least two distinct years.
+func MomentsMemories(threshold int, public bool) (results []MemoryMoment, err error) {
+	stmt := UnscopedDb().Table("photos").
+		Select("photo_month AS month, photo_day AS day, COUNT(DISTINCT photo_year) AS year_count, COUNT(*) AS photo_count").
+		Where("photo_quality >= 3 AND deleted_at IS NULL AND photo_year > 0 AND photo_month > 0 AND photo_day > 0")
+
+	if public {
+		stmt = stmt.Where("photo_private = 0")
+	}
+
+	minYears := 2
+	if threshold > minYears {
+		minYears = threshold
+	}
+
+	stmt = stmt.Group("photo_month, photo_day").
+		Order("photo_month, photo_day").
+		Having("year_count >= ?", minYears)
+
+	if err = stmt.Scan(&results).Error; err != nil {
+		return results, err
+	}
+
+	return results, nil
+}
+
 // RemoveDuplicateMoments deletes generated albums with duplicate slug or filter.
 func RemoveDuplicateMoments() (removed int, err error) {
 	if res := UnscopedDb().Exec(`DELETE FROM links WHERE share_uid 

--- a/internal/entity/query/moments_test.go
+++ b/internal/entity/query/moments_test.go
@@ -67,6 +67,40 @@ func TestMomentsTime(t *testing.T) {
 	})
 }
 
+func TestMomentsMemories(t *testing.T) {
+	t.Run("PublicOnly", func(t *testing.T) {
+		results, err := MomentsMemories(1, true)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("MomentsMemories %+v", results)
+
+		for _, mom := range results {
+			t.Logf("Title: %s, Slug: %s, Month: %d, Day: %d, Years: %d", mom.Title(), mom.Slug(), mom.Month, mom.Day, mom.YearCount)
+
+			assert.GreaterOrEqual(t, mom.Month, 1)
+			assert.LessOrEqual(t, mom.Month, 12)
+			assert.GreaterOrEqual(t, mom.Day, 1)
+			assert.LessOrEqual(t, mom.Day, 31)
+			assert.GreaterOrEqual(t, mom.YearCount, 2)
+			assert.GreaterOrEqual(t, mom.PhotoCount, 1)
+			assert.NotEmpty(t, mom.Title())
+			assert.NotEmpty(t, mom.Slug())
+		}
+	})
+	t.Run("IncludePrivate", func(t *testing.T) {
+		results, err := MomentsMemories(1, false)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("MomentsMemories (private) %+v", results)
+	})
+}
+
 func TestMomentsCountries(t *testing.T) {
 	t.Run("PublicOnly", func(t *testing.T) {
 		results, err := MomentsCountries(1, true)

--- a/internal/photoprism/moments.go
+++ b/internal/photoprism/moments.go
@@ -253,6 +253,29 @@ func (w *Moments) Start() (err error) {
 		}
 	}
 
+	// Create memory albums for days that have photos from at least two different years.
+	if results, queryErr := query.MomentsMemories(1, w.conf.Settings().Features.Private); queryErr != nil {
+		log.Errorf("moments: %s", queryErr.Error())
+	} else {
+		for _, mom := range results {
+			if a := entity.FindMemoryAlbum(mom.Month, mom.Day); a != nil {
+				if !a.Deleted() {
+					log.Tracef("moments: memory %s already exists (%s)", clean.Log(a.AlbumTitle), a.AlbumFilter)
+				} else if restoreErr := a.Restore(); restoreErr != nil {
+					log.Errorf("moments: %s (restore memory)", restoreErr.Error())
+				} else {
+					log.Infof("moments: %s restored", clean.Log(a.AlbumTitle))
+				}
+			} else if a := entity.NewMemoryAlbum(mom.Title(), mom.Slug(), mom.Month, mom.Day); a != nil {
+				if err := a.Create(); err != nil {
+					log.Errorf("moments: %s (create memory)", err)
+				} else {
+					log.Infof("moments: added memory %s (%s)", clean.Log(a.AlbumTitle), a.AlbumFilter)
+				}
+			}
+		}
+	}
+
 	// UpdateFolderDates updates folder year, month and day based on indexed photo metadata.
 	if queryErr := query.UpdateFolderDates(); queryErr != nil {
 		log.Errorf("moments: %s (update folder dates)", queryErr.Error())


### PR DESCRIPTION
**As a PhotoPrism user, I want to discover photos from the same day in previous years, so that I can relive memories the way Facebook and Google Photos do.**

Closes #720

## What this PR does

Adds `AlbumMemory` (`"memory"`) as a new auto-generated album type. The Moments worker now creates one memory album per (month, day) pair where photos exist across **at least two distinct calendar years**. Each album surfaces all photos taken on that date regardless of year, using the existing `Month` + `Day` filter combination already supported by `form.SearchPhotos`.

## Changes

### Backend — `internal/entity/album.go`
- `AlbumMemory = "memory"` constant and `DefaultOrderMemory` sort order
- `NewMemoryAlbum(title, slug string, month, day int) *Album` — constructor following the same pattern as `NewMonthAlbum`
- `FindMemoryAlbum(month, day int) *Album` — lookup by month + day + type

### Backend — `internal/entity/query/moments.go`
- `MemoryMoment` struct with `Month`, `Day`, `YearCount`, `PhotoCount` fields
- `MemoryMoment.Title()` — returns e.g. `"January 15"`
- `MemoryMoment.Slug()` — returns e.g. `"january-15"`
- `MomentsMemories(threshold int, public bool)` — groups photos by `photo_month` + `photo_day`, filters `HAVING year_count >= 2`, respects the public/private setting

### Backend — `internal/entity/query/moments_test.go`
- `TestMomentsMemories` with `PublicOnly` and `IncludePrivate` sub-tests

### Backend — `internal/photoprism/moments.go`
- New generation loop in `Moments.Start()` that creates or restores a memory album for each result from `MomentsMemories`, placed before the existing `UpdateFolderDates` step

### Frontend — `frontend/src/app/routes.js`
- `/memories` list route (`view: "memory"`, `staticFilter: { type: "memory" }`)
- `/memories/:album/:slug` detail route (reuses `AlbumPhotos` component, same as Calendar and Moments)

## How it works

1. When the Moments worker runs, `MomentsMemories` queries for every (month, day) where photos span ≥ 2 years.
2. For each result a `memory` album is created with filter `month=M&day=D` — this causes the photo search to return all photos taken on that date across all years.
3. Users navigate to `/memories` to browse their memory albums, then open one to see the full cross-year gallery.

## Acceptance criteria

- [ ] `AlbumMemory` constant compiles without conflict
- [ ] `MomentsMemories` returns only month+day pairs with `year_count >= 2`
- [ ] Moments worker creates one memory album per qualifying (month, day)
- [ ] Deleted memory albums are restored on the next worker run
- [ ] `/memories` route renders the Albums page filtered to `type: "memory"`
- [ ] `/memories/:album/:slug` opens the photo grid for the selected memory