### PR TITLE
UX: Add timeline photo view

### DIFF
--- a/frontend/src/component/photo/toolbar.vue
+++ b/frontend/src/component/photo/toolbar.vue
@@ -64,7 +64,8 @@
         >
           <v-btn value="cards" icon="mdi-view-column" class="ps-1 action-view-cards" @click="setView('cards')"></v-btn>
           <v-btn v-if="listView" value="list" icon="mdi-view-list" class="action-view-list" @click="setView('list')"></v-btn>
-          <v-btn value="mosaic" icon="mdi-view-comfy" class="pe-1 action-view-mosaic" @click="setView('mosaic')"></v-btn>
+          <v-btn value="mosaic" icon="mdi-view-comfy" class="action-view-mosaic" @click="setView('mosaic')"></v-btn>
+          <v-btn value="timeline" icon="mdi-timeline-clock-outline" class="pe-1 action-view-timeline" @click="setView('timeline')"></v-btn>
         </v-btn-toggle>
 
         <v-btn
@@ -382,20 +383,26 @@ export default {
       return this.all.categories.concat(this.config.categories);
     },
     viewOptions() {
+      const views = [
+        { value: "mosaic", text: this.$gettext("Mosaic") },
+        { value: "cards", text: this.$gettext("Cards") },
+        { value: "timeline", text: this.$gettext("Timeline") },
+      ];
+
       if (this.$config.getSettings()?.search?.listView) {
-        return [
-          { value: "mosaic", text: this.$gettext("Mosaic") },
-          { value: "cards", text: this.$gettext("Cards") },
-          { value: "list", text: this.$gettext("List") },
-        ];
-      } else {
-        return [
-          { value: "mosaic", text: this.$gettext("Mosaic") },
-          { value: "cards", text: this.$gettext("Cards") },
-        ];
+        views.push({ value: "list", text: this.$gettext("List") });
       }
+
+      return views;
     },
     sortOptions() {
+      if (this.settings.view === "timeline") {
+        return [
+          { value: "newest", text: this.$gettext("Newest First") },
+          { value: "oldest", text: this.$gettext("Oldest First") },
+        ];
+      }
+
       switch (this.context) {
         case contexts.Archive:
           return [
@@ -502,6 +509,8 @@ export default {
       if (name) {
         if (name === "list" && !this.listView) {
           name = "mosaic";
+        } else if (name === "timeline" && this.filter.order !== "newest" && this.filter.order !== "oldest") {
+          this.updateFilter({ order: "newest" });
         }
         this.hideExpansionPanel();
         this.refresh({ view: name });

--- a/frontend/src/component/photo/view/timeline.js
+++ b/frontend/src/component/photo/view/timeline.js
@@ -1,0 +1,124 @@
+export const UnknownTimelineKey = "unknown";
+
+function positiveInt(value, min, max) {
+  const n = Number.parseInt(value, 10);
+
+  if (!Number.isInteger(n) || n < min || n > max) {
+    return 0;
+  }
+
+  return n;
+}
+
+function localPart(value, start, length, min, max) {
+  if (typeof value !== "string" || value.length < start + length) {
+    return 0;
+  }
+
+  return positiveInt(value.substring(start, start + length), min, max);
+}
+
+export function photoLocalDateParts(photo) {
+  const takenAtLocal = photo?.TakenAtLocal || "";
+  const year = localPart(takenAtLocal, 0, 4, 1000, 9999) || positiveInt(photo?.Year, 1000, 9999);
+  const month = localPart(takenAtLocal, 5, 2, 1, 12) || positiveInt(photo?.Month, 1, 12);
+  const day = localPart(takenAtLocal, 8, 2, 1, 31) || positiveInt(photo?.Day, 1, 31);
+
+  if (!year || !month) {
+    return {
+      known: false,
+      year: 0,
+      month: 0,
+      day: 0,
+    };
+  }
+
+  return {
+    known: true,
+    year,
+    month,
+    day,
+  };
+}
+
+function monthLabel(month, monthOptions) {
+  const option = monthOptions.find((item) => item.value === month);
+  return option ? option.text : month.toString().padStart(2, "0");
+}
+
+function countLabel(count, gettext) {
+  return count === 1 ? gettext("1 picture") : `${count} ${gettext("pictures")}`;
+}
+
+export function buildTimelineSections(photos, monthOptions, gettext = (s) => s) {
+  const sections = [];
+  const sectionMap = new Map();
+  const unknownSection = {
+    key: UnknownTimelineKey,
+    title: gettext("Unknown date"),
+    count: 0,
+    countLabel: "",
+    days: [
+      {
+        key: UnknownTimelineKey,
+        title: gettext("Unknown"),
+        entries: [],
+      },
+    ],
+  };
+
+  for (let index = 0; index < photos.length; index++) {
+    const photo = photos[index];
+    const parts = photoLocalDateParts(photo);
+    const entry = { photo, index };
+
+    if (!parts.known) {
+      unknownSection.days[0].entries.push(entry);
+      unknownSection.count++;
+      continue;
+    }
+
+    const sectionKey = `${parts.year}-${parts.month.toString().padStart(2, "0")}`;
+    let section = sectionMap.get(sectionKey);
+
+    if (!section) {
+      section = {
+        key: sectionKey,
+        title: `${monthLabel(parts.month, monthOptions)} ${parts.year}`,
+        count: 0,
+        countLabel: "",
+        days: [],
+        dayMap: new Map(),
+      };
+      sectionMap.set(sectionKey, section);
+      sections.push(section);
+    }
+
+    const dayKey = parts.day ? `${sectionKey}-${parts.day.toString().padStart(2, "0")}` : `${sectionKey}-unknown`;
+    let day = section.dayMap.get(dayKey);
+
+    if (!day) {
+      day = {
+        key: dayKey,
+        title: parts.day ? parts.day.toString() : gettext("Unknown"),
+        entries: [],
+      };
+      section.dayMap.set(dayKey, day);
+      section.days.push(day);
+    }
+
+    day.entries.push(entry);
+    section.count++;
+  }
+
+  if (unknownSection.count > 0) {
+    sections.push(unknownSection);
+  }
+
+  for (const section of sections) {
+    section.countLabel = countLabel(section.count, gettext);
+    delete section.dayMap;
+  }
+
+  return sections;
+}

--- a/frontend/src/component/photo/view/timeline.vue
+++ b/frontend/src/component/photo/view/timeline.vue
@@ -1,0 +1,348 @@
+<template>
+  <div class="p-photos p-photo-view-timeline">
+    <div v-if="photos.length === 0" class="pa-3">
+      <v-alert color="surface-variant" :icon="isSharedView ? 'mdi-image-off' : 'mdi-lightbulb-outline'" class="no-results" variant="outlined">
+        <div v-if="filter.order === 'edited'" class="font-weight-bold">
+          {{ $gettext(`No recently edited pictures`) }}
+        </div>
+        <div v-else class="font-weight-bold">
+          {{ $gettext(`No pictures found`) }}
+        </div>
+        <div class="mt-2">
+          {{ $gettext(`Try again using other filters or keywords.`) }}
+          <template v-if="!isSharedView">
+            {{ $gettext(`In case pictures you expect are missing, please rescan your library and wait until indexing has been completed.`) }}
+            <template v-if="$config.feature('review')">
+              {{ $gettext(`Non-photographic and low-quality images require a review before they appear in search results.`) }}
+            </template>
+          </template>
+        </div>
+      </v-alert>
+    </div>
+    <div v-else class="search-results photo-results mosaic-view timeline-view" :class="{ 'select-results': selectMode }">
+      <section v-for="section in sections" :key="section.key" class="timeline-section">
+        <div class="timeline-section__header">
+          <h2>{{ section.title }}</h2>
+          <span>{{ section.countLabel }}</span>
+        </div>
+        <div v-for="day in section.days" :key="day.key" class="timeline-day">
+          <div class="timeline-day__label">
+            <span>{{ day.title }}</span>
+          </div>
+          <div class="v-row timeline-day__photos">
+            <div
+              v-for="{ photo: m, index } in day.entries"
+              :key="m.ID || m.UID"
+              ref="items"
+              class="v-col-4 v-col-sm-3 v-col-md-2 v-col-lg-1"
+              :data-index="index"
+            >
+              <div class="result-container">
+                <div
+                  v-if="index < firstVisibleElementIndex || index > lastVisibleElementIndex"
+                  :data-id="m.ID"
+                  :data-uid="m.UID"
+                  class="media result preview placeholder"
+                />
+                <div
+                  v-else
+                  :data-id="m.ID"
+                  :data-uid="m.UID"
+                  :title="showTitles && m.Title ? m.Title : m.getOriginalName()"
+                  :style="`background-image: url(${m.thumbnailUrl('tile_224')})`"
+                  :class="m.classes()"
+                  class="media result preview"
+                  @contextmenu.stop="onContextMenu($event, index)"
+                  @touchstart.passive="input.touchStart($event, index)"
+                  @touchend.stop="onClick($event, index)"
+                  @mousedown.stop="input.mouseDown($event, index)"
+                  @click.stop.prevent="onClick($event, index)"
+                  @mouseover="playLive(m)"
+                  @mouseleave="pauseLive(m)"
+                >
+                  <div class="preview__overlay"></div>
+                  <div v-if="m.Type === 'live' || m.Type === 'animated'" class="live-player">
+                    <video :id="'live-player-' + m.ID" width="224" height="224" preload="none" loop muted playsinline>
+                      <source :type="m.videoContentType()" :src="m.videoUrl()" />
+                    </video>
+                  </div>
+
+                  <button
+                    v-if="(m.Type !== 'image' && m.Type !== 'video') || selectMode || m.isStack()"
+                    class="input-open"
+                    @touchstart.stop="input.touchStart($event, index)"
+                    @touchend.stop="onOpen($event, index, !isSharedView)"
+                    @touchmove.stop
+                    @click.stop.prevent="onOpen($event, index, !isSharedView)"
+                  >
+                    <i v-if="m.Type === 'raw'" class="action-raw mdi mdi-raw" :title="$gettext('RAW')" />
+                    <i v-else-if="m.Type === 'live'" class="action-live" :title="$gettext('Live')"><icon-live-photo /></i>
+                    <i v-else-if="m.Type === 'animated'" class="mdi mdi-file-gif-box" :title="$gettext('Animated')" />
+                    <i v-else-if="m.Type === 'vector'" class="action-vector mdi mdi-vector-polyline" :title="$gettext('Vector')"></i>
+                    <i v-else-if="m.Type === 'document'" class="action-document mdi mdi-file-pdf-box" :title="$gettext('Document')" />
+                    <i v-else-if="m.Type === 'image' && !selectMode" class="mdi mdi-camera-burst" :title="$gettext('Stack')" />
+                    <i v-else class="mdi mdi-magnify-plus-outline" :title="$gettext('View')" />
+                  </button>
+
+                  <div class="preview-details">
+                    <div v-if="!isSharedView && hidePrivate && m.Private" class="info-icon"><i class="mdi mdi-lock" /></div>
+                    <div v-if="m.Type === 'video'" :title="$gettext('Video')" class="info-text">
+                      {{ m.getDurationInfo() }}
+                    </div>
+                  </div>
+
+                  <button
+                    class="input-select"
+                    @mousedown.stop="input.mouseDown($event, index)"
+                    @touchstart.stop="input.touchStart($event, index)"
+                    @touchend.stop="onSelect($event, index)"
+                    @touchmove.stop.prevent
+                    @click.stop.prevent="onSelect($event, index)"
+                  >
+                    <i class="mdi mdi-check-circle select-on" />
+                    <i class="mdi mdi-circle-outline select-off" />
+                  </button>
+
+                  <button
+                    v-if="!isSharedView"
+                    class="input-favorite"
+                    @touchstart.stop="input.touchStart($event, index)"
+                    @touchend.stop="toggleLike($event, index)"
+                    @touchmove.stop
+                    @click.stop.prevent="toggleLike($event, index)"
+                  >
+                    <i v-if="m.Favorite" class="mdi mdi-star text-favorite favorite-on" />
+                    <i v-else class="mdi mdi-star-outline favorite-off" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script>
+import * as options from "options/options";
+import { Input, InputInvalid, ClickShort, ClickLong } from "common/input";
+import { virtualizationTools } from "common/virtualization-tools";
+import IconLivePhoto from "component/icon/live-photo.vue";
+import { buildTimelineSections } from "component/photo/view/timeline";
+
+export default {
+  name: "PPhotoViewTimeline",
+  components: {
+    IconLivePhoto,
+  },
+  props: {
+    photos: {
+      type: Array,
+      default: () => [],
+    },
+    openPhoto: {
+      type: Function,
+      default: () => {},
+    },
+    editPhoto: {
+      type: Function,
+      default: () => {},
+    },
+    album: {
+      type: Object,
+      default: () => {},
+    },
+    filter: {
+      type: Object,
+      default: () => {},
+    },
+    context: {
+      type: String,
+      default: "",
+    },
+    selectMode: Boolean,
+    isSharedView: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    const input = new Input();
+    const trace = this.$config.get("trace");
+    const settings = this.$config.getSettings();
+    const showTitles = settings.search?.showTitles;
+
+    return {
+      input,
+      trace,
+      showTitles,
+      hidePrivate: settings.features?.private,
+      firstVisibleElementIndex: 0,
+      lastVisibleElementIndex: 0,
+      visibleElementIndices: new Set(),
+    };
+  },
+  computed: {
+    sections() {
+      return buildTimelineSections(this.photos, options.Months(), this.$gettext);
+    },
+  },
+  watch: {
+    photos: {
+      handler() {
+        this.$nextTick(() => {
+          this.observeItems();
+        });
+      },
+      immediate: true,
+    },
+  },
+  beforeCreate() {
+    this.intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        this.visibilitiesChanged(entries);
+      },
+      {
+        rootMargin: "50% 0px",
+      }
+    );
+  },
+  beforeUnmount() {
+    this.intersectionObserver.disconnect();
+  },
+  methods: {
+    observeItems() {
+      if (this.$refs.items === undefined) {
+        return;
+      }
+
+      for (let i = 0; i < this.$refs.items.length; i += 5) {
+        this.intersectionObserver.observe(this.$refs.items[i]);
+      }
+    },
+    elementIndexFromIntersectionObserverEntry(entry) {
+      return parseInt(entry.target.getAttribute("data-index"), 10);
+    },
+    visibilitiesChanged(entries) {
+      const [smallestIndex, largestIndex] = virtualizationTools.updateVisibleElementIndices(
+        this.visibleElementIndices,
+        entries,
+        this.elementIndexFromIntersectionObserverEntry
+      );
+
+      if (smallestIndex === undefined || largestIndex === undefined) {
+        return;
+      }
+
+      this.firstVisibleElementIndex = smallestIndex - 4;
+      this.lastVisibleElementIndex = largestIndex + 4;
+    },
+    livePlayer(photo) {
+      return document.querySelector("#live-player-" + photo.ID);
+    },
+    playLive(photo) {
+      const player = this.livePlayer(photo);
+      if (player) {
+        try {
+          const playPromise = player.play();
+          if (playPromise !== undefined) {
+            playPromise.catch((err) => {
+              if (this.trace && err && err.message) {
+                // Ignore this error, or uncomment the following line to log it.
+                // console.debug(err.message);
+              }
+            });
+          }
+        } catch {
+          // Ignore.
+        }
+      }
+    },
+    pauseLive(photo) {
+      const player = this.livePlayer(photo);
+      if (player) {
+        try {
+          if (!player.paused) {
+            player.pause();
+          }
+        } catch (e) {
+          if (this.trace) {
+            console.log(e);
+          }
+        }
+      }
+    },
+    toggleLike(ev, index) {
+      const inputType = this.input.eval(ev, index);
+
+      if (inputType !== ClickShort) {
+        return;
+      }
+
+      const photo = this.photos[index];
+
+      if (!photo) {
+        return;
+      }
+
+      photo.toggleLike();
+    },
+    onSelect(ev, index) {
+      const inputType = this.input.eval(ev, index);
+
+      if (inputType !== ClickShort) {
+        return;
+      }
+
+      if (ev.shiftKey) {
+        this.selectRange(index);
+      } else {
+        this.toggle(this.photos[index]);
+      }
+    },
+    toggle(photo) {
+      this.$clipboard.toggle(photo);
+      this.$forceUpdate();
+    },
+    onOpen(ev, index, showMerged) {
+      const inputType = this.input.eval(ev, index);
+
+      if (inputType !== ClickShort) {
+        return;
+      }
+
+      this.openPhoto(index, showMerged);
+    },
+    onClick(ev, index) {
+      const inputType = this.input.eval(ev, index);
+      const longClick = inputType === ClickLong;
+
+      if (inputType === InputInvalid) {
+        return;
+      }
+
+      if (longClick || this.selectMode) {
+        if (longClick || ev.shiftKey) {
+          this.selectRange(index);
+        } else {
+          this.toggle(this.photos[index]);
+        }
+      } else {
+        this.openPhoto(index);
+      }
+    },
+    onContextMenu(ev, index) {
+      if (this.$isMobile) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this.selectRange(index);
+      }
+    },
+    selectRange(index) {
+      this.$clipboard.addRange(index, this.photos);
+      this.$forceUpdate();
+    },
+  },
+};
+</script>

--- a/frontend/src/css/views.css
+++ b/frontend/src/css/views.css
@@ -18,7 +18,10 @@
 .cards-view .v-card,
 .mosaic-view,
 .mosaic-view a,
-.mosaic-view .v-card {
+.mosaic-view .v-card,
+.timeline-view,
+.timeline-view a,
+.timeline-view button {
     user-select: none !important;
 }
 
@@ -226,6 +229,66 @@
     aspect-ratio: 1;
     contain: size layout paint style;
     transition: none;
+}
+
+.timeline-view {
+    width: 100%;
+    padding: 8px 10px 28px;
+}
+
+.timeline-view.mosaic-view > .timeline-section {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+.timeline-section__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    min-height: 44px;
+    padding: 14px 6px 8px;
+    color: rgb(var(--v-theme-on-surface));
+}
+
+.timeline-section__header h2 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 500;
+    line-height: 1.4;
+}
+
+.timeline-section__header span,
+.timeline-day__label {
+    color: rgb(var(--v-theme-on-surface-variant));
+    font-size: 0.875rem;
+}
+
+.timeline-day {
+    display: grid;
+    grid-template-columns: minmax(58px, 7vw) minmax(0, 1fr);
+    align-items: start;
+}
+
+.timeline-day__label {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding: 9px 6px 0;
+    font-weight: 500;
+    text-align: end;
+}
+
+.timeline-day__photos {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+.timeline-day__photos > div {
+    margin: 0;
+    padding: 1px;
 }
 
 .search-results .result,
@@ -921,6 +984,27 @@
 
 body.mobile .face-results.cards-view {
     padding-bottom: 144px;
+}
+
+@media (max-width: 600px) {
+    .timeline-view {
+        padding: 4px 4px 96px;
+    }
+
+    .timeline-section__header {
+        min-height: 38px;
+        padding: 12px 4px 6px;
+    }
+
+    .timeline-day {
+        display: block;
+    }
+
+    .timeline-day__label {
+        position: static;
+        padding: 8px 4px 4px;
+        text-align: start;
+    }
 }
 
 .face-results .is-face.is-hidden,

--- a/frontend/src/page/photos.vue
+++ b/frontend/src/page/photos.vue
@@ -33,6 +33,16 @@
         :open-photo="openPhoto"
         :is-shared-view="isShared"
       ></p-photo-view-mosaic>
+      <p-photo-view-timeline
+        v-else-if="settings.view === 'timeline'"
+        :context="context"
+        :photos="results"
+        :select-mode="selectMode"
+        :filter="filter"
+        :edit-photo="editPhoto"
+        :open-photo="openPhoto"
+        :is-shared-view="isShared"
+      ></p-photo-view-timeline>
       <p-photo-view-list
         v-else-if="settings.view === 'list'"
         :context="context"
@@ -70,6 +80,7 @@ import PPhotoToolbar from "component/photo/toolbar.vue";
 import PPhotoClipboard from "component/photo/clipboard.vue";
 import PPhotoViewCards from "component/photo/view/cards.vue";
 import PPhotoViewMosaic from "component/photo/view/mosaic.vue";
+import PPhotoViewTimeline from "component/photo/view/timeline.vue";
 import PPhotoViewList from "component/photo/view/list.vue";
 import PLoading from "component/loading.vue";
 import PScroll from "component/scroll.vue";
@@ -84,6 +95,7 @@ export default {
     PPhotoClipboard,
     PPhotoViewCards,
     PPhotoViewMosaic,
+    PPhotoViewTimeline,
     PPhotoViewList,
     PLoading,
     PScroll,
@@ -116,7 +128,12 @@ export default {
     const label = query["label"] ? query["label"] : "";
     const latlng = query["latlng"] ? query["latlng"] : "";
     const view = this.getViewType();
-    const order = this.sortOrder();
+    let order = this.sortOrder();
+
+    if (view === "timeline" && order !== "newest" && order !== "oldest") {
+      order = "newest";
+    }
+
     const filter = {
       country: country,
       camera: camera,
@@ -217,10 +234,12 @@ export default {
       this.filter.color = query["color"] ? query["color"] : "";
       this.filter.label = query["label"] ? query["label"] : "";
       this.filter.latlng = query["latlng"] ? query["latlng"] : "";
-      this.filter.order = this.sortOrder();
-      this.filter.reverse = this.sortReverse();
-
       this.settings.view = this.getViewType();
+      this.filter.order = this.sortOrder();
+      if (this.settings.view === "timeline" && this.filter.order !== "newest" && this.filter.order !== "oldest") {
+        this.filter.order = "newest";
+      }
+      this.filter.reverse = this.sortReverse();
 
       /**
        * Even if the filter is unchanged, if the route is changed (for example
@@ -326,11 +345,12 @@ export default {
 
       let queryParam = this.$route.query["view"] ? this.$route.query["view"] : "";
       let storedType = appStorage.getItem("photos.view");
+      const supportedTypes = ["cards", "list", "mosaic", "timeline"];
 
-      if (queryParam) {
+      if (queryParam && supportedTypes.includes(queryParam)) {
         appStorage.setItem("photos.view", queryParam);
         return queryParam;
-      } else if (storedType) {
+      } else if (storedType && supportedTypes.includes(storedType)) {
         return storedType;
       } else if (window.innerWidth < 960) {
         return "mosaic";

--- a/frontend/tests/vitest/component/photo/timeline.test.js
+++ b/frontend/tests/vitest/component/photo/timeline.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { shallowMount, config as VTUConfig } from "@vue/test-utils";
+
+import PPhotoViewTimeline from "component/photo/view/timeline.vue";
+import { buildTimelineSections, photoLocalDateParts } from "component/photo/view/timeline";
+import "../../fixtures";
+
+function photo(values) {
+  return {
+    ID: values.ID,
+    UID: values.UID || `uid-${values.ID}`,
+    Type: values.Type || "image",
+    TakenAt: values.TakenAt || "",
+    TakenAtLocal: values.TakenAtLocal || "",
+    Year: values.Year || -1,
+    Month: values.Month || -1,
+    Day: values.Day || -1,
+    Private: false,
+    Favorite: false,
+    Title: values.Title || "",
+    getOriginalName: vi.fn(() => values.Title || `photo-${values.ID}.jpg`),
+    thumbnailUrl: vi.fn(() => `/thumb-${values.ID}.jpg`),
+    classes: vi.fn(() => ["is-photo", "type-image"]),
+    isStack: vi.fn(() => false),
+    videoContentType: vi.fn(() => "video/mp4"),
+    videoUrl: vi.fn(() => `/video-${values.ID}.mp4`),
+    getDurationInfo: vi.fn(() => ""),
+    toggleLike: vi.fn(),
+  };
+}
+
+function mountTimeline(props = {}) {
+  const configMock = {
+    ...VTUConfig.global.mocks.$config,
+    get: vi.fn(() => false),
+    getSettings: vi.fn(() => ({
+      features: { private: true },
+      search: { showTitles: true, showCaptions: false },
+    })),
+  };
+
+  return shallowMount(PPhotoViewTimeline, {
+    props: {
+      photos: [],
+      filter: { order: "newest" },
+      selectMode: false,
+      isSharedView: false,
+      openPhoto: vi.fn(),
+      editPhoto: vi.fn(),
+      ...props,
+    },
+    global: {
+      mocks: {
+        $config: configMock,
+        $clipboard: { toggle: vi.fn(), addRange: vi.fn() },
+        $isMobile: false,
+      },
+      stubs: {
+        IconLivePhoto: true,
+      },
+    },
+  });
+}
+
+describe("component/photo/view/timeline", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = class IntersectionObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  it("uses TakenAtLocal for grouping without timezone conversion", () => {
+    const parts = photoLocalDateParts({
+      TakenAt: "2024-07-01T01:00:00Z",
+      TakenAtLocal: "2024-06-30T23:00:00",
+      Year: 2024,
+      Month: 7,
+      Day: 1,
+    });
+
+    expect(parts).toEqual({
+      known: true,
+      year: 2024,
+      month: 6,
+      day: 30,
+    });
+  });
+
+  it("groups photos by local month and day while preserving result indexes", () => {
+    const photos = [
+      photo({ ID: 1, TakenAtLocal: "2024-06-30T23:00:00" }),
+      photo({ ID: 2, TakenAtLocal: "2024-06-30T09:30:00" }),
+      photo({ ID: 3, TakenAtLocal: "2024-05-03T12:00:00" }),
+      photo({ ID: 4 }),
+    ];
+    const sections = buildTimelineSections(
+      photos,
+      [
+        { value: 5, text: "May" },
+        { value: 6, text: "June" },
+      ],
+      (s) => s
+    );
+
+    expect(sections.map((section) => section.key)).toEqual(["2024-06", "2024-05", "unknown"]);
+    expect(sections[0].title).toBe("June 2024");
+    expect(sections[0].countLabel).toBe("2 pictures");
+    expect(sections[0].days[0].title).toBe("30");
+    expect(sections[0].days[0].entries.map((entry) => entry.index)).toEqual([0, 1]);
+    expect(sections[2].title).toBe("Unknown date");
+    expect(sections[2].days[0].entries[0].index).toBe(3);
+  });
+
+  it("renders a separate scrollable timeline view", () => {
+    const wrapper = mountTimeline({
+      photos: [photo({ ID: 1, TakenAtLocal: "2024-06-30T23:00:00" }), photo({ ID: 2, TakenAtLocal: "2024-05-03T12:00:00" })],
+    });
+
+    expect(wrapper.find(".timeline-view").exists()).toBe(true);
+    expect(wrapper.findAll(".timeline-section")).toHaveLength(2);
+    expect(wrapper.find(".timeline-section__header h2").text()).toBe("June 2024");
+    expect(wrapper.find(".timeline-day__label").text()).toBe("30");
+  });
+
+  it("keeps the original result index when opening a photo", () => {
+    const openPhoto = vi.fn();
+    const wrapper = mountTimeline({
+      openPhoto,
+      photos: [
+        photo({ ID: 1, TakenAtLocal: "2024-06-30T23:00:00" }),
+        photo({ ID: 2, TakenAtLocal: "2024-05-03T12:00:00" }),
+        photo({ ID: 3, TakenAtLocal: "2024-05-02T12:00:00" }),
+      ],
+    });
+
+    wrapper.vm.input.mouseDown({ timeStamp: 100 }, 2);
+    wrapper.vm.onClick({ timeStamp: 200, shiftKey: false }, 2);
+
+    expect(openPhoto).toHaveBeenCalledWith(2);
+  });
+});

--- a/frontend/tests/vitest/component/photo/toolbar.test.js
+++ b/frontend/tests/vitest/component/photo/toolbar.test.js
@@ -207,6 +207,15 @@ describe("component/photo/toolbar", () => {
   });
 
   describe("view handling", () => {
+    it("includes timeline in the view options", () => {
+      const { wrapper } = mountToolbar({
+        searchOverrides: { listView: false },
+      });
+
+      const values = wrapper.vm.viewOptions.map((o) => o.value);
+      expect(values).toEqual(["mosaic", "cards", "timeline"]);
+    });
+
     it("setView keeps list when listView search setting is enabled", () => {
       const refresh = vi.fn();
       const { wrapper } = mountToolbar({
@@ -234,9 +243,42 @@ describe("component/photo/toolbar", () => {
       expect(refresh).toHaveBeenCalledWith({ view: "mosaic" });
       expect(wrapper.vm.expanded).toBe(false);
     });
+
+    it("setView resets non-date sort order when switching to timeline", () => {
+      const refresh = vi.fn();
+      const updateFilter = vi.fn();
+      const { wrapper } = mountToolbar({
+        refresh,
+        updateFilter,
+        filter: {
+          q: "",
+          country: "",
+          camera: 0,
+          year: 0,
+          month: 0,
+          color: "",
+          label: "",
+          order: "relevance",
+          latlng: null,
+        },
+      });
+
+      wrapper.vm.expanded = true;
+      wrapper.vm.setView("timeline");
+
+      expect(updateFilter).toHaveBeenCalledWith({ order: "newest" });
+      expect(refresh).toHaveBeenCalledWith({ view: "timeline" });
+      expect(wrapper.vm.expanded).toBe(false);
+    });
   });
 
   describe("sortOptions", () => {
+    it("limits timeline sorting to chronological order", () => {
+      const { wrapper } = mountToolbar({ settings: { view: "timeline" } });
+
+      expect(wrapper.vm.sortOptions.map((o) => o.value)).toEqual(["newest", "oldest"]);
+    });
+
     it("provides archive-specific sort options for archive context", () => {
       const { wrapper } = mountToolbar({ context: contexts.Archive });
 
@@ -342,5 +384,4 @@ describe("component/photo/toolbar", () => {
     });
   });
 });
-
 


### PR DESCRIPTION
### Summary

Adds a separate Timeline view for the Photos page. It groups the existing paged photo search results by local taken month and day, reuses the mosaic thumbnail interactions, and keeps lightbox/select actions tied to the original result index.

Timeline mode is kept to newest/oldest sorting so the loaded result stream remains chronological. Photos without a usable local taken date are shown in an Unknown date section.

### Notes

- Uses `TakenAtLocal`/local date fields for grouping; no browser timezone conversion is applied.
- Adds the Timeline option to the toolbar toggle and View select.
- Shares the current search/filter/pagination behavior instead of adding a new API contract.

### Validation

- `npm run test -- tests/vitest/component/photo/timeline.test.js tests/vitest/component/photo/toolbar.test.js`
- `npm run lint`
- `npm run build`
- `git diff --check`

IssueHunt payout: linked GitHub account `@jamilahmadzai`; PayPal withdrawal email `jamilurrehman722@gmail.com`.

Closes #152