### PR TITLE
Photos: Add month timeline rail

### DIFF
--- a/frontend/src/component/photo/timeline.vue
+++ b/frontend/src/component/photo/timeline.vue
@@ -1,0 +1,238 @@
+<template>
+  <aside v-if="!disabled" class="p-photo-timeline" :aria-label="$gettext('Timeline')" :aria-busy="loading ? 'true' : 'false'" data-testid="photo-timeline">
+    <template v-if="visible">
+      <div v-for="group in yearGroups" :key="group.year" class="p-photo-timeline__group">
+        <div class="p-photo-timeline__year">{{ group.year }}</div>
+        <div class="p-photo-timeline__months">
+          <button
+            v-for="bucket in group.buckets"
+            :key="bucketKey(bucket)"
+            type="button"
+            class="p-photo-timeline__month"
+            :class="{ 'is-active': isActive(bucket) }"
+            :title="bucketAriaLabel(bucket)"
+            :aria-label="bucketAriaLabel(bucket)"
+            :aria-pressed="isActive(bucket) ? 'true' : 'false'"
+            :data-testid="`timeline-month-${bucket.year}-${bucket.month}`"
+            @click="selectBucket(bucket)"
+          >
+            <span class="p-photo-timeline__month-label">{{ monthLabel(bucket.month) }}</span>
+            <span v-if="bucket.photoCount > 0" class="p-photo-timeline__month-count">{{ bucket.photoCount }}</span>
+          </button>
+        </div>
+      </div>
+
+      <div v-if="unknownDateCount > 0" class="p-photo-timeline__unknown" data-testid="timeline-unknown">
+        {{ $gettext("Unknown") }}: {{ unknownDateCount }}
+      </div>
+    </template>
+  </aside>
+</template>
+
+<script>
+import Photo from "model/photo";
+import { Info } from "luxon";
+
+const MonthLabels = Info.months("short");
+
+export default {
+  name: "PPhotoTimeline",
+  props: {
+    filter: {
+      type: Object,
+      default: () => ({}),
+    },
+    staticFilter: {
+      type: Object,
+      default: () => ({}),
+    },
+    updateQuery: {
+      type: Function,
+      default: () => {},
+    },
+    refreshToken: {
+      type: Number,
+      default: 0,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["visibility"],
+  data() {
+    return {
+      buckets: [],
+      loading: false,
+      requestId: 0,
+      unknownDateCount: 0,
+    };
+  },
+  computed: {
+    requestSignature() {
+      if (this.disabled) {
+        return "disabled";
+      }
+
+      const params = this.timelineParams();
+
+      return JSON.stringify({ ...params, refreshToken: this.refreshToken });
+    },
+    visible() {
+      return !this.disabled && this.buckets.length > 0;
+    },
+    yearGroups() {
+      const groups = [];
+      const years = {};
+
+      this.buckets.forEach((bucket) => {
+        if (!years[bucket.year]) {
+          years[bucket.year] = {
+            year: bucket.year,
+            buckets: [],
+          };
+          groups.push(years[bucket.year]);
+        }
+
+        years[bucket.year].buckets.push(bucket);
+      });
+
+      return groups;
+    },
+  },
+  watch: {
+    requestSignature: {
+      immediate: true,
+      handler() {
+        if (this.disabled) {
+          this.cancelTimeline();
+          return;
+        }
+
+        this.loadTimeline();
+      },
+    },
+  },
+  beforeUnmount() {
+    this.requestId++;
+  },
+  methods: {
+    emitVisibility() {
+      this.$emit("visibility", this.loading || this.buckets.length > 0);
+    },
+    cancelTimeline() {
+      this.requestId++;
+      this.loading = false;
+      this.buckets = [];
+      this.unknownDateCount = 0;
+      this.emitVisibility();
+    },
+    timelineParams() {
+      const params = {};
+
+      if (this.filter && typeof this.filter === "object") {
+        Object.assign(params, this.filter);
+      }
+
+      if (this.staticFilter && typeof this.staticFilter === "object") {
+        Object.assign(params, this.staticFilter);
+      }
+
+      delete params.year;
+      delete params.month;
+      delete params.day;
+
+      params.bucket = "month";
+
+      return params;
+    },
+    loadTimeline() {
+      const requestId = ++this.requestId;
+
+      if (typeof Photo.timeline !== "function") {
+        this.buckets = [];
+        this.unknownDateCount = 0;
+        this.loading = false;
+        this.emitVisibility();
+        return;
+      }
+
+      this.loading = true;
+      this.emitVisibility();
+
+      Promise.resolve()
+        .then(() => Photo.timeline(this.timelineParams()))
+        .then((response) => {
+          if (requestId !== this.requestId) {
+            return;
+          }
+
+          const data = response?.data || response || {};
+
+          this.buckets = this.normalizeBuckets(data.buckets);
+          this.unknownDateCount = Math.max(0, Number(data.unknownDateCount) || 0);
+          this.emitVisibility();
+        })
+        .catch(() => {
+          if (requestId !== this.requestId) {
+            return;
+          }
+
+          this.buckets = [];
+          this.unknownDateCount = 0;
+          this.emitVisibility();
+        })
+        .finally(() => {
+          if (requestId === this.requestId) {
+            this.loading = false;
+            this.emitVisibility();
+          }
+        });
+    },
+    normalizeBuckets(buckets) {
+      if (!Array.isArray(buckets)) {
+        return [];
+      }
+
+      return buckets
+        .map((bucket) => ({
+          key: bucket.key || bucket.Key || "",
+          label: bucket.label || bucket.Label || "",
+          year: Number(bucket.year ?? bucket.Year),
+          month: Number(bucket.month ?? bucket.Month),
+          photoCount: Number(bucket.photoCount ?? bucket.PhotoCount) || 0,
+        }))
+        .filter((bucket) => bucket.year > 0 && bucket.month > 0 && bucket.month <= 12);
+    },
+    bucketKey(bucket) {
+      return bucket.key || `${bucket.year}-${bucket.month}`;
+    },
+    bucketTitle(bucket) {
+      if (bucket.label) {
+        return bucket.label;
+      }
+
+      return `${this.monthLabel(bucket.month)} ${bucket.year}`;
+    },
+    bucketAriaLabel(bucket) {
+      return this.$gettext("Filter photos from %{date}, %{count} pictures", {
+        date: this.bucketTitle(bucket),
+        count: Number(bucket.photoCount) || 0,
+      });
+    },
+    monthLabel(month) {
+      return MonthLabels[month - 1] || String(month).padStart(2, "0");
+    },
+    isActive(bucket) {
+      return Number(this.filter?.year) === bucket.year && Number(this.filter?.month) === bucket.month;
+    },
+    selectBucket(bucket) {
+      this.updateQuery({
+        year: bucket.year,
+        month: bucket.month,
+        day: 0,
+      });
+    },
+  },
+};
+</script>

--- a/frontend/src/css/views.css
+++ b/frontend/src/css/views.css
@@ -201,6 +201,110 @@
     padding: 0;
 }
 
+.p-photo-results {
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
+}
+
+.p-photo-results__views {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+}
+
+.p-photo-results--with-timeline {
+    gap: 8px;
+}
+
+.p-photo-results__timeline {
+    flex: 0 0 88px;
+    width: 88px;
+}
+
+.p-photo-timeline {
+    position: sticky;
+    top: 72px;
+    width: 100%;
+    max-height: calc(100vh - 84px);
+    padding: 10px 8px;
+    overflow-y: auto;
+    color: rgba(var(--v-theme-on-surface), 0.76);
+    user-select: none;
+}
+
+.p-photo-timeline__group + .p-photo-timeline__group {
+    margin-top: 12px;
+}
+
+.p-photo-timeline__year {
+    margin: 0 0 5px;
+    padding-left: 2px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1;
+    color: rgba(var(--v-theme-on-surface), 0.56);
+}
+
+.p-photo-timeline__months {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 3px;
+}
+
+.p-photo-timeline__month {
+    min-width: 0;
+    padding: 4px 2px;
+    border: 0;
+    border-radius: 7px;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
+}
+
+.p-photo-timeline__month:hover {
+    background: rgba(var(--v-theme-on-surface), 0.08);
+}
+
+.p-photo-timeline__month:focus-visible {
+    background: rgba(var(--v-theme-on-surface), 0.08);
+    outline: 2px solid rgba(var(--v-theme-on-surface), 0.5);
+    outline-offset: -2px;
+}
+
+.p-photo-timeline__month.is-active {
+    color: rgb(var(--v-theme-on-primary));
+    background: rgb(var(--v-theme-primary));
+}
+
+.p-photo-timeline__month-label,
+.p-photo-timeline__month-count {
+    display: block;
+    overflow: hidden;
+    line-height: 1.1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.p-photo-timeline__month-label {
+    font-size: 0.68rem;
+    font-weight: 700;
+}
+
+.p-photo-timeline__month-count {
+    margin-top: 1px;
+    font-size: 0.61rem;
+    opacity: 0.68;
+}
+
+.p-photo-timeline__unknown {
+    margin-top: 12px;
+    padding: 0 2px;
+    font-size: 0.68rem;
+    line-height: 1.25;
+    color: rgba(var(--v-theme-on-surface), 0.52);
+}
+
 .search-results.cards-view {
     margin: 0;
     padding: 2px;

--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -1457,6 +1457,21 @@ export class Photo extends RestModel {
 
     return results.concat(response.models);
   }
+
+  static timeline(params) {
+    const values = params ? { ...params } : {};
+
+    delete values.count;
+    delete values.offset;
+    delete values.merged;
+    delete values.order;
+    delete values.reverse;
+    delete values.view;
+
+    values.bucket = params?.bucket || "month";
+
+    return $api.get(this.getCollectionResource() + "/timeline", { params: values }).then((resp) => resp.data);
+  }
 }
 
 // evictCachedFromEntities drops cached entries from a WS payload, accepting

--- a/frontend/src/page/photos.vue
+++ b/frontend/src/page/photos.vue
@@ -23,40 +23,53 @@
 
       <p-photo-clipboard :context="context" :refresh="refresh"></p-photo-clipboard>
 
-      <p-photo-view-mosaic
-        v-if="settings.view === 'mosaic'"
-        :context="context"
-        :photos="results"
-        :select-mode="selectMode"
-        :filter="filter"
-        :edit-photo="editPhoto"
-        :open-photo="openPhoto"
-        :is-shared-view="isShared"
-      ></p-photo-view-mosaic>
-      <p-photo-view-list
-        v-else-if="settings.view === 'list'"
-        :context="context"
-        :photos="results"
-        :select-mode="selectMode"
-        :filter="filter"
-        :open-photo="openPhoto"
-        :edit-photo="editPhoto"
-        :open-date="openDate"
-        :open-location="openLocation"
-        :is-shared-view="isShared"
-      ></p-photo-view-list>
-      <p-photo-view-cards
-        v-else
-        :context="context"
-        :photos="results"
-        :select-mode="selectMode"
-        :filter="filter"
-        :open-photo="openPhoto"
-        :edit-photo="editPhoto"
-        :open-date="openDate"
-        :open-location="openLocation"
-        :is-shared-view="isShared"
-      ></p-photo-view-cards>
+      <div class="p-photo-results" :class="{ 'p-photo-results--with-timeline': timelineVisible }">
+        <div class="p-photo-results__views">
+          <p-photo-view-mosaic
+            v-if="settings.view === 'mosaic'"
+            :context="context"
+            :photos="results"
+            :select-mode="selectMode"
+            :filter="filter"
+            :edit-photo="editPhoto"
+            :open-photo="openPhoto"
+            :is-shared-view="isShared"
+          ></p-photo-view-mosaic>
+          <p-photo-view-list
+            v-else-if="settings.view === 'list'"
+            :context="context"
+            :photos="results"
+            :select-mode="selectMode"
+            :filter="filter"
+            :open-photo="openPhoto"
+            :edit-photo="editPhoto"
+            :open-date="openDate"
+            :open-location="openLocation"
+            :is-shared-view="isShared"
+          ></p-photo-view-list>
+          <p-photo-view-cards
+            v-else
+            :context="context"
+            :photos="results"
+            :select-mode="selectMode"
+            :filter="filter"
+            :open-photo="openPhoto"
+            :edit-photo="editPhoto"
+            :open-date="openDate"
+            :open-location="openLocation"
+            :is-shared-view="isShared"
+          ></p-photo-view-cards>
+        </div>
+
+        <div v-if="timelineEnabled" v-show="timelineVisible" class="p-photo-results__timeline">
+          <p-photo-timeline
+            :filter="timelineParams"
+            :refresh-token="timelineRefreshToken"
+            :update-query="updateQuery"
+            @visibility="setTimelineVisible"
+          ></p-photo-timeline>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -68,6 +81,7 @@ import { ACTION_CREATED, ACTION_UPDATED, ACTION_DELETED, ACTION_ARCHIVED, ACTION
 import * as contexts from "options/contexts";
 import PPhotoToolbar from "component/photo/toolbar.vue";
 import PPhotoClipboard from "component/photo/clipboard.vue";
+import PPhotoTimeline from "component/photo/timeline.vue";
 import PPhotoViewCards from "component/photo/view/cards.vue";
 import PPhotoViewMosaic from "component/photo/view/mosaic.vue";
 import PPhotoViewList from "component/photo/view/list.vue";
@@ -82,6 +96,7 @@ export default {
   components: {
     PPhotoToolbar,
     PPhotoClipboard,
+    PPhotoTimeline,
     PPhotoViewCards,
     PPhotoViewMosaic,
     PPhotoViewList,
@@ -112,6 +127,7 @@ export default {
     const lens = query["lens"] ? parseInt(query["lens"]) : 0;
     const year = query["year"] ? parseInt(query["year"]) : 0;
     const month = query["month"] ? parseInt(query["month"]) : 0;
+    const day = query["day"] ? parseInt(query["day"]) : 0;
     const color = query["color"] ? query["color"] : "";
     const label = query["label"] ? query["label"] : "";
     const latlng = query["latlng"] ? query["latlng"] : "";
@@ -125,6 +141,7 @@ export default {
       latlng: latlng,
       year: year,
       month: month,
+      day: day,
       color: color,
       order: order,
       reverse: this.sortReverse(),
@@ -168,6 +185,8 @@ export default {
       filter: filter,
       lastFilter: {},
       routeName: routeName,
+      timelineRefreshToken: 0,
+      timelineRailVisible: true,
       loading: true,
       lightbox: {
         results: [],
@@ -185,6 +204,47 @@ export default {
     },
     context: function () {
       return this.getContext();
+    },
+    // timelineEnabled keeps the rail out of disabled, embedded, and mobile layouts.
+    timelineEnabled: function () {
+      return !this.embedded && !!this.$vuetify?.display?.mdAndUp && this.$config.feature("calendar") && this.$config.allow("calendar", "search");
+    },
+    timelineVisible: function () {
+      return this.timelineEnabled && this.timelineRailVisible;
+    },
+    // timelineParams mirrors search filters without result-shaping params.
+    timelineParams: function () {
+      const params = {};
+      const ignored = {
+        count: true,
+        offset: true,
+        order: true,
+        reverse: true,
+        merged: true,
+        view: true,
+      };
+      const addFilter = (filter, keepOverrides) => {
+        if (!filter || typeof filter !== "object") {
+          return;
+        }
+
+        for (const [key, value] of Object.entries(filter)) {
+          if (ignored[key] || value === undefined || value === null) {
+            continue;
+          }
+
+          if (!keepOverrides && (value === "" || value === false || value === 0)) {
+            continue;
+          }
+
+          params[key] = value;
+        }
+      };
+
+      addFilter(this.filter, false);
+      addFilter(this.staticFilter, true);
+
+      return params;
     },
   },
   watch: {
@@ -214,6 +274,7 @@ export default {
       this.filter.lens = query["lens"] ? parseInt(query["lens"]) : 0;
       this.filter.year = query["year"] ? parseInt(query["year"]) : 0;
       this.filter.month = query["month"] ? parseInt(query["month"]) : 0;
+      this.filter.day = query["day"] ? parseInt(query["day"]) : 0;
       this.filter.color = query["color"] ? query["color"] : "";
       this.filter.label = query["label"] ? query["label"] : "";
       this.filter.latlng = query["latlng"] ? query["latlng"] : "";
@@ -579,8 +640,25 @@ export default {
         }
       }
     },
+    refreshTimeline() {
+      this.timelineRefreshToken++;
+    },
+    setTimelineVisible(visible) {
+      this.timelineRailVisible = !!visible;
+    },
     updateQuery(props) {
-      this.updateFilter(props);
+      let updates = props;
+
+      if (props && typeof props === "object" && !props.target) {
+        const hasDay = Object.prototype.hasOwnProperty.call(props, "day");
+        const hasDateScope = Object.prototype.hasOwnProperty.call(props, "year") || Object.prototype.hasOwnProperty.call(props, "month");
+
+        if (hasDateScope && !hasDay) {
+          updates = { ...props, day: 0 };
+        }
+      }
+
+      this.updateFilter(updates);
 
       if (this.loading) {
         return false;
@@ -644,6 +722,7 @@ export default {
       // Enable infinite scrolling if it was disabled.
       this.scrollDisabled = false;
 
+      this.refreshTimeline();
       this.loadMore(true);
     },
     reset() {
@@ -731,6 +810,7 @@ export default {
         return;
       }
 
+      this.refreshTimeline();
       this.loadMore(true);
     },
     updateResults(entity) {
@@ -771,9 +851,11 @@ export default {
       }
 
       const type = ev.split(".")[1];
+      let refreshTimeline = false;
 
       switch (type) {
         case ACTION_UPDATED:
+          refreshTimeline = true;
           for (let i = 0; i < data.entities.length; i++) {
             const values = data.entities[i];
 
@@ -787,6 +869,7 @@ export default {
           }
           break;
         case ACTION_RESTORED:
+          refreshTimeline = true;
           this.dirty = true;
           this.complete = false;
 
@@ -803,6 +886,7 @@ export default {
 
           break;
         case ACTION_ARCHIVED:
+          refreshTimeline = true;
           this.dirty = true;
           this.complete = false;
 
@@ -820,6 +904,7 @@ export default {
 
           break;
         case ACTION_DELETED:
+          refreshTimeline = true;
           this.dirty = true;
           this.complete = false;
 
@@ -833,12 +918,14 @@ export default {
 
           break;
         case ACTION_CREATED:
+          refreshTimeline = true;
           this.dirty = true;
           this.scrollDisabled = false;
           this.complete = false;
 
           break;
         case ACTION_EDITED:
+          refreshTimeline = true;
           // photos.edited is a lightweight UID-only batch signal
           // (event.EntitiesEdited). The cards list may now show stale
           // labels/albums/title for the affected UIDs; mark dirty so
@@ -851,6 +938,10 @@ export default {
           break;
         default:
           console.warn("unexpected event type", ev);
+      }
+
+      if (refreshTimeline) {
+        this.refreshTimeline();
       }
 
       // TODO: Needed?

--- a/frontend/tests/vitest/component/photo/timeline.test.js
+++ b/frontend/tests/vitest/component/photo/timeline.test.js
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import PPhotoTimeline from "component/photo/timeline.vue";
+import Photo from "model/photo";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function mountTimeline(props = {}) {
+  return mount(PPhotoTimeline, {
+    props: {
+      filter: {},
+      staticFilter: {},
+      updateQuery: vi.fn(),
+      ...props,
+    },
+  });
+}
+
+describe("component/photo/timeline", () => {
+  let originalTimeline;
+
+  beforeEach(() => {
+    originalTimeline = Photo.timeline;
+    Photo.timeline = vi.fn();
+  });
+
+  afterEach(() => {
+    if (originalTimeline) {
+      Photo.timeline = originalTimeline;
+    } else {
+      delete Photo.timeline;
+    }
+
+    vi.restoreAllMocks();
+  });
+
+  it("maps month button clicks to year, month, and day query updates", async () => {
+    const updateQuery = vi.fn();
+    const searchSpy = vi.spyOn(Photo, "search");
+
+    Photo.timeline.mockResolvedValue({
+      buckets: [
+        {
+          key: "2025-04",
+          label: "April 2025",
+          year: 2025,
+          month: 4,
+          photoCount: 3,
+        },
+      ],
+      unknownDateCount: 2,
+    });
+
+    const wrapper = mountTimeline({
+      filter: { q: "kitten", type: "image", year: 2025, month: 4, day: 12 },
+      staticFilter: { type: "raw" },
+      updateQuery,
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    expect(Photo.timeline).toHaveBeenCalledWith({
+      q: "kitten",
+      type: "raw",
+      bucket: "month",
+    });
+    expect(wrapper.emitted("visibility").at(-1)).toEqual([true]);
+    expect(searchSpy).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="timeline-unknown"]').text()).toContain("2");
+    expect(wrapper.find('[data-testid="timeline-month-2025-4"]').attributes("aria-label")).toBe("Filter photos from April 2025, 3 pictures");
+    expect(wrapper.find('[data-testid="timeline-month-2025-4"]').attributes("aria-pressed")).toBe("true");
+
+    await wrapper.find('[data-testid="timeline-month-2025-4"]').trigger("click");
+
+    expect(updateQuery).toHaveBeenCalledWith({ year: 2025, month: 4, day: 0 });
+  });
+
+  it("keeps the rail mounted while loading and reloads when refreshToken changes", async () => {
+    const first = deferred();
+    const second = deferred();
+
+    Photo.timeline.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const wrapper = mountTimeline({
+      filter: { q: "kitten" },
+      refreshToken: 0,
+    });
+
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="photo-timeline"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="photo-timeline"]').attributes("aria-busy")).toBe("true");
+    expect(wrapper.emitted("visibility").at(-1)).toEqual([true]);
+
+    await wrapper.setProps({ refreshToken: 1 });
+
+    expect(Photo.timeline).toHaveBeenCalledTimes(2);
+
+    second.resolve({
+      buckets: [
+        {
+          key: "2025-04",
+          label: "April 2025",
+          year: 2025,
+          month: 4,
+          photoCount: 3,
+        },
+      ],
+      unknownDateCount: 0,
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="photo-timeline"]').attributes("aria-busy")).toBe("false");
+    expect(wrapper.find('[data-testid="timeline-month-2025-4"]').exists()).toBe(true);
+    expect(wrapper.emitted("visibility").at(-1)).toEqual([true]);
+  });
+
+  it("collapses parent rail visibility after an empty result or error", async () => {
+    Photo.timeline.mockResolvedValue({
+      buckets: [],
+      unknownDateCount: 0,
+    });
+
+    const wrapper = mountTimeline();
+
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="photo-timeline"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="photo-timeline"]').attributes("aria-busy")).toBe("false");
+    expect(wrapper.emitted("visibility").at(-1)).toEqual([false]);
+
+    Photo.timeline.mockRejectedValue(new Error("offline"));
+    await wrapper.setProps({ refreshToken: 1 });
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.emitted("visibility").at(-1)).toEqual([false]);
+  });
+
+  it("collapses parent rail visibility for unknown-date-only results", async () => {
+    Photo.timeline.mockResolvedValue({
+      buckets: [],
+      unknownDateCount: 5,
+    });
+
+    const wrapper = mountTimeline();
+
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="timeline-unknown"]').exists()).toBe(false);
+    expect(wrapper.emitted("visibility").at(-1)).toEqual([false]);
+  });
+
+  it("keeps stale timeline responses from overwriting newer bucket data", async () => {
+    const first = deferred();
+    const second = deferred();
+
+    Photo.timeline.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const wrapper = mountTimeline({
+      filter: { q: "first" },
+    });
+
+    await nextTick();
+    await wrapper.setProps({ filter: { q: "second" } });
+
+    second.resolve({
+      buckets: [
+        {
+          key: "2026-02",
+          label: "February 2026",
+          year: 2026,
+          month: 2,
+          photoCount: 8,
+        },
+      ],
+      unknownDateCount: 0,
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="timeline-month-2026-2"]').exists()).toBe(true);
+
+    first.resolve({
+      buckets: [
+        {
+          key: "2024-09",
+          label: "September 2024",
+          year: 2024,
+          month: 9,
+          photoCount: 4,
+        },
+      ],
+      unknownDateCount: 0,
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="timeline-month-2026-2"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="timeline-month-2024-9"]').exists()).toBe(false);
+  });
+});

--- a/frontend/tests/vitest/model/photo.test.js
+++ b/frontend/tests/vitest/model/photo.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import "../fixtures";
+import { Mock } from "../fixtures";
 import * as media from "common/media";
 import { Photo, BatchSize, MaxLength } from "model/photo";
 import $event from "common/event";
@@ -528,6 +528,51 @@ describe("model/photo", () => {
   it("should get collection resource", () => {
     const result = Photo.getCollectionResource();
     expect(result).toBe("photos");
+  });
+
+  it("should get photo timeline with sanitized params", async () => {
+    const params = {
+      q: "sunset",
+      label: "vacation",
+      country: "de",
+      public: "",
+      private: "true",
+      quality: 3,
+      count: 25,
+      offset: 50,
+      merged: true,
+      order: "taken_at",
+      reverse: true,
+      view: "list",
+      year: 2024,
+      month: 5,
+      day: 21,
+    };
+    const original = { ...params };
+    const response = { bucket: "month", count: 1, entries: [{ date: "2024-05", count: 1 }] };
+
+    Mock.history.get.length = 0;
+    Mock.onGet("api/v1/photos/timeline").reply(200, response);
+
+    const result = await Photo.timeline(params);
+
+    expect(result).toEqual(response);
+    expect(params).toEqual(original);
+    expect(Mock.history.get).toHaveLength(1);
+    const call = Mock.history.get[0];
+    expect(call.url).toMatch(/photos\/timeline$/);
+    expect(call.params).toEqual({
+      q: "sunset",
+      label: "vacation",
+      country: "de",
+      public: "",
+      private: "true",
+      quality: 3,
+      bucket: "month",
+      year: 2024,
+      month: 5,
+      day: 21,
+    });
   });
 
   it("should return batch size", () => {

--- a/frontend/tests/vitest/page/photos.onupdate.test.js
+++ b/frontend/tests/vitest/page/photos.onupdate.test.js
@@ -20,6 +20,7 @@ function newStub() {
     dirty: false,
     complete: true,
     scrollDisabled: true,
+    timelineRefreshToken: 0,
     results: [],
     lightbox: { results: [] },
     $clipboard: { removeId: vi.fn() },
@@ -28,6 +29,9 @@ function newStub() {
     updateResults: vi.fn(),
     loadMore: vi.fn(),
     refresh: vi.fn(),
+    refreshTimeline: vi.fn(function () {
+      this.timelineRefreshToken++;
+    }),
   };
 }
 
@@ -51,6 +55,8 @@ describe("page/photos.vue onUpdate", () => {
     // updateResults work should run.
     expect(stub.removeResult).not.toHaveBeenCalled();
     expect(stub.updateResults).not.toHaveBeenCalled();
+    expect(stub.refreshTimeline).toHaveBeenCalledTimes(1);
+    expect(stub.timelineRefreshToken).toBe(1);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -62,6 +68,7 @@ describe("page/photos.vue onUpdate", () => {
 
     expect(stub.dirty).toBe(false);
     expect(stub.complete).toBe(true);
+    expect(stub.refreshTimeline).not.toHaveBeenCalled();
   });
 
   it("short-circuits on malformed payloads without warning", () => {
@@ -71,6 +78,7 @@ describe("page/photos.vue onUpdate", () => {
     onUpdate.call(stub, "photos.edited", { entities: "not-an-array" });
 
     expect(stub.dirty).toBe(false);
+    expect(stub.refreshTimeline).not.toHaveBeenCalled();
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -79,6 +87,17 @@ describe("page/photos.vue onUpdate", () => {
     onUpdate.call(stub, "photos.unknown", { entities: ["uid-1"] });
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(stub.refreshTimeline).not.toHaveBeenCalled();
+  });
+
+  it("refreshes timeline counts when imports complete", () => {
+    const stub = newStub();
+
+    PPagePhotos.methods.onImportCompleted.call(stub);
+
+    expect(stub.refreshTimeline).toHaveBeenCalledTimes(1);
+    expect(stub.timelineRefreshToken).toBe(1);
+    expect(stub.loadMore).toHaveBeenCalledWith(true);
   });
 });
 

--- a/frontend/tests/vitest/page/photos.timeline.test.js
+++ b/frontend/tests/vitest/page/photos.timeline.test.js
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("component/photo/timeline.vue", () => ({
+  default: { name: "PPhotoTimeline", template: "<div />" },
+}));
+
+import PPagePhotos from "page/photos.vue";
+
+// baseFilter returns the Photos page filter shape used by query helpers.
+function baseFilter(values = {}) {
+  return {
+    country: "",
+    camera: 0,
+    lens: 0,
+    label: "",
+    latlng: "",
+    year: 0,
+    month: 0,
+    day: 0,
+    color: "",
+    order: "newest",
+    reverse: false,
+    q: "",
+    ...values,
+  };
+}
+
+// pageContext returns the minimal Options API context required by data().
+function pageContext(query = {}) {
+  return {
+    $route: { name: "all", query },
+    $config: {
+      getSettings: () => ({ features: { edit: true, places: true, private: false, review: false } }),
+      allow: () => true,
+      deny: () => false,
+      feature: () => true,
+    },
+    $clipboard: { selection: [] },
+    staticFilter: null,
+    getViewType: () => "cards",
+    sortOrder: () => "newest",
+    sortReverse: () => false,
+  };
+}
+
+describe("page/photos.vue timeline rail", () => {
+  it("is enabled only for calendar-capable non-embedded md-and-up layouts", () => {
+    const timelineEnabled = PPagePhotos.computed.timelineEnabled;
+    const base = {
+      embedded: false,
+      $vuetify: { display: { mdAndUp: true } },
+      $config: { feature: () => true, allow: () => true },
+    };
+
+    expect(timelineEnabled.call(base)).toBe(true);
+    expect(timelineEnabled.call({ ...base, embedded: true })).toBe(false);
+    expect(timelineEnabled.call({ ...base, $vuetify: { display: { mdAndUp: false } } })).toBe(false);
+    expect(timelineEnabled.call({ ...base, $config: { feature: () => false, allow: () => true } })).toBe(false);
+    expect(timelineEnabled.call({ ...base, $config: { feature: () => true, allow: () => false } })).toBe(false);
+  });
+
+  it("reserves the timeline rail only while the mounted child reports visible content", () => {
+    const timelineVisible = PPagePhotos.computed.timelineVisible;
+    const stub = { timelineEnabled: true, timelineRailVisible: true };
+
+    expect(timelineVisible.call(stub)).toBe(true);
+    expect(timelineVisible.call({ ...stub, timelineRailVisible: false })).toBe(false);
+    expect(timelineVisible.call({ ...stub, timelineEnabled: false })).toBe(false);
+  });
+
+  it("builds timeline params from active filters without result-shaping keys", () => {
+    const params = PPagePhotos.computed.timelineParams.call({
+      filter: baseFilter({
+        country: "de",
+        year: 2024,
+        month: 5,
+        day: 21,
+        public: "true",
+        quality: "3",
+        q: "cats",
+        reverse: true,
+      }),
+      staticFilter: {
+        favorite: true,
+        private: "true",
+        public: "",
+        hidden: false,
+        offset: 100,
+      },
+    });
+
+    expect(params).toEqual({
+      country: "de",
+      year: 2024,
+      month: 5,
+      day: 21,
+      public: "",
+      quality: "3",
+      q: "cats",
+      favorite: true,
+      private: "true",
+      hidden: false,
+    });
+  });
+
+  it("initializes the day filter from the route query", () => {
+    const data = PPagePhotos.data.call(pageContext({ year: "2024", month: "5", day: "21" }));
+
+    expect(data.filter.year).toBe(2024);
+    expect(data.filter.month).toBe(5);
+    expect(data.filter.day).toBe(21);
+  });
+
+  it("syncs the day filter when the route changes", () => {
+    const stub = {
+      $view: { isActive: () => true, focus: vi.fn() },
+      $refs: { page: {} },
+      $route: { name: "all", query: { year: "2024", month: "5", day: "21" } },
+      $config: {
+        getSettings: () => ({ features: { private: false, review: false } }),
+      },
+      staticFilter: null,
+      filter: baseFilter(),
+      settings: { view: "cards" },
+      routeName: "all",
+      lastFilter: {},
+      getViewType: () => "cards",
+      sortOrder: () => "newest",
+      sortReverse: () => false,
+      search: vi.fn(),
+    };
+
+    PPagePhotos.watch.$route.call(stub);
+
+    expect(stub.filter.year).toBe(2024);
+    expect(stub.filter.month).toBe(5);
+    expect(stub.filter.day).toBe(21);
+    expect(stub.search).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the timeline clear day through updateQuery", () => {
+    const replace = vi.fn();
+    const stub = {
+      filter: baseFilter({ q: "cats", day: 21 }),
+      settings: { view: "cards" },
+      loading: false,
+      $route: { query: { view: "cards", q: "cats", order: "newest", day: "21" } },
+      $router: { replace },
+      updateFilter: PPagePhotos.methods.updateFilter,
+    };
+
+    const changed = PPagePhotos.methods.updateQuery.call(stub, { day: 0 });
+
+    expect(changed).toBe(true);
+    expect(stub.filter.day).toBe(0);
+    expect(replace).toHaveBeenCalledWith({ query: { view: "cards", order: "newest", q: "cats" } });
+  });
+
+  it("updates timeline rail visibility from the child component", () => {
+    const stub = { timelineRailVisible: true };
+
+    PPagePhotos.methods.setTimelineVisible.call(stub, false);
+    expect(stub.timelineRailVisible).toBe(false);
+
+    PPagePhotos.methods.setTimelineVisible.call(stub, true);
+    expect(stub.timelineRailVisible).toBe(true);
+  });
+
+  it("clears hidden day filters when year or month changes", () => {
+    const replace = vi.fn();
+    const stub = {
+      filter: baseFilter({ year: 2024, month: 5, day: 21 }),
+      settings: { view: "cards" },
+      loading: false,
+      $route: { query: { view: "cards", order: "newest", year: "2024", month: "5", day: "21" } },
+      $router: { replace },
+      updateFilter: PPagePhotos.methods.updateFilter,
+    };
+
+    const changed = PPagePhotos.methods.updateQuery.call(stub, { year: 2025 });
+
+    expect(changed).toBe(true);
+    expect(stub.filter.year).toBe(2025);
+    expect(stub.filter.day).toBe(0);
+    expect(replace).toHaveBeenCalledWith({ query: { view: "cards", order: "newest", year: 2025, month: 5 } });
+  });
+
+  it("includes day in photo search params without adding thumbnail sources", () => {
+    const params = PPagePhotos.methods.searchParams.call({
+      searchCount: () => 156,
+      offset: 0,
+      filter: baseFilter({ year: 2024, month: 5, day: 21 }),
+      staticFilter: null,
+    });
+
+    expect(params).toMatchObject({
+      count: 156,
+      offset: 0,
+      merged: true,
+      year: 2024,
+      month: 5,
+      day: 21,
+    });
+  });
+});

--- a/internal/api/photos_timeline.go
+++ b/internal/api/photos_timeline.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+
+	"github.com/photoprism/photoprism/internal/auth/acl"
+	"github.com/photoprism/photoprism/internal/entity"
+	"github.com/photoprism/photoprism/internal/entity/search"
+	"github.com/photoprism/photoprism/internal/event"
+	"github.com/photoprism/photoprism/internal/form"
+	"github.com/photoprism/photoprism/internal/photoprism/get"
+	"github.com/photoprism/photoprism/pkg/i18n"
+	"github.com/photoprism/photoprism/pkg/log/status"
+)
+
+// photosTimelineForm checks authorization and parses the timeline request without requiring a count parameter.
+func photosTimelineForm(c *gin.Context) (frm form.SearchPhotos, bucket string, s *entity.Session, err error) {
+	s = Auth(c, acl.ResourceCalendar, acl.ActionSearch)
+
+	// Abort if calendar access is not granted.
+	if s.Abort(c) {
+		return frm, bucket, s, i18n.Error(i18n.ErrForbidden)
+	}
+
+	s = AuthAny(c, acl.ResourcePhotos, acl.Permissions{acl.ActionSearch, acl.ActionView, acl.AccessShared})
+
+	// Abort if photo visibility is not granted.
+	if s.Abort(c) {
+		return frm, bucket, s, i18n.Error(i18n.ErrForbidden)
+	}
+
+	values := c.Request.URL.Query()
+	bucket = strings.ToLower(strings.TrimSpace(values.Get("bucket")))
+
+	switch bucket {
+	case search.PhotoTimelineBucketMonth:
+		// Supported.
+	default:
+		err = fmt.Errorf("invalid timeline bucket")
+		event.AuditWarn([]string{ClientIP(c), "session %s", string(acl.ResourceCalendar), "timeline bucket invalid", status.Error(err)}, s.RefID)
+		AbortBadRequest(c, err)
+		return frm, bucket, s, err
+	}
+
+	if values.Has("order") {
+		err = fmt.Errorf("unsupported timeline order")
+		event.AuditWarn([]string{ClientIP(c), "session %s", string(acl.ResourceCalendar), "timeline order invalid", status.Error(err)}, s.RefID)
+		AbortBadRequest(c, err)
+		return frm, bucket, s, err
+	}
+
+	// Abort if request params are invalid.
+	if err = bindPhotoTimelineFilters(values, &frm); err != nil {
+		event.AuditWarn([]string{ClientIP(c), "session %s", string(acl.ResourceCalendar), "timeline form invalid", status.Error(err)}, s.RefID)
+		AbortBadRequest(c, err)
+		return frm, bucket, s, err
+	}
+
+	settings := get.Config().Settings()
+
+	if !settings.Features.Calendar {
+		AbortFeatureDisabled(c)
+		return frm, bucket, s, i18n.Error(i18n.ErrFeatureDisabled)
+	}
+
+	// Ignore private flag if feature is disabled.
+	if !settings.Features.Private {
+		frm.Public = false
+	}
+
+	// Apply the same review restriction as /photos search for users without manage permission.
+	if frm.Scope == "" &&
+		settings.Features.Review &&
+		acl.Rules.Deny(acl.ResourcePhotos, s.GetUserRole(), acl.ActionManage) {
+		frm.Quality = 3
+	}
+
+	// Timeline buckets do not use seek/pagination or file-merge semantics.
+	frm.Count = 0
+	frm.Offset = 0
+	frm.Order = ""
+	frm.Reverse = false
+	frm.Merged = false
+
+	return frm, bucket, s, nil
+}
+
+// bindPhotoTimelineFilters maps search filters without result-shaping params.
+func bindPhotoTimelineFilters(values url.Values, frm *form.SearchPhotos) error {
+	filters := make(url.Values, len(values))
+
+	for key, value := range values {
+		filters[key] = append([]string(nil), value...)
+	}
+
+	filters.Del("bucket")
+	filters.Del("count")
+	filters.Del("offset")
+	filters.Del("order")
+	filters.Del("reverse")
+	filters.Del("merged")
+
+	return binding.MapFormWithTag(frm, filters, "form")
+}
+
+// SearchPhotoTimeline returns local photo timeline buckets for matching search filters.
+//
+//	@Summary		returns local photo timeline buckets
+//	@Description	Returns month buckets in descending local-date order.
+//	@Description	Result-shaping parameters such as count, offset, order, reverse, and merged are not part of this endpoint.
+//	@Id				SearchPhotoTimeline
+//	@Tags			Photos
+//	@Produce		json
+//	@Success		200				{object}	search.PhotoTimeline
+//	@Failure		400,401,403,404	{object}	i18n.Response
+//	@Param			bucket			query		string	true	"timeline bucket"	Enums(month)
+//	@Param			public			query		bool	false	"excludes private pictures"
+//	@Param			quality			query		int		false	"minimum quality score (1-7)"	Enums(0, 1, 2, 3, 4, 5, 6, 7)
+//	@Param			q				query		string	false	"search query"
+//	@Param			s				query		string	false	"album uid"
+//	@Param			path			query		string	false	"photo path"
+//	@Param			video			query		bool	false	"is type video"
+//	@Router			/api/v1/photos/timeline [get]
+func SearchPhotoTimeline(router *gin.RouterGroup) {
+	router.GET("/photos/timeline", func(c *gin.Context) {
+		f, bucket, s, err := photosTimelineForm(c)
+
+		// Abort if authorization or form are invalid.
+		if err != nil {
+			return
+		}
+
+		// Find matching timeline buckets.
+		result, err := search.UserPhotoTimeline(f, s, bucket)
+
+		// Ok?
+		if err != nil {
+			event.AuditWarn([]string{ClientIP(c), "session %s", string(acl.ResourceCalendar), "timeline", status.Error(err)}, s.RefID)
+			AbortBadRequest(c, err)
+			return
+		}
+
+		// Add token headers for clients that need refreshed tokens.
+		AddTokenHeaders(c, s)
+
+		// Return as JSON.
+		c.JSON(http.StatusOK, result)
+	})
+}

--- a/internal/api/photos_timeline_test.go
+++ b/internal/api/photos_timeline_test.go
@@ -1,0 +1,217 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+
+	"github.com/photoprism/photoprism/internal/auth/acl"
+)
+
+func TestSearchPhotoTimeline(t *testing.T) {
+	t.Run("MissingBucketRejected", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?uid=ps6sg6be2lvl0yh0")
+
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+	})
+
+	t.Run("SuccessWithoutCount", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0")
+		body := r.Body.String()
+
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, "month", gjson.Get(body, "bucket").String())
+		assert.Equal(t, "desc", gjson.Get(body, "order").String())
+		assert.Equal(t, int64(1), gjson.Get(body, "photoCount").Int())
+		assert.Equal(t, int64(0), gjson.Get(body, "unknownDateCount").Int())
+		assert.Equal(t, int64(1), gjson.Get(body, "buckets.#").Int())
+		assert.Equal(t, "1990-04", gjson.Get(body, "buckets.0.key").String())
+		assert.Equal(t, int64(1), gjson.Get(body, "buckets.0.photoCount").Int())
+	})
+
+	t.Run("CalendarPermissionRequired", func(t *testing.T) {
+		withTimelineAclRule(t, acl.ResourceCalendar, acl.Roles{})
+
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0")
+
+		assert.Equal(t, http.StatusForbidden, r.Code)
+	})
+
+	t.Run("PhotoPermissionRequired", func(t *testing.T) {
+		withTimelineAclRule(t, acl.ResourcePhotos, acl.Roles{})
+
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0")
+
+		assert.Equal(t, http.StatusForbidden, r.Code)
+	})
+
+	t.Run("CalendarFeatureRequired", func(t *testing.T) {
+		_, _, conf := NewApiTest()
+		settings := conf.Settings()
+		enabled := settings.Features.Calendar
+		settings.Features.Calendar = false
+		t.Cleanup(func() {
+			settings.Features.Calendar = enabled
+		})
+
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0")
+
+		assert.Equal(t, http.StatusForbidden, r.Code)
+		assert.Equal(t, "Feature disabled", gjson.Get(r.Body.String(), "error").String())
+	})
+
+	t.Run("DayBucket", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=day&uid=ps6sg6be2lvl0yh0")
+
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+	})
+
+	t.Run("CountOffsetIgnored", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0&count=1&offset=1")
+		body := r.Body.String()
+
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, int64(1), gjson.Get(body, "photoCount").Int())
+		assert.Equal(t, int64(1), gjson.Get(body, "buckets.#").Int())
+		assert.Equal(t, "1990-04", gjson.Get(body, "buckets.0.key").String())
+	})
+
+	t.Run("InvalidShapingParamsIgnored", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0&count=bad&offset=bad&reverse=bad&merged=bad")
+		body := r.Body.String()
+
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, int64(1), gjson.Get(body, "photoCount").Int())
+		assert.Equal(t, "1990-04", gjson.Get(body, "buckets.0.key").String())
+	})
+
+	t.Run("ReverseMergedIgnored", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0&reverse=true&merged=true")
+		body := r.Body.String()
+
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, "desc", gjson.Get(body, "order").String())
+		assert.Equal(t, "1990-04", gjson.Get(body, "buckets.0.key").String())
+	})
+
+	t.Run("OrderRejected", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0&order=asc")
+
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+	})
+
+	t.Run("EmptyOrderRejected", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0&order=")
+
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+	})
+
+	t.Run("InvalidFilterRejected", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&added=not-a-date")
+
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+	})
+
+	t.Run("InvalidBucket", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=year&uid=ps6sg6be2lvl0yh0")
+
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+	})
+
+	t.Run("NoMatchReturnsEmptyBuckets", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&label=totally-unknown-label")
+		body := r.Body.String()
+
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, int64(0), gjson.Get(body, "photoCount").Int())
+		assert.Equal(t, int64(0), gjson.Get(body, "unknownDateCount").Int())
+		assert.Contains(t, strings.ReplaceAll(body, " ", ""), `"buckets":[]`)
+	})
+
+	t.Run("DoesNotMutateRequestQuery", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+
+		req := httptest.NewRequest("GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0&count=bad&offset=bad", nil)
+		rawQuery := req.URL.RawQuery
+		w := httptest.NewRecorder()
+
+		app.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, rawQuery, req.URL.RawQuery)
+	})
+
+	t.Run("BeforePhotoUidRoute", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		SearchPhotoTimeline(router)
+		GetPhoto(router)
+
+		r := PerformRequest(app, "GET", "/api/v1/photos/timeline?bucket=month&uid=ps6sg6be2lvl0yh0")
+		body := r.Body.String()
+
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, "month", gjson.Get(body, "bucket").String())
+	})
+}
+
+func withTimelineAclRule(t *testing.T, resource acl.Resource, roles acl.Roles) {
+	t.Helper()
+
+	acl.RulesMutex.Lock()
+	previous := acl.Rules[resource]
+	acl.Rules[resource] = roles
+	acl.RulesMutex.Unlock()
+
+	t.Cleanup(func() {
+		acl.RulesMutex.Lock()
+		acl.Rules[resource] = previous
+		acl.RulesMutex.Unlock()
+	})
+}

--- a/internal/api/swagger.json
+++ b/internal/api/swagger.json
@@ -4301,6 +4301,58 @@
             },
             "type": "object"
         },
+        "search.PhotoTimeline": {
+            "properties": {
+                "bucket": {
+                    "type": "string"
+                },
+                "buckets": {
+                    "items": {
+                        "$ref": "#/definitions/search.PhotoTimelineBucket"
+                    },
+                    "type": "array"
+                },
+                "order": {
+                    "type": "string"
+                },
+                "photoCount": {
+                    "type": "integer"
+                },
+                "unknownDateCount": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "search.PhotoTimelineBucket": {
+            "properties": {
+                "day": {
+                    "type": "integer"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "month": {
+                    "type": "integer"
+                },
+                "photoCount": {
+                    "type": "integer"
+                },
+                "until": {
+                    "type": "string"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
         "search.Subject": {
             "properties": {
                 "Alias": {
@@ -9175,6 +9227,109 @@
                     }
                 },
                 "summary": "finds pictures and returns them as JSON",
+                "tags": [
+                    "Photos"
+                ]
+            }
+        },
+        "/api/v1/photos/timeline": {
+            "get": {
+                "description": "Returns month buckets in descending local-date order.\nResult-shaping parameters such as count, offset, order, reverse, and merged are not part of this endpoint.",
+                "operationId": "SearchPhotoTimeline",
+                "parameters": [
+                    {
+                        "description": "timeline bucket",
+                        "enum": [
+                            "month"
+                        ],
+                        "in": "query",
+                        "name": "bucket",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "description": "excludes private pictures",
+                        "in": "query",
+                        "name": "public",
+                        "type": "boolean"
+                    },
+                    {
+                        "description": "minimum quality score (1-7)",
+                        "enum": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7
+                        ],
+                        "in": "query",
+                        "name": "quality",
+                        "type": "integer"
+                    },
+                    {
+                        "description": "search query",
+                        "in": "query",
+                        "name": "q",
+                        "type": "string"
+                    },
+                    {
+                        "description": "album uid",
+                        "in": "query",
+                        "name": "s",
+                        "type": "string"
+                    },
+                    {
+                        "description": "photo path",
+                        "in": "query",
+                        "name": "path",
+                        "type": "string"
+                    },
+                    {
+                        "description": "is type video",
+                        "in": "query",
+                        "name": "video",
+                        "type": "boolean"
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/search.PhotoTimeline"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/i18n.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/i18n.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/i18n.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/i18n.Response"
+                        }
+                    }
+                },
+                "summary": "returns local photo timeline buckets",
                 "tags": [
                     "Photos"
                 ]

--- a/internal/entity/search/photos.go
+++ b/internal/entity/search/photos.go
@@ -53,10 +53,66 @@ func PhotoIds(frm form.SearchPhotos) (files PhotoResults, count int, err error) 
 func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string) (results PhotoResults, count int, err error) {
 	start := time.Now()
 
+	query, err := newSearchPhotosQuery(frm, sess, resultCols)
+	if err != nil {
+		return PhotoResults{}, 0, err
+	} else if query.db == nil {
+		return PhotoResults{}, 0, nil
+	}
+
+	frm = query.form
+	s := query.db
+
+	// Query database.
+	if err = s.Scan(&results).Error; err != nil {
+		return results, 0, err
+	}
+
+	// Log number of results.
+	log.Debugf("photos: found %s for %s [%s]", english.Plural(len(results), "result", "results"), frm.SerializeAll(), time.Since(start))
+
+	// Merge files that belong to the same photo.
+	if frm.Merged {
+		// Return merged files.
+		return results.Merge()
+	}
+
+	// Return unmerged files.
+	return results, len(results), nil
+}
+
+type searchPhotosQuery struct {
+	db   *gorm.DB
+	form form.SearchPhotos
+}
+
+type searchPhotosQueryOptions struct {
+	resultCols      string
+	applyOrder      bool
+	applyPagination bool
+	applyLabelGroup bool
+	allowUIDFast    bool
+}
+
+// newSearchPhotosQuery builds the photos search query without scanning results.
+func newSearchPhotosQuery(frm form.SearchPhotos, sess *entity.Session, resultCols string) (query searchPhotosQuery, err error) {
+	return newSearchPhotosQueryWithOptions(frm, sess, searchPhotosQueryOptions{
+		resultCols:      resultCols,
+		applyOrder:      true,
+		applyPagination: true,
+		applyLabelGroup: true,
+		allowUIDFast:    true,
+	})
+}
+
+// newSearchPhotosQueryWithOptions builds a photos query with optional result shaping.
+func newSearchPhotosQueryWithOptions(frm form.SearchPhotos, sess *entity.Session, opts searchPhotosQueryOptions) (query searchPhotosQuery, err error) {
+	query.form = frm
+
 	// Parse query string and filter.
 	if err = frm.ParseQueryString(); err != nil {
 		log.Debugf("search: %s", err)
-		return PhotoResults{}, 0, ErrBadRequest
+		return query, ErrBadRequest
 	}
 
 	// Find photos near another?
@@ -66,7 +122,7 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		// Find a nearby picture using the UID or return an empty result otherwise.
 		if err = Db().First(&photo, "photo_uid = ?", frm.Near).Error; err != nil {
 			log.Debugf("search: %s (find nearby)", err)
-			return PhotoResults{}, 0, ErrNotFound
+			return query, ErrNotFound
 		}
 
 		// Set the S2 Cell ID to search for.
@@ -81,8 +137,12 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 	}
 
 	// Specify table names and joins.
-	s := UnscopedDb().Table(entity.File{}.TableName()).Select(resultCols).
+	s := UnscopedDb().Table(entity.File{}.TableName()).
 		Joins("JOIN photos ON files.photo_id = photos.id AND files.media_id IS NOT NULL")
+
+	if opts.resultCols != "" {
+		s = s.Select(opts.resultCols)
+	}
 
 	// Include additional columns from details table?
 	if frm.Details {
@@ -110,15 +170,15 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		frm.Scope = strings.ToLower(frm.Scope)
 
 		if idType, idPrefix := rnd.IdType(frm.Scope); idType != rnd.TypeUID || idPrefix != entity.AlbumUID {
-			return PhotoResults{}, 0, ErrInvalidId
+			return query, ErrInvalidId
 		} else if album, albumErr = entity.CachedAlbumByUID(frm.Scope); albumErr != nil || album.AlbumUID == "" {
-			return PhotoResults{}, 0, ErrInvalidId
+			return query, ErrInvalidId
 		} else if album.AlbumFilter == "" {
 			s = s.Joins("JOIN photos_albums ON photos_albums.photo_uid = files.photo_uid").
 				Where("photos_albums.hidden = 0 AND photos_albums.album_uid = ?", album.AlbumUID)
 		} else if formErr := form.Unserialize(&frm, album.AlbumFilter); formErr != nil {
 			log.Debugf("search: %s (%s)", clean.Error(formErr), clean.Log(album.AlbumFilter))
-			return PhotoResults{}, 0, ErrBadFilter
+			return query, ErrBadFilter
 		} else {
 			frm.Filter = album.AlbumFilter
 			s = s.Where("files.photo_uid NOT IN (SELECT photo_uid FROM photos_albums pa WHERE pa.hidden = 1 AND pa.album_uid = ?)", album.AlbumUID)
@@ -160,7 +220,7 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		if frm.Scope != "" && album.CreatedBy != user.UserUID && !sess.HasShare(frm.Scope) && (sess.GetUser().HasSharedAccessOnly(acl.ResourcePhotos) || sess.NotRegistered()) ||
 			frm.Scope == "" && acl.Rules.Deny(acl.ResourcePhotos, aclRole, acl.ActionSearch) {
 			event.AuditErr([]string{sess.IP(), "session %s", "%s %s as %s", status.Denied}, sess.RefID, acl.ActionSearch.String(), string(acl.ResourcePhotos), aclRole)
-			return PhotoResults{}, 0, ErrForbidden
+			return query, ErrForbidden
 		}
 
 		// Limit results for external users.
@@ -178,41 +238,46 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		}
 	}
 
-	// Set sort order.
-	switch frm.Order {
-	case sortby.Edited:
-		s = s.Where("photos.edited_at IS NOT NULL").Order(OrderExpr("photos.edited_at DESC, files.media_id", frm.Reverse))
-	case sortby.Updated, sortby.UpdatedAt:
-		s = s.Where("photos.updated_at > photos.created_at").Order(OrderExpr("photos.updated_at DESC, files.media_id", frm.Reverse))
-	case sortby.Archived:
-		s = s.Order(OrderExpr("photos.deleted_at DESC, files.media_id", frm.Reverse))
-	case sortby.Relevance:
-		if frm.Label != "" {
-			s = s.Order(OrderExpr("photos.photo_quality DESC, photos_labels.uncertainty ASC, files.time_index", frm.Reverse))
-		} else {
-			s = s.Order(OrderExpr("photos.photo_quality DESC, files.time_index", frm.Reverse))
+	if opts.applyOrder {
+		// Set sort order.
+		switch frm.Order {
+		case sortby.Edited:
+			s = s.Where("photos.edited_at IS NOT NULL").Order(OrderExpr("photos.edited_at DESC, files.media_id", frm.Reverse))
+		case sortby.Updated, sortby.UpdatedAt:
+			s = s.Where("photos.updated_at > photos.created_at").Order(OrderExpr("photos.updated_at DESC, files.media_id", frm.Reverse))
+		case sortby.Archived:
+			s = s.Order(OrderExpr("photos.deleted_at DESC, files.media_id", frm.Reverse))
+		case sortby.Relevance:
+			if frm.Label != "" {
+				s = s.Order(OrderExpr("photos.photo_quality DESC, photos_labels.uncertainty ASC, files.time_index", frm.Reverse))
+			} else {
+				s = s.Order(OrderExpr("photos.photo_quality DESC, files.time_index", frm.Reverse))
+			}
+		case sortby.Duration:
+			s = s.Order(OrderExpr("photos.photo_duration DESC, files.time_index", frm.Reverse))
+		case sortby.Size:
+			s = s.Order(OrderExpr("files.file_size DESC, files.time_index", frm.Reverse))
+		case sortby.Newest:
+			s = s.Order(OrderExpr("files.time_index", frm.Reverse))
+		case sortby.Oldest:
+			s = s.Order(OrderExpr("files.photo_taken_at ASC, files.media_id", frm.Reverse))
+		case sortby.Similar:
+			s = s.Where("files.file_diff > 0")
+			s = s.Order(OrderExpr("photos.photo_color ASC, photos.cell_id ASC, files.file_diff, files.photo_id, files.time_index", frm.Reverse))
+		case sortby.Name:
+			s = s.Order(OrderExpr("photos.photo_path ASC, photos.photo_name ASC, files.time_index", frm.Reverse))
+		case sortby.Title:
+			s = s.Order(OrderExpr("photos.photo_title ASC, photos.photo_name ASC, files.time_index", frm.Reverse))
+		case sortby.Random:
+			s = s.Order(sortby.RandomExpr(s.Dialect()))
+		case sortby.Default, sortby.Imported, sortby.Added:
+			s = s.Order(OrderExpr("files.media_id", frm.Reverse))
+		default:
+			return query, ErrBadSortOrder
 		}
-	case sortby.Duration:
-		s = s.Order(OrderExpr("photos.photo_duration DESC, files.time_index", frm.Reverse))
-	case sortby.Size:
-		s = s.Order(OrderExpr("files.file_size DESC, files.time_index", frm.Reverse))
-	case sortby.Newest:
-		s = s.Order(OrderExpr("files.time_index", frm.Reverse))
-	case sortby.Oldest:
-		s = s.Order(OrderExpr("files.photo_taken_at ASC, files.media_id", frm.Reverse))
-	case sortby.Similar:
-		s = s.Where("files.file_diff > 0")
-		s = s.Order(OrderExpr("photos.photo_color ASC, photos.cell_id ASC, files.file_diff, files.photo_id, files.time_index", frm.Reverse))
-	case sortby.Name:
-		s = s.Order(OrderExpr("photos.photo_path ASC, photos.photo_name ASC, files.time_index", frm.Reverse))
-	case sortby.Title:
-		s = s.Order(OrderExpr("photos.photo_title ASC, photos.photo_name ASC, files.time_index", frm.Reverse))
-	case sortby.Random:
-		s = s.Order(sortby.RandomExpr(s.Dialect()))
-	case sortby.Default, sortby.Imported, sortby.Added:
-		s = s.Order(OrderExpr("files.media_id", frm.Reverse))
-	default:
-		return PhotoResults{}, 0, ErrBadSortOrder
+	} else {
+		frm.Order = sortby.Default
+		frm.Reverse = false
 	}
 
 	// Exclude files with errors by default.
@@ -245,7 +310,7 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		idType, prefix := rnd.ContainsType(ids)
 
 		if idType == rnd.TypeUnknown {
-			return PhotoResults{}, 0, fmt.Errorf("%s ids specified", idType)
+			return query, fmt.Errorf("%s ids specified", idType)
 		} else if idType.SHA() {
 			s = s.Where("files.file_hash IN (?)", ids)
 		} else if idType == rnd.TypeUID {
@@ -255,23 +320,15 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 			case entity.FileUID:
 				s = s.Where("files.file_uid IN (?)", ids)
 			default:
-				return PhotoResults{}, 0, fmt.Errorf("invalid ids specified")
+				return query, fmt.Errorf("invalid ids specified")
 			}
 		}
 
 		// Find UIDs only to improve performance.
-		if sess == nil && frm.FindUidOnly() {
-			if result := s.Scan(&results); result.Error != nil {
-				return results, 0, result.Error
-			}
-
-			log.Debugf("photos: found %s for %s [%s]", english.Plural(len(results), "result", "results"), frm.SerializeAll(), time.Since(start))
-
-			if frm.Merged {
-				return results.Merge()
-			}
-
-			return results, len(results), nil
+		if opts.allowUIDFast && sess == nil && frm.FindUidOnly() {
+			query.db = s
+			query.form = frm
+			return query, nil
 		}
 	}
 
@@ -290,7 +347,8 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 
 		if labelErr != nil || (sawPositive && len(include) == 0) {
 			log.Debugf("search: label %s not found", txt.LogParamLower(frm.Label))
-			return PhotoResults{}, 0, nil
+			query.form = frm
+			return query, nil
 		}
 
 		// JOIN the first positive group so photos_labels.uncertainty is
@@ -298,8 +356,11 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		// groups compose as AND via IN subqueries.
 		for i, ids := range include {
 			if i == 0 {
-				s = s.Joins("JOIN photos_labels ON photos_labels.photo_id = files.photo_id AND photos_labels.uncertainty < 100 AND photos_labels.label_id IN (?)", ids).
-					Group("photos.id, files.id")
+				s = s.Joins("JOIN photos_labels ON photos_labels.photo_id = files.photo_id AND photos_labels.uncertainty < 100 AND photos_labels.label_id IN (?)", ids)
+
+				if opts.applyLabelGroup {
+					s = s.Group("photos.id, files.id")
+				}
 			} else {
 				s = s.Where("files.photo_id IN (SELECT photo_id FROM photos_labels WHERE uncertainty < 100 AND label_id IN (?))", ids)
 			}
@@ -824,27 +885,16 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		}
 	}
 
-	// Search result count and offset.
-	if frm.Count <= 0 || frm.Count > MaxResults {
-		frm.Count = MaxResults
+	if opts.applyPagination {
+		// Search result count and offset.
+		if frm.Count <= 0 || frm.Count > MaxResults {
+			frm.Count = MaxResults
+		}
+
+		s = s.Limit(frm.Count).Offset(frm.Offset)
 	}
 
-	s = s.Limit(frm.Count).Offset(frm.Offset)
-
-	// Query database.
-	if err = s.Scan(&results).Error; err != nil {
-		return results, 0, err
-	}
-
-	// Log number of results.
-	log.Debugf("photos: found %s for %s [%s]", english.Plural(len(results), "result", "results"), frm.SerializeAll(), time.Since(start))
-
-	// Merge files that belong to the same photo.
-	if frm.Merged {
-		// Return merged files.
-		return results.Merge()
-	}
-
-	// Return unmerged files.
-	return results, len(results), nil
+	query.db = s
+	query.form = frm
+	return query, nil
 }

--- a/internal/entity/search/photos_test.go
+++ b/internal/entity/search/photos_test.go
@@ -2460,3 +2460,274 @@ func TestPhotos(t *testing.T) {
 		assert.True(t, foundRight)
 	})
 }
+
+func TestPhotosUidOnlyMergedBehavior(t *testing.T) {
+	const uid = "ps6sg6be2lvl0yh0"
+
+	t.Run("Unmerged", func(t *testing.T) {
+		frm := form.SearchPhotos{UID: uid}
+
+		photos, count, err := Photos(frm)
+
+		assert.NoError(t, err)
+		assert.Len(t, photos, 3)
+		assert.Equal(t, 3, count)
+
+		for _, photo := range photos {
+			assert.Equal(t, uid, photo.PhotoUID)
+			assert.Empty(t, photo.Files)
+		}
+	})
+
+	t.Run("Merged", func(t *testing.T) {
+		frm := form.SearchPhotos{UID: uid, Merged: true}
+
+		photos, count, err := Photos(frm)
+
+		assert.NoError(t, err)
+		assert.Len(t, photos, 1)
+		assert.Equal(t, 3, count)
+		assert.Equal(t, uid, photos[0].PhotoUID)
+		assert.True(t, photos[0].Merged)
+		assert.Len(t, photos[0].Files, 3)
+	})
+
+	t.Run("CountAndOffsetDoNotDisableUidOnlyPath", func(t *testing.T) {
+		frm := form.SearchPhotos{
+			UID:    uid,
+			Count:  1,
+			Offset: 1,
+			Merged: true,
+		}
+
+		photos, count, err := Photos(frm)
+
+		assert.NoError(t, err)
+		assert.Len(t, photos, 1)
+		assert.Equal(t, 3, count)
+		assert.Equal(t, uid, photos[0].PhotoUID)
+		assert.Len(t, photos[0].Files, 3)
+	})
+
+	t.Run("LabelFieldDoesNotDisableUidOnlyPath", func(t *testing.T) {
+		frm := form.SearchPhotos{
+			UID:    uid,
+			Label:  "totally-unknown-label",
+			Merged: true,
+		}
+
+		photos, count, err := Photos(frm)
+
+		assert.NoError(t, err)
+		assert.Len(t, photos, 1)
+		assert.Equal(t, 3, count)
+		assert.Equal(t, uid, photos[0].PhotoUID)
+		assert.Len(t, photos[0].Files, 3)
+	})
+
+	t.Run("ParsedQueryLabelDoesNotDisableUidOnlyPath", func(t *testing.T) {
+		frm := form.SearchPhotos{
+			UID:    uid,
+			Query:  `label:"totally-unknown-label"`,
+			Merged: true,
+		}
+
+		photos, count, err := Photos(frm)
+
+		assert.NoError(t, err)
+		assert.Len(t, photos, 1)
+		assert.Equal(t, 3, count)
+		assert.Equal(t, uid, photos[0].PhotoUID)
+		assert.Len(t, photos[0].Files, 3)
+	})
+}
+
+func TestUserPhotoTimeline(t *testing.T) {
+	const uid = "ps6sg6be2lvl0yh0"
+
+	t.Run("MonthBucketCountsMergedPhotoOnce", func(t *testing.T) {
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: uid}, nil, PhotoTimelineBucketMonth)
+
+		assert.NoError(t, err)
+		assert.Equal(t, PhotoTimelineBucketMonth, timeline.Bucket)
+		assert.Equal(t, PhotoTimelineOrderDesc, timeline.Order)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Equal(t, 0, timeline.UnknownDateCount)
+		assert.Len(t, timeline.Buckets, 1)
+		assert.Equal(t, "1990-04", timeline.Buckets[0].Key)
+		assert.Equal(t, 1990, timeline.Buckets[0].Year)
+		assert.Equal(t, 4, timeline.Buckets[0].Month)
+		assert.Nil(t, timeline.Buckets[0].Day)
+		assert.Equal(t, "1990-04-01", timeline.Buckets[0].From)
+		assert.Equal(t, "1990-05-01", timeline.Buckets[0].Until)
+		assert.Equal(t, 1, timeline.Buckets[0].PhotoCount)
+	})
+
+	t.Run("MonthBucketsAreDescending", func(t *testing.T) {
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: "ps6sg6be2lvl0y11|ps6sg6be2lvl0yh0"}, nil, PhotoTimelineBucketMonth)
+
+		assert.NoError(t, err)
+		assert.Equal(t, PhotoTimelineOrderDesc, timeline.Order)
+		assert.Equal(t, 2, timeline.PhotoCount)
+		assert.Equal(t, 0, timeline.UnknownDateCount)
+		assert.Len(t, timeline.Buckets, 2)
+		assert.Equal(t, "2014-07", timeline.Buckets[0].Key)
+		assert.Equal(t, "1990-04", timeline.Buckets[1].Key)
+	})
+
+	t.Run("MonthBucketIncludesIncompleteDay", func(t *testing.T) {
+		incompleteUID := "ps6sg6be2lvl0y11"
+
+		assert.NoError(t, entity.Db().Model(&entity.Photo{}).Where("photo_uid = ?", incompleteUID).UpdateColumn("photo_day", 0).Error)
+
+		t.Cleanup(func() {
+			assert.NoError(t, entity.Db().Model(&entity.Photo{}).Where("photo_uid = ?", incompleteUID).UpdateColumn("photo_day", 10).Error)
+		})
+
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: incompleteUID}, nil, PhotoTimelineBucketMonth)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Equal(t, 0, timeline.UnknownDateCount)
+		assert.Len(t, timeline.Buckets, 1)
+		assert.Equal(t, "2014-07", timeline.Buckets[0].Key)
+		assert.Equal(t, 1, timeline.Buckets[0].PhotoCount)
+	})
+
+	t.Run("DayBucketTreatsIncompleteDayAsUnknown", func(t *testing.T) {
+		incompleteUID := "ps6sg6be2lvl0y11"
+
+		assert.NoError(t, entity.Db().Model(&entity.Photo{}).Where("photo_uid = ?", incompleteUID).UpdateColumn("photo_day", 0).Error)
+
+		t.Cleanup(func() {
+			assert.NoError(t, entity.Db().Model(&entity.Photo{}).Where("photo_uid = ?", incompleteUID).UpdateColumn("photo_day", 10).Error)
+		})
+
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: incompleteUID}, nil, PhotoTimelineBucketDay)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Equal(t, 1, timeline.UnknownDateCount)
+		assert.Empty(t, timeline.Buckets)
+	})
+
+	t.Run("DayBucketUsesLocalDateFields", func(t *testing.T) {
+		localUID := "ps6sg6be2lvl0y11"
+		takenAt := time.Date(2020, 6, 30, 23, 30, 0, 0, time.UTC)
+		takenAtLocal := time.Date(2020, 7, 1, 1, 30, 0, 0, time.UTC)
+
+		assert.NoError(t, entity.Db().Model(&entity.Photo{}).Where("photo_uid = ?", localUID).UpdateColumns(entity.Values{
+			"taken_at":       takenAt,
+			"taken_at_local": takenAtLocal,
+			"photo_year":     2020,
+			"photo_month":    7,
+			"photo_day":      1,
+		}).Error)
+
+		t.Cleanup(func() {
+			assert.NoError(t, entity.Db().Model(&entity.Photo{}).Where("photo_uid = ?", localUID).UpdateColumns(entity.Values{
+				"taken_at":       time.Date(2014, 7, 17, 15, 42, 12, 0, time.UTC),
+				"taken_at_local": time.Date(2014, 7, 17, 17, 42, 12, 0, time.UTC),
+				"photo_year":     2014,
+				"photo_month":    7,
+				"photo_day":      10,
+			}).Error)
+		})
+
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: localUID}, nil, PhotoTimelineBucketDay)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Equal(t, 0, timeline.UnknownDateCount)
+		assert.Len(t, timeline.Buckets, 1)
+		assert.Equal(t, "2020-07-01", timeline.Buckets[0].Key)
+		assert.Equal(t, "2020-07-01", timeline.Buckets[0].From)
+		assert.Equal(t, "2020-07-02", timeline.Buckets[0].Until)
+		assert.NotNil(t, timeline.Buckets[0].Day)
+
+		if timeline.Buckets[0].Day != nil {
+			assert.Equal(t, 1, *timeline.Buckets[0].Day)
+		}
+	})
+
+	t.Run("CountAndOffsetDoNotChangeBuckets", func(t *testing.T) {
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: uid, Count: 1, Offset: 1}, nil, PhotoTimelineBucketMonth)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Len(t, timeline.Buckets, 1)
+		assert.Equal(t, "1990-04", timeline.Buckets[0].Key)
+		assert.Equal(t, 1, timeline.Buckets[0].PhotoCount)
+	})
+
+	t.Run("PrimaryFilterIsSupported", func(t *testing.T) {
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: uid, Primary: true}, nil, PhotoTimelineBucketMonth)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Len(t, timeline.Buckets, 1)
+		assert.Equal(t, 1, timeline.Buckets[0].PhotoCount)
+	})
+
+	t.Run("UnknownDateCount", func(t *testing.T) {
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: "ps6sg6be2lvl0y45"}, nil, PhotoTimelineBucketMonth)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Equal(t, 1, timeline.UnknownDateCount)
+		assert.Empty(t, timeline.Buckets)
+	})
+
+	t.Run("NullDateFieldsCountAsUnknown", func(t *testing.T) {
+		nullUID := "ps6sg6be2lvl0y11"
+
+		assert.NoError(t, entity.Db().Model(&entity.Photo{}).Where("photo_uid = ?", nullUID).UpdateColumns(entity.Values{
+			"photo_year":  nil,
+			"photo_month": nil,
+			"photo_day":   nil,
+		}).Error)
+
+		t.Cleanup(func() {
+			assert.NoError(t, entity.Db().Model(&entity.Photo{}).Where("photo_uid = ?", nullUID).UpdateColumns(entity.Values{
+				"photo_year":  2014,
+				"photo_month": 7,
+				"photo_day":   10,
+			}).Error)
+		})
+
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{UID: nullUID}, nil, PhotoTimelineBucketDay)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Equal(t, 1, timeline.UnknownDateCount)
+		assert.Empty(t, timeline.Buckets)
+	})
+
+	t.Run("LabelFilterDoesNotDuplicatePhotoCount", func(t *testing.T) {
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{
+			UID:   uid,
+			Label: "cow|updatePhotoLabel",
+		}, nil, PhotoTimelineBucketMonth)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, timeline.PhotoCount)
+		assert.Len(t, timeline.Buckets, 1)
+		assert.Equal(t, 1, timeline.Buckets[0].PhotoCount)
+	})
+
+	t.Run("NoMatchReturnsEmptyBucketSlice", func(t *testing.T) {
+		timeline, err := UserPhotoTimeline(form.SearchPhotos{Label: "totally-unknown-label"}, nil, PhotoTimelineBucketMonth)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, timeline.PhotoCount)
+		assert.Equal(t, 0, timeline.UnknownDateCount)
+		assert.NotNil(t, timeline.Buckets)
+		assert.Empty(t, timeline.Buckets)
+	})
+
+	t.Run("InvalidBucket", func(t *testing.T) {
+		_, err := UserPhotoTimeline(form.SearchPhotos{UID: uid}, nil, "year")
+
+		assert.ErrorIs(t, err, ErrBadRequest)
+	})
+}

--- a/internal/entity/search/photos_timeline.go
+++ b/internal/entity/search/photos_timeline.go
@@ -1,0 +1,187 @@
+package search
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jinzhu/gorm"
+
+	"github.com/photoprism/photoprism/internal/entity"
+	"github.com/photoprism/photoprism/internal/form"
+)
+
+const (
+	PhotoTimelineBucketMonth = "month"
+	PhotoTimelineBucketDay   = "day"
+	PhotoTimelineOrderDesc   = "desc"
+)
+
+// PhotoTimeline contains local-date buckets for photo search results.
+type PhotoTimeline struct {
+	Bucket           string                `json:"bucket"`
+	Order            string                `json:"order"`
+	PhotoCount       int                   `json:"photoCount"`
+	UnknownDateCount int                   `json:"unknownDateCount"`
+	Buckets          []PhotoTimelineBucket `json:"buckets"`
+}
+
+// PhotoTimelineBucket contains a single local-date photo count bucket.
+type PhotoTimelineBucket struct {
+	Key        string `json:"key"`
+	Label      string `json:"label"`
+	Year       int    `json:"year"`
+	Month      int    `json:"month"`
+	Day        *int   `json:"day,omitempty"`
+	From       string `json:"from"`
+	Until      string `json:"until"`
+	PhotoCount int    `json:"photoCount"`
+}
+
+type photoTimelineBucketRow struct {
+	Year       int `gorm:"column:year"`
+	Month      int `gorm:"column:month"`
+	Day        int `gorm:"column:day"`
+	PhotoCount int `gorm:"column:photo_count"`
+}
+
+type photoTimelineCountRow struct {
+	PhotoCount int `gorm:"column:photo_count"`
+}
+
+// UserPhotoTimeline returns local-date timeline buckets for matching photos.
+func UserPhotoTimeline(frm form.SearchPhotos, sess *entity.Session, bucket string) (timeline PhotoTimeline, err error) {
+	if bucket == "" {
+		bucket = PhotoTimelineBucketMonth
+	}
+
+	if bucket != PhotoTimelineBucketMonth && bucket != PhotoTimelineBucketDay {
+		return timeline, ErrBadRequest
+	}
+
+	frm.Count = 0
+	frm.Offset = 0
+	frm.Order = ""
+	frm.Reverse = false
+	frm.Merged = false
+
+	query, err := newSearchPhotosQueryWithOptions(frm, sess, searchPhotosQueryOptions{
+		applyOrder:      false,
+		applyPagination: false,
+		applyLabelGroup: false,
+		allowUIDFast:    false,
+	})
+
+	if err != nil {
+		return timeline, err
+	} else if query.db == nil {
+		return PhotoTimeline{Bucket: bucket, Order: PhotoTimelineOrderDesc, Buckets: []PhotoTimelineBucket{}}, nil
+	}
+
+	total, err := photoTimelineCount(query.db, "")
+
+	if err != nil {
+		return timeline, err
+	}
+
+	validWhere := "photos.photo_year > 0 AND photos.photo_month > 0"
+
+	if bucket == PhotoTimelineBucketDay {
+		validWhere += " AND photos.photo_day > 0"
+	}
+
+	buckets, err := photoTimelineBuckets(query.db, bucket, validWhere)
+
+	if err != nil {
+		return timeline, err
+	}
+
+	valid := 0
+
+	for i := range buckets {
+		valid += buckets[i].PhotoCount
+	}
+
+	return PhotoTimeline{
+		Bucket:           bucket,
+		Order:            PhotoTimelineOrderDesc,
+		PhotoCount:       total,
+		UnknownDateCount: total - valid,
+		Buckets:          buckets,
+	}, nil
+}
+
+// photoTimelineCount returns the number of distinct photos matching the query.
+func photoTimelineCount(s *gorm.DB, where string) (count int, err error) {
+	row := photoTimelineCountRow{}
+	q := s.Select("COUNT(DISTINCT photos.id) AS photo_count")
+
+	if where != "" {
+		q = q.Where(where)
+	}
+
+	if err = q.Scan(&row).Error; err != nil {
+		return 0, err
+	}
+
+	return row.PhotoCount, nil
+}
+
+// photoTimelineBuckets returns grouped local-date photo buckets.
+func photoTimelineBuckets(s *gorm.DB, bucket, validWhere string) (buckets []PhotoTimelineBucket, err error) {
+	rows := make([]photoTimelineBucketRow, 0)
+	selectCols := "photos.photo_year AS year, photos.photo_month AS month, COUNT(DISTINCT photos.id) AS photo_count"
+	groupCols := "photos.photo_year, photos.photo_month"
+	orderCols := "photos.photo_year DESC, photos.photo_month DESC"
+
+	if bucket == PhotoTimelineBucketDay {
+		selectCols = "photos.photo_year AS year, photos.photo_month AS month, photos.photo_day AS day, COUNT(DISTINCT photos.id) AS photo_count"
+		groupCols = "photos.photo_year, photos.photo_month, photos.photo_day"
+		orderCols = "photos.photo_year DESC, photos.photo_month DESC, photos.photo_day DESC"
+	}
+
+	if err = s.Select(selectCols).Where(validWhere).Group(groupCols).Order(orderCols).Scan(&rows).Error; err != nil {
+		return buckets, err
+	}
+
+	buckets = make([]PhotoTimelineBucket, 0, len(rows))
+
+	for _, row := range rows {
+		buckets = append(buckets, newPhotoTimelineBucket(row, bucket))
+	}
+
+	return buckets, nil
+}
+
+// newPhotoTimelineBucket formats a local-date bucket row for API responses.
+func newPhotoTimelineBucket(row photoTimelineBucketRow, bucket string) PhotoTimelineBucket {
+	if bucket == PhotoTimelineBucketDay {
+		day := row.Day
+		date := time.Date(row.Year, time.Month(row.Month), row.Day, 0, 0, 0, 0, time.UTC)
+		next := date.AddDate(0, 0, 1)
+
+		return PhotoTimelineBucket{
+			Key:        date.Format("2006-01-02"),
+			Label:      date.Format("Jan 2, 2006"),
+			Year:       row.Year,
+			Month:      row.Month,
+			Day:        &day,
+			From:       date.Format("2006-01-02"),
+			Until:      next.Format("2006-01-02"),
+			PhotoCount: row.PhotoCount,
+		}
+	}
+
+	date := time.Date(row.Year, time.Month(row.Month), 1, 0, 0, 0, 0, time.UTC)
+	next := date.AddDate(0, 1, 0)
+
+	return PhotoTimelineBucket{
+		Key:        date.Format("2006-01"),
+		Label:      fmt.Sprintf("%s %d", date.Month(), row.Year),
+		Year:       row.Year,
+		Month:      row.Month,
+		Day:        nil,
+		From:       date.Format("2006-01-02"),
+		Until:      next.Format("2006-01-02"),
+		PhotoCount: row.PhotoCount,
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -106,6 +106,7 @@ func registerRoutes(router *gin.Engine, conf *config.Config) {
 	// Photo Search and Organization.
 	api.SearchPhotos(APIv1)
 	api.SearchPhotosView(APIv1)
+	api.SearchPhotoTimeline(APIv1)
 	api.SearchGeo(APIv1)
 	api.GetPlacesReverse(APIv1)
 	api.GetPlacesSearch(APIv1)

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -11,12 +11,55 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/photoprism/photoprism/internal/config"
 	"github.com/photoprism/photoprism/internal/config/pwa"
 	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/photoprism/photoprism/pkg/http/header"
 )
+
+func TestRegisterRoutesSearchPhotoTimeline(t *testing.T) {
+	r := gin.New()
+	conf := config.TestConfig()
+
+	r.LoadHTMLFiles(conf.TemplateFiles()...)
+
+	oldAPIv1 := APIv1
+	oldRegisterAPIDocs := registerAPIDocs
+
+	APIv1 = r.Group(conf.BaseUri(config.ApiUri), APIMiddleware(conf))
+	registerAPIDocs = nil
+
+	t.Cleanup(func() {
+		APIv1 = oldAPIv1
+		registerAPIDocs = oldRegisterAPIDocs
+	})
+
+	registerRoutes(r, conf)
+
+	t.Run("TimelineRoute", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(header.MethodGet, conf.BaseUri(config.ApiUri+"/photos/timeline")+"?bucket=month&uid=ps6sg6be2lvl0yh0", nil)
+
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "month", gjson.Get(w.Body.String(), "bucket").String())
+		assert.Equal(t, "desc", gjson.Get(w.Body.String(), "order").String())
+		assert.Equal(t, int64(1), gjson.Get(w.Body.String(), "photoCount").Int())
+	})
+
+	t.Run("PhotoUidRoute", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(header.MethodGet, conf.BaseUri(config.ApiUri+"/photos/ps6sg6be2lvl0yh0"), nil)
+
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "ps6sg6be2lvl0yh0", gjson.Get(w.Body.String(), "UID").String())
+	})
+}
 
 func TestStaticRoutes(t *testing.T) {
 	// Create router.


### PR DESCRIPTION
### Description

Adds a phase-one timeline rail to the Photos view, backed by a new month-bucket API that reuses the existing photo search filters and permission checks.

This keeps the existing photo browser as the main experience and adds a lightweight desktop navigation aid for jumping to months. The rail is hidden on smaller screens, when Calendar access is unavailable, and when the current filters do not produce date buckets.

Main changes:

- Add `GET /api/v1/photos/timeline?bucket=month` for local-date month buckets.
- Reuse existing photo search filters and ACL checks for timeline counts.
- Add a responsive timeline rail to the Photos view for desktop layouts.
- Keep timeline requests independent from the currently selected month so the rail can still be used for navigation.
- Collapse the rail for empty and unknown-date-only results to avoid an empty gutter.
- Update Swagger API docs and add backend/frontend test coverage.

#### Related Issues

- Related to #152

### Acceptance Criteria

- [x] The phase-one timeline rail and month bucket API are implemented without requiring configuration changes.
- [x] Automated unit/API/component tests are included.
- [x] API documentation has been updated through Swagger.
- [x] Database-related timeline tests have been run with SQLite and MariaDB.
- [x] Browser UX was smoke-tested locally in Chromium on desktop and mobile viewports.
- [ ] Safari and Firefox browser UX were not tested locally.

### Validation

- `npm --workspace frontend test -- tests/vitest/component/photo/timeline.test.js tests/vitest/model/photo.test.js tests/vitest/page/photos.timeline.test.js tests/vitest/page/photos.onupdate.test.js tests/vitest/component/photo/toolbar.test.js`
- `npm --workspace frontend run lint`
- `npm --workspace frontend run build`
- `go test -count=1 ./internal/api -run '^TestSearchPhotoTimeline$|^TestSearchPhotos$|^TestSearchPhotosView$'` with SQLite and MariaDB
- `go test -count=1 ./internal/entity/search -run '^TestUserPhotoTimeline$|^TestPhotosUidOnlyMergedBehavior$'` with SQLite and MariaDB
- `go test -count=1 ./internal/server -run '^TestRegisterRoutesSearchPhotoTimeline$'` with SQLite and MariaDB
- `make swag-fmt swag`
- Local Chromium UX checks: desktop rail, month click URL/query behavior, stale `day` cleanup, empty/unknown-only collapse, mobile absence, cards/mosaic/list layout smoke, and console warning/error check.
