### PR TITLE
Metrics: Add import and index progress counters

### DIFF
--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/photoprism/photoprism/internal/auth/acl"
 	"github.com/photoprism/photoprism/internal/config"
+	"github.com/photoprism/photoprism/internal/photoprism"
 	"github.com/photoprism/photoprism/internal/photoprism/get"
 	reg "github.com/photoprism/photoprism/internal/service/cluster/registry"
 	"github.com/photoprism/photoprism/pkg/http/header"
@@ -24,10 +25,12 @@ const (
 	metricsUsageSubsystem      = "usage"
 	metricsStatisticsSubsystem = "statistics"
 	metricsClusterSubsystem    = "cluster"
+	metricsWorkerSubsystem     = "worker"
 
 	metricsLabelState   = "state"
 	metricsLabelStat    = "stat"
 	metricsLabelRole    = "role"
+	metricsLabelWorker  = "worker"
 	metricsLabelUUID    = "uuid"
 	metricsLabelCIDR    = "cidr"
 	metricsLabelEdition = "edition"
@@ -42,6 +45,11 @@ const (
 	metricBuildInfo      = "build_info"
 	metricClusterNodes   = "nodes"
 	metricClusterInfo    = "info"
+	metricWorkerRunning  = "running"
+	metricWorkerFiles    = "files_processed"
+	metricWorkerBytes    = "bytes_processed"
+	metricWorkerStarted  = "started_time_seconds"
+	metricWorkerFinished = "finished_time_seconds"
 
 	metricsAccountsHelp      = "active user and guest accounts on this PhotoPrism instance"
 	metricsFilesBytesHelp    = "filesystem usage in bytes for files indexed by this PhotoPrism instance"
@@ -51,6 +59,11 @@ const (
 	metricsBuildInfoHelp     = "information about the photoprism instance"
 	metricsClusterNodesHelp  = "registered cluster nodes grouped by role"
 	metricsClusterInfoHelp   = "cluster metadata for this PhotoPrism portal"
+	metricsWorkerRunningHelp = "whether a PhotoPrism worker is currently processing files"
+	metricsWorkerFilesHelp   = "files processed by a PhotoPrism worker during its current or most recent run"
+	metricsWorkerBytesHelp   = "bytes processed by a PhotoPrism worker during its current or most recent run"
+	metricsWorkerStartedHelp  = "unix time when a PhotoPrism worker current or most recent run started"
+	metricsWorkerFinishedHelp = "unix time when a PhotoPrism worker most recent run finished"
 )
 
 // GetMetrics provides a Prometheus-compatible metrics endpoint for monitoring the instance, including usage details and portal cluster metrics.
@@ -87,6 +100,7 @@ func GetMetrics(router *gin.RouterGroup) {
 			registerBuildInfoMetric(factory, conf.ClientPublic())
 			registerUsageMetrics(factory, usage)
 			registerClusterMetrics(factory, conf)
+			registerWorkerProgressMetrics(factory, photoprism.WorkerProgressSnapshots())
 
 			var metrics []*dto.MetricFamily
 			var err error
@@ -296,4 +310,81 @@ func clusterNodeCounts(conf *config.Config) (map[string]int, error) {
 	}
 
 	return counts, nil
+}
+
+// registerWorkerProgressMetrics exports import and index processing progress metrics.
+func registerWorkerProgressMetrics(factory promauto.Factory, snapshots []photoprism.WorkerProgress) {
+	running := factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsWorkerSubsystem,
+			Name:      metricWorkerRunning,
+			Help:      metricsWorkerRunningHelp,
+		}, []string{metricsLabelWorker},
+	)
+
+	files := factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsWorkerSubsystem,
+			Name:      metricWorkerFiles,
+			Help:      metricsWorkerFilesHelp,
+		}, []string{metricsLabelWorker},
+	)
+
+	bytes := factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsWorkerSubsystem,
+			Name:      metricWorkerBytes,
+			Help:      metricsWorkerBytesHelp,
+		}, []string{metricsLabelWorker},
+	)
+
+	started := factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsWorkerSubsystem,
+			Name:      metricWorkerStarted,
+			Help:      metricsWorkerStartedHelp,
+		}, []string{metricsLabelWorker},
+	)
+
+	finished := factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsWorkerSubsystem,
+			Name:      metricWorkerFinished,
+			Help:      metricsWorkerFinishedHelp,
+		}, []string{metricsLabelWorker},
+	)
+
+	for _, snapshot := range snapshots {
+		if snapshot.Worker == "" {
+			continue
+		}
+
+		labels := prometheus.Labels{metricsLabelWorker: snapshot.Worker}
+
+		if snapshot.Running {
+			running.With(labels).Set(1)
+		} else {
+			running.With(labels).Set(0)
+		}
+
+		files.With(labels).Set(float64(snapshot.Files))
+		bytes.With(labels).Set(float64(snapshot.Bytes))
+
+		if snapshot.StartedAt.IsZero() {
+			started.With(labels).Set(0)
+		} else {
+			started.With(labels).Set(float64(snapshot.StartedAt.Unix()))
+		}
+
+		if snapshot.FinishedAt.IsZero() {
+			finished.With(labels).Set(0)
+		} else {
+			finished.With(labels).Set(float64(snapshot.FinishedAt.Unix()))
+		}
+	}
 }

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/photoprism/photoprism/internal/photoprism"
 	"github.com/photoprism/photoprism/internal/service/cluster"
 	reg "github.com/photoprism/photoprism/internal/service/cluster/registry"
 	"github.com/photoprism/photoprism/pkg/http/header"
@@ -114,6 +115,29 @@ func TestGetMetrics(t *testing.T) {
 			accountsFree := parseValue(`photoprism_usage_accounts_ratio{state="free"} (` + floatPattern + `)`)
 			assert.InEpsilon(t, 1.0, accountsUsed+accountsFree, 0.01)
 		})
+	})
+	t.Run("ExposeWorkerProgressMetrics", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+
+		GetMetrics(router)
+
+		photoprism.StartWorkerProgress(photoprism.ActionImport)
+		photoprism.ObserveWorkerProgress(photoprism.ActionImport, 2048)
+		t.Cleanup(func() {
+			photoprism.FinishWorkerProgress(photoprism.ActionImport)
+		})
+
+		resp := PerformRequestWithStream(app, "GET", "/api/v1/metrics")
+
+		if resp.Code != http.StatusOK {
+			t.Fatal(resp.Body.String())
+		}
+
+		body := resp.Body.String()
+
+		assert.Contains(t, body, `photoprism_worker_running{worker="import"} 1`)
+		assert.Contains(t, body, `photoprism_worker_files_processed{worker="import"} 1`)
+		assert.Contains(t, body, `photoprism_worker_bytes_processed{worker="import"} 2048`)
 	})
 	t.Run("ExposeClusterMetricsForPortal", func(t *testing.T) {
 		app, router, conf := NewApiTest()

--- a/internal/photoprism/import.go
+++ b/internal/photoprism/import.go
@@ -85,6 +85,9 @@ func (imp *Import) Start(opt ImportOptions) fs.Done {
 		defer mutex.IndexWorker.Stop()
 	}
 
+	StartWorkerProgress(opt.Action)
+	defer FinishWorkerProgress(opt.Action)
+
 	jobs := make(chan ImportJob)
 
 	// Start a fixed number of goroutines to import files.

--- a/internal/photoprism/index.go
+++ b/internal/photoprism/index.go
@@ -96,6 +96,8 @@ func (ind *Index) Start(o IndexOptions) (found fs.Done, updated int) {
 	}
 
 	defer mutex.IndexWorker.Stop()
+	StartWorkerProgress(o.Action)
+	defer FinishWorkerProgress(o.Action)
 
 	jobs := make(chan IndexJob)
 

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -73,6 +73,8 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 		return result
 	}
 
+	ObserveWorkerProgress(o.Action, fileSize)
+
 	fileHash := ""
 	fileChanged := true
 	fileRenamed := false

--- a/internal/photoprism/progress.go
+++ b/internal/photoprism/progress.go
@@ -1,0 +1,180 @@
+package photoprism
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+var defaultProgressWorkers = []string{ActionImport, ActionIndex}
+var workerProgress = newWorkerProgressTracker()
+
+// WorkerProgress contains observable file processing progress for a worker.
+type WorkerProgress struct {
+	Worker     string
+	Running    bool
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Files      int
+	Bytes      int64
+}
+
+type workerProgressTracker struct {
+	mu        sync.RWMutex
+	snapshots map[string]WorkerProgress
+}
+
+// newWorkerProgressTracker creates a tracker with stable default workers.
+func newWorkerProgressTracker() *workerProgressTracker {
+	result := &workerProgressTracker{
+		snapshots: make(map[string]WorkerProgress, len(defaultProgressWorkers)),
+	}
+
+	for _, worker := range defaultProgressWorkers {
+		result.snapshots[worker] = WorkerProgress{Worker: worker}
+	}
+
+	return result
+}
+
+// resetWorkerProgressForTest resets progress state for package tests.
+func resetWorkerProgressForTest() {
+	workerProgress = newWorkerProgressTracker()
+}
+
+// StartWorkerProgress marks a worker as running and resets the current run counters.
+func StartWorkerProgress(worker string) {
+	workerProgress.Start(worker)
+}
+
+// ObserveWorkerProgress records one processed file for the worker.
+func ObserveWorkerProgress(worker string, bytes int64) {
+	workerProgress.Observe(worker, bytes)
+}
+
+// FinishWorkerProgress marks a worker as idle while preserving its last run counters.
+func FinishWorkerProgress(worker string) {
+	workerProgress.Finish(worker)
+}
+
+// WorkerProgressSnapshot returns a copy of the current progress for one worker.
+func WorkerProgressSnapshot(worker string) WorkerProgress {
+	return workerProgress.Snapshot(worker)
+}
+
+// WorkerProgressSnapshots returns sorted copies of all worker progress snapshots.
+func WorkerProgressSnapshots() []WorkerProgress {
+	return workerProgress.Snapshots()
+}
+
+// Start marks a worker as running and resets the current run counters.
+func (t *workerProgressTracker) Start(worker string) {
+	if worker == "" {
+		return
+	}
+
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.snapshots[worker] = WorkerProgress{
+		Worker:    worker,
+		Running:   true,
+		StartedAt: now,
+	}
+}
+
+// Observe records one processed file and its byte size for a worker.
+func (t *workerProgressTracker) Observe(worker string, bytes int64) {
+	if worker == "" {
+		return
+	}
+
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	snapshot := t.snapshots[worker]
+
+	if snapshot.Worker == "" {
+		snapshot.Worker = worker
+	}
+
+	if snapshot.StartedAt.IsZero() {
+		snapshot.StartedAt = now
+	}
+
+	snapshot.Running = true
+	snapshot.FinishedAt = time.Time{}
+	snapshot.Files++
+
+	if bytes > 0 {
+		snapshot.Bytes += bytes
+	}
+
+	t.snapshots[worker] = snapshot
+}
+
+// Finish marks a worker as idle without clearing its last run counters.
+func (t *workerProgressTracker) Finish(worker string) {
+	if worker == "" {
+		return
+	}
+
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	snapshot := t.snapshots[worker]
+
+	if snapshot.Worker == "" {
+		snapshot.Worker = worker
+	}
+
+	snapshot.Running = false
+	snapshot.FinishedAt = now
+	t.snapshots[worker] = snapshot
+}
+
+// Snapshot returns a copy of the current progress for one worker.
+func (t *workerProgressTracker) Snapshot(worker string) WorkerProgress {
+	if worker == "" {
+		return WorkerProgress{}
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	snapshot := t.snapshots[worker]
+
+	if snapshot.Worker == "" {
+		snapshot.Worker = worker
+	}
+
+	return snapshot
+}
+
+// Snapshots returns sorted copies of all tracked worker progress snapshots.
+func (t *workerProgressTracker) Snapshots() []WorkerProgress {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	result := make([]WorkerProgress, 0, len(t.snapshots))
+
+	for worker, snapshot := range t.snapshots {
+		if snapshot.Worker == "" {
+			snapshot.Worker = worker
+		}
+
+		result = append(result, snapshot)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Worker < result[j].Worker
+	})
+
+	return result
+}

--- a/internal/photoprism/progress_test.go
+++ b/internal/photoprism/progress_test.go
@@ -1,0 +1,44 @@
+package photoprism
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkerProgressSnapshotTracksCurrentRun(t *testing.T) {
+	resetWorkerProgressForTest()
+
+	StartWorkerProgress(ActionIndex)
+	ObserveWorkerProgress(ActionIndex, 1024)
+	ObserveWorkerProgress(ActionIndex, 2048)
+
+	snapshot := WorkerProgressSnapshot(ActionIndex)
+
+	assert.Equal(t, ActionIndex, snapshot.Worker)
+	assert.True(t, snapshot.Running)
+	assert.False(t, snapshot.StartedAt.IsZero())
+	assert.True(t, snapshot.FinishedAt.IsZero())
+	assert.Equal(t, 2, snapshot.Files)
+	assert.Equal(t, int64(3072), snapshot.Bytes)
+
+	FinishWorkerProgress(ActionIndex)
+
+	snapshot = WorkerProgressSnapshot(ActionIndex)
+
+	assert.False(t, snapshot.Running)
+	assert.False(t, snapshot.StartedAt.IsZero())
+	assert.False(t, snapshot.FinishedAt.IsZero())
+	assert.Equal(t, 2, snapshot.Files)
+	assert.Equal(t, int64(3072), snapshot.Bytes)
+}
+
+func TestWorkerProgressSnapshotsIncludeDefaultWorkers(t *testing.T) {
+	resetWorkerProgressForTest()
+
+	snapshots := WorkerProgressSnapshots()
+
+	assert.Len(t, snapshots, 2)
+	assert.Equal(t, ActionImport, snapshots[0].Worker)
+	assert.Equal(t, ActionIndex, snapshots[1].Worker)
+}


### PR DESCRIPTION
Related to #639.

## Summary
- track the active import/index worker run state, processed file count, and processed bytes
- expose those values through the existing Prometheus-compatible /api/v1/metrics endpoint
- keep default import/index metric series available before the first run
- avoid a two-pass scan, total file count, or ETA calculation so the feature has minimal filesystem overhead

## Tests
- git diff --check
- go test ./internal/photoprism -run TestWorkerProgress -count=1 (not run: Go toolchain is not available in this Windows environment, Docker Desktop is not running, and downloading the official Go toolchain was blocked by local TLS/network policy)