### PR TITLE
Build: Add notf tag to build without TensorFlow dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,8 @@ build-js:
 	(cd frontend &&	env BUILD_ENV=production NODE_ENV=production npm run build)
 	(cd frontend && node scripts/precompress.js)
 build-go: build-develop
+build-notf:
+	go build -tags notf -o $(BINARY_NAME) ./cmd/photoprism
 build-develop:
 	rm -f $(BINARY_NAME)
 	scripts/build.sh develop $(BINARY_NAME)

--- a/internal/ai/classify/model.go
+++ b/internal/ai/classify/model.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package classify
 
 import (

--- a/internal/ai/classify/model_external_test.go
+++ b/internal/ai/classify/model_external_test.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package classify
 
 import (

--- a/internal/ai/classify/model_notf.go
+++ b/internal/ai/classify/model_notf.go
@@ -1,0 +1,47 @@
+//go:build notf
+
+package classify
+
+import (
+	"github.com/photoprism/photoprism/internal/ai/tensorflow"
+)
+
+// Model is a stub compiled when TensorFlow support is disabled at build time.
+type Model struct {
+	disabled bool
+}
+
+// NewModel returns a disabled stub classification model.
+func NewModel(modelsPath, name, defaultLabelsPath string, meta *tensorflow.ModelInfo, disabled bool) *Model {
+	return &Model{disabled: true}
+}
+
+// NewNasnet returns a disabled stub NASNet classification model.
+func NewNasnet(modelsPath string, disabled bool) *Model {
+	return &Model{disabled: true}
+}
+
+// Init is a no-op in notf builds.
+func (m *Model) Init() error {
+	return nil
+}
+
+// File returns empty labels in notf builds.
+func (m *Model) File(fileName string, confidenceThreshold int) (Labels, error) {
+	return nil, nil
+}
+
+// Url returns empty labels in notf builds.
+func (m *Model) Url(imgUrl string, confidenceThreshold int) (Labels, error) {
+	return nil, nil
+}
+
+// Run returns empty labels in notf builds.
+func (m *Model) Run(img []byte, confidenceThreshold int) (Labels, error) {
+	return nil, nil
+}
+
+// ModelLoaded always returns false in notf builds.
+func (m *Model) ModelLoaded() bool {
+	return false
+}

--- a/internal/ai/classify/model_test.go
+++ b/internal/ai/classify/model_test.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package classify
 
 import (

--- a/internal/ai/face/model.go
+++ b/internal/ai/face/model.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package face
 
 import (

--- a/internal/ai/face/model_notf.go
+++ b/internal/ai/face/model_notf.go
@@ -1,0 +1,42 @@
+//go:build notf
+
+package face
+
+import (
+	"image"
+
+	"github.com/photoprism/photoprism/internal/ai/tensorflow"
+)
+
+// Model is a stub compiled when TensorFlow support is disabled at build time.
+// Face detection via the ONNX engine still works; only Facenet embeddings
+// (face recognition/clustering) are unavailable.
+type Model struct {
+	disabled bool
+}
+
+// NewModel returns a disabled stub Facenet model.
+func NewModel(modelPath, cachePath string, resolution int, meta *tensorflow.ModelInfo, disabled bool) *Model {
+	return &Model{disabled: true}
+}
+
+// Init is a no-op in notf builds.
+func (m *Model) Init() error {
+	return nil
+}
+
+// ModelLoaded always returns false in notf builds.
+func (m *Model) ModelLoaded() bool {
+	return false
+}
+
+// Detect runs face detection using the active ONNX engine and returns faces
+// without embeddings (Facenet is not available in notf builds).
+func (m *Model) Detect(fileName string, minSize int, cacheCrop bool, expected int) (Faces, error) {
+	return Detect(fileName, minSize)
+}
+
+// Run returns nil embeddings in notf builds.
+func (m *Model) Run(img image.Image) Embeddings {
+	return nil
+}

--- a/internal/ai/nsfw/model.go
+++ b/internal/ai/nsfw/model.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package nsfw
 
 import (

--- a/internal/ai/nsfw/model_notf.go
+++ b/internal/ai/nsfw/model_notf.go
@@ -1,0 +1,37 @@
+//go:build notf
+
+package nsfw
+
+import (
+	"github.com/photoprism/photoprism/internal/ai/tensorflow"
+)
+
+// Model is a stub compiled when TensorFlow support is disabled at build time.
+type Model struct {
+	disabled bool
+}
+
+// NewModel returns a disabled stub NSFW model.
+func NewModel(modelPath string, meta *tensorflow.ModelInfo, disabled bool) *Model {
+	return &Model{disabled: true}
+}
+
+// Init is a no-op in notf builds.
+func (m *Model) Init() error {
+	return nil
+}
+
+// File returns a zero Result in notf builds.
+func (m *Model) File(fileName string) (Result, error) {
+	return Result{}, nil
+}
+
+// Url returns a zero Result in notf builds.
+func (m *Model) Url(imgUrl string) (Result, error) {
+	return Result{}, nil
+}
+
+// Run returns a zero Result in notf builds.
+func (m *Model) Run(img []byte) (Result, error) {
+	return Result{}, nil
+}

--- a/internal/ai/tensorflow/image.go
+++ b/internal/ai/tensorflow/image.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package tensorflow
 
 import (

--- a/internal/ai/tensorflow/image_test.go
+++ b/internal/ai/tensorflow/image_test.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package tensorflow
 
 import (

--- a/internal/ai/tensorflow/info_test.go
+++ b/internal/ai/tensorflow/info_test.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package tensorflow
 
 import (

--- a/internal/ai/tensorflow/model.go
+++ b/internal/ai/tensorflow/model.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package tensorflow
 
 import (

--- a/internal/ai/tensorflow/model_test.go
+++ b/internal/ai/tensorflow/model_test.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package tensorflow
 
 import (

--- a/internal/ai/tensorflow/op.go
+++ b/internal/ai/tensorflow/op.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package tensorflow
 
 import (

--- a/internal/ai/tensorflow/tensor_builder.go
+++ b/internal/ai/tensorflow/tensor_builder.go
@@ -1,3 +1,5 @@
+//go:build !notf
+
 package tensorflow
 
 import (


### PR DESCRIPTION
### Description

Adds a "notf" Go build tag to optionally compile PhotoPrism without libtensorflow.so runtime requirement for platforms like FreeBSD (which currently lacks it).

These changes implement/fix/improve...

#### Related Issues

- #5591 