### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/internal/service/cidr.go
+++ b/internal/service/cidr.go
@@ -21,7 +21,7 @@ func ParseCIDRs(raw string) (result []*net.IPNet, err error) {
 		return result, nil
 	}
 
-	for _, token := range strings.Split(raw, ",") {
+	for token := range strings.SplitSeq(raw, ",") {
 		token = strings.TrimSpace(token)
 
 		if token == "" {

--- a/internal/service/webdav/path.go
+++ b/internal/service/webdav/path.go
@@ -7,7 +7,7 @@ import (
 
 // isHiddenPath reports whether any segment of a WebDAV path starts with a dot.
 func isHiddenPath(dir string) bool {
-	for _, segment := range strings.Split(trimPath(dir), "/") {
+	for segment := range strings.SplitSeq(trimPath(dir), "/") {
 		if strings.HasPrefix(segment, ".") {
 			return true
 		}

--- a/pkg/http/security/web_overlay.go
+++ b/pkg/http/security/web_overlay.go
@@ -77,7 +77,7 @@ func OverlayHasAmbiguousPath(requestPath, escapedPath string) bool {
 	}
 
 	if relPath := strings.Trim(cleanPath, "/"); relPath != "" {
-		for _, segment := range strings.Split(relPath, "/") {
+		for segment := range strings.SplitSeq(relPath, "/") {
 			if segment == "" || segment == "." || segment == ".." || fs.FileNameHidden(segment) {
 				return true
 			}
@@ -120,9 +120,9 @@ func OverlayPathBlocked(webPath string) bool {
 		return false
 	}
 
-	segments := strings.Split(relPath, "/")
+	segments := strings.SplitSeq(relPath, "/")
 
-	for _, segment := range segments {
+	for segment := range segments {
 		if segment == "" || fs.FileNameHidden(segment) {
 			return true
 		}


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901



#### Related Issues

- Links to issues that this PR fixes, implements, or is otherwise related to...

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [ ] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes
- [ ] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [ ] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->