### PR TITLE
Add Memories route for photos from today in previous years

### DIFF
--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -48,6 +48,18 @@ const c = window.__CONFIG__;
 const siteTitle = c.siteTitle ? c.siteTitle : c.name;
 const loginRoute = "login";
 
+const memoriesRouteProps = () => {
+  const today = new Date();
+
+  return {
+    staticFilter: {
+      quality: "3",
+      month: `${today.getMonth() + 1}`,
+      day: `${today.getDate()}`,
+    },
+  };
+};
+
 export default [
   {
     name: "home",
@@ -245,6 +257,13 @@ export default [
     component: Albums,
     meta: { title: $gettext("Calendar"), requiresAuth: true },
     props: { view: "month", defaultOrder: "newest", staticFilter: { type: "month" } },
+  },
+  {
+    name: "memories",
+    path: "/memories",
+    component: Photos,
+    meta: { title: $gettext("Memories"), requiresAuth: true },
+    props: memoriesRouteProps,
   },
   {
     name: "month",

--- a/frontend/src/component/navigation.vue
+++ b/frontend/src/component/navigation.vue
@@ -119,6 +119,19 @@
                   </v-list-item-title>
                 </v-list-item>
 
+                <v-list-item
+                  v-show="$config.feature('calendar')"
+                  :to="{ name: 'memories' }"
+                  :exact="true"
+                  variant="text"
+                  class="nav-memories"
+                  @click.stop=""
+                >
+                  <v-list-item-title :class="`nav-menu-item menu-item`">
+                    {{ $gettext(`Memories`) }}
+                  </v-list-item-title>
+                </v-list-item>
+
                 <v-list-item :to="{ name: 'photos', query: { q: 'stacks' } }" :exact="true" variant="text" class="nav-stacks" @click.stop="">
                   <v-list-item-title :class="`nav-menu-item menu-item`">
                     {{ $gettext(`Stacks`) }}

--- a/frontend/tests/vitest/app/routes-memories.test.js
+++ b/frontend/tests/vitest/app/routes-memories.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "../fixtures";
+import routes from "app/routes";
+
+const memoriesRoute = routes.find((r) => r.name === "memories");
+
+describe("app/routes /memories", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("filters photos by the current month and day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 25, 12, 0, 0));
+
+    expect(memoriesRoute.path).toBe("/memories");
+    expect(memoriesRoute.props()).toEqual({
+      staticFilter: {
+        quality: "3",
+        month: "5",
+        day: "25",
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Description

Adds a small Memories entry point for issue #720 by reusing the existing photo search filters.

- adds a /memories route that filters by today's month and day
- exposes Memories in the Search navigation menu when Calendar is enabled
- adds a focused route test for the generated month/day filter

This keeps the first implementation intentionally small: it uses existing month/day search behavior instead of introducing a new album type or background indexer.

Refs #720

### Verification

- git diff --check
- Added frontend/tests/vitest/app/routes-memories.test.js for the route filter contract

I did not run the full frontend test suite in this environment.