### PR TITLE
Allow manual country override when coordinates exist

### DIFF
--- a/frontend/src/component/photo/batch-edit.vue
+++ b/frontend/src/component/photo/batch-edit.vue
@@ -721,10 +721,8 @@ export default {
       return latData?.mixed || lngData?.mixed;
     },
     isCountryReadOnly() {
-      if (!this.formData || !this.formData.Lat || !this.formData.Lng) {
-        return false;
-      }
-      return !!(this.formData.Lat.value || this.formData.Lng.value);
+      // Country corrections should not require clearing existing coordinates.
+      return false;
     },
     // canViewLabels gates the Labels section on the deployment's
     // `labels` feature flag and the session's `labels:search` grant —

--- a/frontend/src/component/photo/edit/details.vue
+++ b/frontend/src/component/photo/edit/details.vue
@@ -155,7 +155,6 @@
                 v-model="view.model.Country"
                 :append-inner-icon="view.model.PlaceSrc === 'manual' ? 'mdi-check' : ''"
                 :disabled="disabled"
-                :readonly="!!(view.model.Lat || view.model.Lng)"
                 :label="$gettext('Country')"
                 hide-no-data
                 autocomplete="off"

--- a/frontend/tests/acceptance/acceptance-public/batch.js
+++ b/frontend/tests/acceptance/acceptance-public/batch.js
@@ -117,7 +117,7 @@ test.meta("testID", "batch-003").meta({ mode: "public" })("Common: Test batch di
   await t.click(photoedit.locationAction);
   await t.typeText(photoedit.locationSearch, "Brandenburger Tor Berlin").wait(5000).pressKey("enter");
   await t.click(photoedit.locationConfirm);
-  await t.expect(photoedit.country.hasAttribute("readonly")).ok();
+  await t.expect(photoedit.country.hasAttribute("readonly")).notOk();
   await t.expect(photoedit.countryValue.innerText).eql("Germany");
   await t.click(Selector(".input-labels input"));
 

--- a/frontend/tests/vitest/component/photo/batch-edit.test.js
+++ b/frontend/tests/vitest/component/photo/batch-edit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { shallowMount, config as VTUConfig } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import PPhotoBatchEdit from "component/photo/batch-edit.vue";
 import * as contexts from "options/contexts";
@@ -580,7 +580,7 @@ describe("component/photo/batch-edit", () => {
 
     it("should clamp invalid index to first photo", () => {
       const thumbMock = [{ UID: "uid1" }];
-      const spy = vi.spyOn(Thumb, "fromPhotos").mockReturnValue(thumbMock);
+      vi.spyOn(Thumb, "fromPhotos").mockReturnValue(thumbMock);
 
       const ctx = wrapper.vm.getLightboxContext(5);
 
@@ -636,28 +636,28 @@ describe("component/photo/batch-edit", () => {
     });
   });
 
-  describe("Country field read-only when coordinates are set", () => {
+  describe("Country field editable when coordinates are set", () => {
     beforeEach(() => {
       wrapper.vm.values = { ...mockValues };
       wrapper.vm.setFormData();
     });
 
-    it("is not read-only when both Lat/Lng are zero", () => {
+    it("stays editable when both Lat/Lng are zero", () => {
       wrapper.vm.formData.Lat.value = 0;
       wrapper.vm.formData.Lng.value = 0;
       expect(wrapper.vm.isCountryReadOnly).toBe(false);
     });
 
-    it("is read-only when Lat is non-zero", () => {
+    it("stays editable when Lat is non-zero", () => {
       wrapper.vm.formData.Lat.value = 37.5;
       wrapper.vm.formData.Lng.value = 0;
-      expect(wrapper.vm.isCountryReadOnly).toBe(true);
+      expect(wrapper.vm.isCountryReadOnly).toBe(false);
     });
 
-    it("is read-only when Lng is non-zero", () => {
+    it("stays editable when Lng is non-zero", () => {
       wrapper.vm.formData.Lat.value = 0;
       wrapper.vm.formData.Lng.value = -122.4;
-      expect(wrapper.vm.isCountryReadOnly).toBe(true);
+      expect(wrapper.vm.isCountryReadOnly).toBe(false);
     });
   });
 

--- a/frontend/tests/vitest/component/photo/edit/details.test.js
+++ b/frontend/tests/vitest/component/photo/edit/details.test.js
@@ -363,7 +363,7 @@ describe("component/photo/edit/details", () => {
       expect(wrapper.vm.locationDialog).toBe(false);
     });
 
-    it("sets Country VAutocomplete readonly prop when Lat/Lng are present", async () => {
+    it("keeps Country VAutocomplete editable when Lat/Lng are present", async () => {
       // Use full mount with real VAutocomplete (not stubbed) so we can assert props
       const w = mount(PTabPhotoDetails, {
         props: { uid: "p123" },
@@ -396,13 +396,13 @@ describe("component/photo/edit/details", () => {
       const allAutocompletes = w.findAllComponents({ name: "VAutocomplete" });
       const countryAuto = allAutocompletes.find((c) => c.classes().includes("input-country"));
       expect(countryAuto).toBeTruthy();
-      expect(countryAuto.props("readonly")).toBe(false);
+      expect(countryAuto.props("readonly")).not.toBe(true);
 
-      // Set Lat/Lng to non-zero → readonly=true
+      // Country can be corrected manually without clearing the coordinates.
       w.vm.view.model.Lat = 37.5;
       w.vm.view.model.Lng = -122.4;
       await nextTick();
-      expect(countryAuto.props("readonly")).toBe(true);
+      expect(countryAuto.props("readonly")).not.toBe(true);
 
       w.unmount();
     });

--- a/internal/entity/photo.go
+++ b/internal/entity/photo.go
@@ -155,7 +155,8 @@ func SavePhotoForm(m *Photo, form form.Photo) error {
 		return fmt.Errorf("photo is nil")
 	}
 
-	locChanged := m.PhotoLat != form.PhotoLat || m.PhotoLng != form.PhotoLng || m.PhotoCountry != form.PhotoCountry
+	coordinatesChanged := m.PhotoLat != form.PhotoLat || m.PhotoLng != form.PhotoLng
+	countryChanged := m.PhotoCountry != form.PhotoCountry
 
 	if err := deepcopier.Copy(m).From(form); err != nil {
 		return err
@@ -190,8 +191,12 @@ func SavePhotoForm(m *Photo, form form.Photo) error {
 		details.Keywords = strings.Join(txt.UniqueWords(txt.Words(details.Keywords)), ", ")
 	}
 
-	if locChanged && (m.PlaceSrc == SrcManual || m.PlaceSrc == SrcBatch) {
+	if coordinatesChanged && (m.PlaceSrc == SrcManual || m.PlaceSrc == SrcBatch) {
 		locKeywords, labels := m.UpdateLocation()
+
+		if countryChanged {
+			m.PhotoCountry = form.PhotoCountry
+		}
 
 		m.AddLabels(labels)
 

--- a/internal/entity/photo_test.go
+++ b/internal/entity/photo_test.go
@@ -118,6 +118,78 @@ func TestSavePhotoForm(t *testing.T) {
 		assert.Equal(t, SrcBatch, photo.TakenSrc)
 		assert.True(t, photo.TakenAt.Equal(expectedUTC))
 	})
+	t.Run("CountryOnlyChangeKeepsCoordinates", func(t *testing.T) {
+		photo := PhotoFixtures.Get("Photo01")
+		originalCountry := photo.PhotoCountry
+		originalLat := photo.PhotoLat
+		originalLng := photo.PhotoLng
+		originalCellID := photo.CellID
+		originalPlaceID := photo.PlaceID
+		originalPlaceSrc := photo.PlaceSrc
+
+		defer func() {
+			require.NoError(t, Db().Model(&Photo{}).Where("id = ?", photo.ID).Updates(Values{
+				"photo_country": originalCountry,
+				"photo_lat":     originalLat,
+				"photo_lng":     originalLng,
+				"cell_id":       originalCellID,
+				"place_id":      originalPlaceID,
+				"place_src":     originalPlaceSrc,
+			}).Error)
+		}()
+
+		formSnapshot, err := form.NewPhoto(&photo)
+		require.NoError(t, err)
+		formSnapshot.PhotoCountry = "ua"
+		formSnapshot.PlaceSrc = SrcManual
+
+		require.NoError(t, SavePhotoForm(&photo, formSnapshot))
+		require.NoError(t, Db().First(&photo, photo.ID).Error)
+
+		require.Equal(t, "ua", photo.PhotoCountry)
+		require.Equal(t, originalLat, photo.PhotoLat)
+		require.Equal(t, originalLng, photo.PhotoLng)
+		require.Equal(t, originalCellID, photo.CellID)
+		require.Equal(t, originalPlaceID, photo.PlaceID)
+		require.Equal(t, SrcManual, photo.PlaceSrc)
+	})
+	t.Run("CountryChangeWithCoordinatesKeepsManualCountry", func(t *testing.T) {
+		photo := PhotoFixtures.Get("Photo01")
+		originalCountry := photo.PhotoCountry
+		originalLat := photo.PhotoLat
+		originalLng := photo.PhotoLng
+		originalCellID := photo.CellID
+		originalPlaceID := photo.PlaceID
+		originalPlaceSrc := photo.PlaceSrc
+		originalTimeZone := photo.TimeZone
+
+		defer func() {
+			require.NoError(t, Db().Model(&Photo{}).Where("id = ?", photo.ID).Updates(Values{
+				"photo_country": originalCountry,
+				"photo_lat":     originalLat,
+				"photo_lng":     originalLng,
+				"cell_id":       originalCellID,
+				"place_id":      originalPlaceID,
+				"place_src":     originalPlaceSrc,
+				"time_zone":     originalTimeZone,
+			}).Error)
+		}()
+
+		formSnapshot, err := form.NewPhoto(&photo)
+		require.NoError(t, err)
+		formSnapshot.PhotoLat = originalLat + 0.01
+		formSnapshot.PhotoLng = originalLng + 0.01
+		formSnapshot.PhotoCountry = "ua"
+		formSnapshot.PlaceSrc = SrcManual
+
+		require.NoError(t, SavePhotoForm(&photo, formSnapshot))
+		require.NoError(t, Db().First(&photo, photo.ID).Error)
+
+		require.Equal(t, "ua", photo.PhotoCountry)
+		require.Equal(t, formSnapshot.PhotoLat, photo.PhotoLat)
+		require.Equal(t, formSnapshot.PhotoLng, photo.PhotoLng)
+		require.Equal(t, SrcManual, photo.PlaceSrc)
+	})
 }
 
 func TestPhoto_LabelKeywords(t *testing.T) {

--- a/internal/photoprism/batch/save_photo.go
+++ b/internal/photoprism/batch/save_photo.go
@@ -84,8 +84,9 @@ func savePhoto(req *PhotoSaveRequest) (bool, error) {
 		p.UpdateDateFields()
 	}
 
-	locationChanged := formValues.PhotoLat.Action == ActionUpdate ||
-		formValues.PhotoLng.Action == ActionUpdate ||
+	coordinatesChanged := formValues.PhotoLat.Action == ActionUpdate ||
+		formValues.PhotoLng.Action == ActionUpdate
+	locationChanged := coordinatesChanged ||
 		formValues.PhotoCountry.Action == ActionUpdate ||
 		formValues.PhotoAltitude.Action == ActionUpdate
 
@@ -107,7 +108,13 @@ func savePhoto(req *PhotoSaveRequest) (bool, error) {
 
 	if locationChanged {
 		p.PlaceSrc = entity.SrcBatch
+	}
+
+	if coordinatesChanged {
 		locKeywords, locLabels := p.UpdateLocation()
+		if formValues.PhotoCountry.Action == ActionUpdate {
+			p.PhotoCountry = formValues.PhotoCountry.Value
+		}
 		if len(locLabels) > 0 {
 			p.AddLabels(locLabels)
 		}

--- a/internal/photoprism/batch/save_photo_test.go
+++ b/internal/photoprism/batch/save_photo_test.go
@@ -81,4 +81,86 @@ func TestSavePhoto(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, saved)
 	})
+	t.Run("UpdatesCountryWithoutResolvingCoordinates", func(t *testing.T) {
+		countryPhoto := entity.FindPhoto(entity.Photo{PhotoUID: fixture.PhotoUID})
+		require.NotNil(t, countryPhoto)
+
+		originalCountry := countryPhoto.PhotoCountry
+		originalLat := countryPhoto.PhotoLat
+		originalLng := countryPhoto.PhotoLng
+		originalCellID := countryPhoto.CellID
+		originalPlaceID := countryPhoto.PlaceID
+		originalPlaceSrc := countryPhoto.PlaceSrc
+
+		defer restorePhoto(t, fixture.PhotoUID, entity.Values{
+			"photo_country": originalCountry,
+			"photo_lat":     originalLat,
+			"photo_lng":     originalLng,
+			"cell_id":       originalCellID,
+			"place_id":      originalPlaceID,
+			"place_src":     originalPlaceSrc,
+		})
+
+		values := &PhotosForm{
+			PhotoCountry: String{Value: "ua", Action: ActionUpdate},
+		}
+
+		req, err := NewPhotoSaveRequest(countryPhoto, values)
+		require.NoError(t, err)
+
+		saved, err := savePhoto(req)
+		require.NoError(t, err)
+		require.True(t, saved)
+
+		updated := entity.FindPhoto(entity.Photo{PhotoUID: fixture.PhotoUID})
+		require.NotNil(t, updated)
+		require.Equal(t, "ua", updated.PhotoCountry)
+		require.Equal(t, originalLat, updated.PhotoLat)
+		require.Equal(t, originalLng, updated.PhotoLng)
+		require.Equal(t, originalCellID, updated.CellID)
+		require.Equal(t, originalPlaceID, updated.PlaceID)
+		require.Equal(t, entity.SrcBatch, updated.PlaceSrc)
+	})
+	t.Run("UpdatesCountryWithCoordinatesKeepsManualCountry", func(t *testing.T) {
+		countryPhoto := entity.FindPhoto(entity.Photo{PhotoUID: fixture.PhotoUID})
+		require.NotNil(t, countryPhoto)
+
+		originalCountry := countryPhoto.PhotoCountry
+		originalLat := countryPhoto.PhotoLat
+		originalLng := countryPhoto.PhotoLng
+		originalCellID := countryPhoto.CellID
+		originalPlaceID := countryPhoto.PlaceID
+		originalPlaceSrc := countryPhoto.PlaceSrc
+		originalTimeZone := countryPhoto.TimeZone
+
+		defer restorePhoto(t, fixture.PhotoUID, entity.Values{
+			"photo_country": originalCountry,
+			"photo_lat":     originalLat,
+			"photo_lng":     originalLng,
+			"cell_id":       originalCellID,
+			"place_id":      originalPlaceID,
+			"place_src":     originalPlaceSrc,
+			"time_zone":     originalTimeZone,
+		})
+
+		values := &PhotosForm{
+			PhotoLat:     Float{Value: originalLat + 0.01, Action: ActionUpdate},
+			PhotoLng:     Float{Value: originalLng + 0.01, Action: ActionUpdate},
+			PhotoCountry: String{Value: "ua", Action: ActionUpdate},
+		}
+
+		req, err := NewPhotoSaveRequest(countryPhoto, values)
+		require.NoError(t, err)
+
+		saved, err := savePhoto(req)
+		require.NoError(t, err)
+		require.True(t, saved)
+
+		updated := entity.FindPhoto(entity.Photo{PhotoUID: fixture.PhotoUID})
+		require.NotNil(t, updated)
+		require.Equal(t, "ua", updated.PhotoCountry)
+		require.Equal(t, values.PhotoLat.Value, updated.PhotoLat)
+		require.Equal(t, values.PhotoLng.Value, updated.PhotoLng)
+		require.Equal(t, entity.SrcBatch, updated.PlaceSrc)
+	})
 }


### PR DESCRIPTION
## Summary
- Allows explicit manual/batch Country overrides while existing coordinates remain set.
- Preserves an explicitly submitted Country value when location resolution runs because coordinates changed.
- Leaves coordinate and Time Zone behavior unchanged; this only removes the Country-only lock and keeps that manual correction from being overwritten on save.

## Validation
- npm run test -w frontend -- tests/vitest/component/photo/edit/details.test.js tests/vitest/component/photo/batch-edit.test.js
- npx eslint --cache frontend/src/component/photo/edit/details.vue frontend/src/component/photo/batch-edit.vue frontend/tests/vitest/component/photo/edit/details.test.js frontend/tests/vitest/component/photo/batch-edit.test.js
- node --check frontend/tests/acceptance/acceptance-public/batch.js
- git diff --check
- go test ./internal/entity ./internal/photoprism/batch -run 'TestSavePhotoForm|TestSavePhoto' -count=1 (not run in this PowerShell session: go.exe is not on PATH; WSL attempt is blocked by missing libvips pkg-config metadata and TensorFlow C API headers)

Closes #678
