### PR TITLE
Import XMP face regions

### DIFF
--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -73,6 +73,7 @@ type Data struct {
 	Rotation         int           `meta:"Rotation"`
 	Views            int           `meta:"-"`
 	Albums           []string      `meta:"-"`
+	FaceRegions      FaceRegions   `meta:"-"`
 	Warning          string        `meta:"Warning" report:"-"`
 	Error            error         `meta:"-"`
 	json             map[string]string

--- a/internal/meta/testdata/regions.xmp
+++ b/internal/meta/testdata/regions.xmp
@@ -1,0 +1,26 @@
+<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+      xmlns:mwg-rs="http://www.metadataworkinggroup.com/schemas/regions/"
+      xmlns:stArea="http://ns.adobe.com/xmp/sType/Area#">
+      <mwg-rs:Regions rdf:parseType="Resource">
+        <mwg-rs:RegionList>
+          <rdf:Bag>
+            <rdf:li>
+              <rdf:Description mwg-rs:Name="Ryan Gosling" mwg-rs:Type="Face">
+                <mwg-rs:Area stArea:x="0.498486" stArea:y="0.367807" stArea:w="0.436419" stArea:h="0.485614" stArea:unit="normalized"/>
+              </rdf:Description>
+            </rdf:li>
+            <rdf:li>
+              <rdf:Description mwg-rs:Name="Ignored Area" mwg-rs:Type="Pet">
+                <mwg-rs:Area stArea:x="0.25" stArea:y="0.25" stArea:w="0.1" stArea:h="0.1" stArea:unit="normalized"/>
+              </rdf:Description>
+            </rdf:li>
+          </rdf:Bag>
+        </mwg-rs:RegionList>
+      </mwg-rs:Regions>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>

--- a/internal/meta/testdata/regions.xmp
+++ b/internal/meta/testdata/regions.xmp
@@ -17,6 +17,9 @@
                 <mwg-rs:Area stArea:x="0.25" stArea:y="0.25" stArea:w="0.1" stArea:h="0.1" stArea:unit="normalized"/>
               </rdf:Description>
             </rdf:li>
+            <rdf:li rdf:parseType="Resource" mwg-rs:Name="Neil Armstrong" mwg-rs:Type="Face">
+              <mwg-rs:Area stArea:x="0.3" stArea:y="0.4" stArea:w="0.2" stArea:h="0.3" stArea:unit="normalized"/>
+            </rdf:li>
           </rdf:Bag>
         </mwg-rs:RegionList>
       </mwg-rs:Regions>

--- a/internal/meta/xmp.go
+++ b/internal/meta/xmp.go
@@ -76,6 +76,7 @@ func (data *Data) XMP(fileName string) (err error) {
 	}
 
 	data.Favorite = doc.Favorite()
+	data.FaceRegions = doc.FaceRegions()
 
 	return nil
 }

--- a/internal/meta/xmp_document.go
+++ b/internal/meta/xmp_document.go
@@ -197,6 +197,7 @@ type XmpDocument struct {
 					Li   string `xml:"li"` // Gopher
 				} `xml:"Bag" json:"bag"`
 			} `xml:"PersonInImage" json:"personinimage"`
+			Regions xmpRegions `xml:"Regions" json:"regions"`
 		} `xml:"Description" json:"description"`
 	} `xml:"RDF" json:"rdf"`
 }
@@ -289,4 +290,9 @@ func (doc *XmpDocument) Keywords() string {
 func (doc *XmpDocument) Favorite() bool {
 	fstop := doc.RDF.Description.FStopFavorite
 	return fstop == "1"
+}
+
+// FaceRegions returns normalized face regions found in the XMP document.
+func (doc *XmpDocument) FaceRegions() FaceRegions {
+	return doc.RDF.Description.Regions.FaceRegions()
 }

--- a/internal/meta/xmp_regions.go
+++ b/internal/meta/xmp_regions.go
@@ -22,20 +22,25 @@ type xmpRegions struct {
 	RegionList struct {
 		Bag struct {
 			Li []struct {
+				Name        string        `xml:"http://www.metadataworkinggroup.com/schemas/regions/ Name,attr"`
+				Type        string        `xml:"http://www.metadataworkinggroup.com/schemas/regions/ Type,attr"`
+				DirectArea  xmpRegionArea `xml:"Area"`
 				Description struct {
-					Name string `xml:"http://www.metadataworkinggroup.com/schemas/regions/ Name,attr"`
-					Type string `xml:"http://www.metadataworkinggroup.com/schemas/regions/ Type,attr"`
-					Area struct {
-						X    string `xml:"http://ns.adobe.com/xmp/sType/Area# x,attr"`
-						Y    string `xml:"http://ns.adobe.com/xmp/sType/Area# y,attr"`
-						W    string `xml:"http://ns.adobe.com/xmp/sType/Area# w,attr"`
-						H    string `xml:"http://ns.adobe.com/xmp/sType/Area# h,attr"`
-						Unit string `xml:"http://ns.adobe.com/xmp/sType/Area# unit,attr"`
-					} `xml:"Area"`
+					Name string        `xml:"http://www.metadataworkinggroup.com/schemas/regions/ Name,attr"`
+					Type string        `xml:"http://www.metadataworkinggroup.com/schemas/regions/ Type,attr"`
+					Area xmpRegionArea `xml:"Area"`
 				} `xml:"Description"`
 			} `xml:"li"`
 		} `xml:"Bag"`
 	} `xml:"RegionList"`
+}
+
+type xmpRegionArea struct {
+	X    string `xml:"http://ns.adobe.com/xmp/sType/Area# x,attr"`
+	Y    string `xml:"http://ns.adobe.com/xmp/sType/Area# y,attr"`
+	W    string `xml:"http://ns.adobe.com/xmp/sType/Area# w,attr"`
+	H    string `xml:"http://ns.adobe.com/xmp/sType/Area# h,attr"`
+	Unit string `xml:"http://ns.adobe.com/xmp/sType/Area# unit,attr"`
 }
 
 func parseRegionFloat(s string) float32 {
@@ -63,15 +68,23 @@ func (r FaceRegion) Valid() bool {
 
 func (r xmpRegions) FaceRegions() (regions FaceRegions) {
 	for _, li := range r.RegionList.Bag.Li {
-		d := li.Description
+		name := li.Description.Name
+		regionType := li.Description.Type
+		area := li.Description.Area
+
+		if name == "" && regionType == "" {
+			name = li.Name
+			regionType = li.Type
+			area = li.DirectArea
+		}
 
 		region := FaceRegion{
-			Name: SanitizeString(d.Name),
-			Type: SanitizeString(d.Type),
-			X:    parseRegionFloat(d.Area.X),
-			Y:    parseRegionFloat(d.Area.Y),
-			W:    parseRegionFloat(d.Area.W),
-			H:    parseRegionFloat(d.Area.H),
+			Name: SanitizeString(name),
+			Type: SanitizeString(regionType),
+			X:    parseRegionFloat(area.X),
+			Y:    parseRegionFloat(area.Y),
+			W:    parseRegionFloat(area.W),
+			H:    parseRegionFloat(area.H),
 		}
 
 		if region.Valid() {

--- a/internal/meta/xmp_regions.go
+++ b/internal/meta/xmp_regions.go
@@ -1,0 +1,83 @@
+package meta
+
+import (
+	"strconv"
+	"strings"
+)
+
+// FaceRegion represents an XMP face area with normalized coordinates.
+type FaceRegion struct {
+	Name string
+	Type string
+	X    float32
+	Y    float32
+	W    float32
+	H    float32
+}
+
+// FaceRegions represents a list of XMP face regions.
+type FaceRegions []FaceRegion
+
+type xmpRegions struct {
+	RegionList struct {
+		Bag struct {
+			Li []struct {
+				Description struct {
+					Name string `xml:"http://www.metadataworkinggroup.com/schemas/regions/ Name,attr"`
+					Type string `xml:"http://www.metadataworkinggroup.com/schemas/regions/ Type,attr"`
+					Area struct {
+						X    string `xml:"http://ns.adobe.com/xmp/sType/Area# x,attr"`
+						Y    string `xml:"http://ns.adobe.com/xmp/sType/Area# y,attr"`
+						W    string `xml:"http://ns.adobe.com/xmp/sType/Area# w,attr"`
+						H    string `xml:"http://ns.adobe.com/xmp/sType/Area# h,attr"`
+						Unit string `xml:"http://ns.adobe.com/xmp/sType/Area# unit,attr"`
+					} `xml:"Area"`
+				} `xml:"Description"`
+			} `xml:"li"`
+		} `xml:"Bag"`
+	} `xml:"RegionList"`
+}
+
+func parseRegionFloat(s string) float32 {
+	if f, err := strconv.ParseFloat(strings.TrimSpace(s), 32); err == nil {
+		return float32(f)
+	}
+
+	return 0
+}
+
+// Left returns the top-left X coordinate used by PhotoPrism markers.
+func (r FaceRegion) Left() float32 {
+	return r.X - r.W/2
+}
+
+// Top returns the top-left Y coordinate used by PhotoPrism markers.
+func (r FaceRegion) Top() float32 {
+	return r.Y - r.H/2
+}
+
+// Valid tests if the region contains a usable normalized face area.
+func (r FaceRegion) Valid() bool {
+	return strings.EqualFold(r.Type, "face") && r.W > 0 && r.H > 0
+}
+
+func (r xmpRegions) FaceRegions() (regions FaceRegions) {
+	for _, li := range r.RegionList.Bag.Li {
+		d := li.Description
+
+		region := FaceRegion{
+			Name: SanitizeString(d.Name),
+			Type: SanitizeString(d.Type),
+			X:    parseRegionFloat(d.Area.X),
+			Y:    parseRegionFloat(d.Area.Y),
+			W:    parseRegionFloat(d.Area.W),
+			H:    parseRegionFloat(d.Area.H),
+		}
+
+		if region.Valid() {
+			regions = append(regions, region)
+		}
+	}
+
+	return regions
+}

--- a/internal/meta/xmp_test.go
+++ b/internal/meta/xmp_test.go
@@ -87,4 +87,24 @@ func TestXMP(t *testing.T) {
 		assert.True(t, data.TakenAtLocal.IsZero())
 		assert.Equal(t, "UTC", data.TimeZone)
 	})
+	t.Run("Regions", func(t *testing.T) {
+		data, err := XMP("testdata/regions.xmp")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if assert.Len(t, data.FaceRegions, 1) {
+			region := data.FaceRegions[0]
+
+			assert.Equal(t, "Ryan Gosling", region.Name)
+			assert.Equal(t, "Face", region.Type)
+			assert.InDelta(t, 0.498486, region.X, 0.000001)
+			assert.InDelta(t, 0.367807, region.Y, 0.000001)
+			assert.InDelta(t, 0.436419, region.W, 0.000001)
+			assert.InDelta(t, 0.485614, region.H, 0.000001)
+			assert.InDelta(t, 0.2802765, region.Left(), 0.000001)
+			assert.InDelta(t, 0.125, region.Top(), 0.000001)
+		}
+	})
 }

--- a/internal/meta/xmp_test.go
+++ b/internal/meta/xmp_test.go
@@ -94,7 +94,7 @@ func TestXMP(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if assert.Len(t, data.FaceRegions, 1) {
+		if assert.Len(t, data.FaceRegions, 2) {
 			region := data.FaceRegions[0]
 
 			assert.Equal(t, "Ryan Gosling", region.Name)
@@ -105,6 +105,15 @@ func TestXMP(t *testing.T) {
 			assert.InDelta(t, 0.485614, region.H, 0.000001)
 			assert.InDelta(t, 0.2802765, region.Left(), 0.000001)
 			assert.InDelta(t, 0.125, region.Top(), 0.000001)
+
+			direct := data.FaceRegions[1]
+
+			assert.Equal(t, "Neil Armstrong", direct.Name)
+			assert.Equal(t, "Face", direct.Type)
+			assert.InDelta(t, 0.3, direct.X, 0.000001)
+			assert.InDelta(t, 0.4, direct.Y, 0.000001)
+			assert.InDelta(t, 0.2, direct.W, 0.000001)
+			assert.InDelta(t, 0.3, direct.H, 0.000001)
 		}
 	})
 }

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -495,6 +495,10 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			if data.Favorite {
 				_ = photo.SetFavorite(data.Favorite)
 			}
+
+			if _, markerErr := importXmpFaceRegions(photo.ID, &file, data.FaceRegions); markerErr != nil {
+				log.Warnf("index: %s in %s (xmp face regions)", markerErr, logName)
+			}
 		} else {
 			log.Warn(dataErr.Error())
 			file.FileError = clip.Chars(dataErr.Error(), txt.ClipError)

--- a/internal/photoprism/index_xmp_markers.go
+++ b/internal/photoprism/index_xmp_markers.go
@@ -1,0 +1,107 @@
+package photoprism
+
+import (
+	"github.com/photoprism/photoprism/internal/ai/face"
+	"github.com/photoprism/photoprism/internal/entity"
+	"github.com/photoprism/photoprism/internal/meta"
+	"github.com/photoprism/photoprism/internal/thumb/crop"
+)
+
+func xmpMarkerTarget(photoID uint, file *entity.File) *entity.File {
+	if file == nil {
+		return nil
+	}
+
+	if file.FilePrimary && len(file.FileUID) != 0 {
+		return file
+	}
+
+	if photoID == 0 {
+		return nil
+	}
+
+	primary := &entity.File{}
+
+	if err := entity.UnscopedDb().
+		Where("photo_id = ? AND file_primary = 1 AND file_error = ''", photoID).
+		First(primary).Error; err != nil {
+		return nil
+	}
+
+	return primary
+}
+
+func mergeXmpFaceRegion(file *entity.File, region meta.FaceRegion) (changed bool, err error) {
+	if file == nil || !region.Valid() {
+		return false, nil
+	}
+
+	area := crop.NewArea("face", region.Left(), region.Top(), region.W, region.H)
+	marker := entity.NewMarker(*file, area, "", entity.SrcXmp, entity.MarkerFace, 100, 100)
+
+	if marker == nil {
+		return false, nil
+	}
+
+	marker.MarkerName = region.Name
+	marker.SubjSrc = entity.SrcXmp
+	marker.MarkerReview = false
+
+	markers := file.Markers()
+
+	for i := range *markers {
+		existing := &(*markers)[i]
+
+		if existing.MarkerType != entity.MarkerFace || existing.OverlapPercent(*marker) <= face.OverlapThreshold {
+			continue
+		}
+
+		if region.Name == "" {
+			return false, nil
+		}
+
+		if changed, err = existing.SetName(region.Name, entity.SrcXmp); err != nil {
+			return false, err
+		} else if changed && existing.MarkerUID != "" {
+			return true, existing.Save()
+		}
+
+		return changed, nil
+	}
+
+	markers.Append(*marker)
+
+	return true, nil
+}
+
+func importXmpFaceRegions(photoID uint, file *entity.File, regions meta.FaceRegions) (count int, err error) {
+	if len(regions) == 0 {
+		return 0, nil
+	}
+
+	target := xmpMarkerTarget(photoID, file)
+
+	if target == nil {
+		return 0, nil
+	}
+
+	for _, region := range regions {
+		if changed, mergeErr := mergeXmpFaceRegion(target, region); mergeErr != nil {
+			return count, mergeErr
+		} else if changed {
+			count++
+		}
+	}
+
+	if count == 0 {
+		return 0, nil
+	}
+
+	if _, err = target.SaveMarkers(); err != nil {
+		return count, err
+	}
+
+	_, err = target.UpdatePhotoFaceCount()
+
+	return count, err
+}


### PR DESCRIPTION
## Summary
- parse MWG/XMP face regions from XMP sidecars into metadata
- import region boxes as XMP-sourced face markers on the primary image file
- merge overlapping XMP regions into existing face markers by applying the XMP person name instead of creating duplicates

Fixes #554.

## Verification
- `go test ./internal/meta`
- `go test ./internal/photoprism` could not complete locally because this machine is missing PhotoPrism native dependencies: `pkg-config`/libvips and TensorFlow C headers.