### PR TITLE
Library: Show import and index progress counts

### DIFF
--- a/frontend/src/page/library/import.vue
+++ b/frontend/src/page/library/import.vue
@@ -2,7 +2,12 @@
   <div class="p-tab p-tab-import">
     <v-form ref="form" class="p-form p-photo-import" validate-on="invalid-input" @submit.prevent="submit">
       <div class="form-header">
-        <span v-if="fileName" class="text-break">{{ $gettext(`Importing %{s}…`, { s: fileName }) }}</span>
+        <span v-if="fileName" class="text-break">
+          {{ $gettext(`Importing %{s}…`, { s: fileName }) }}
+          <span v-if="fileCount" class="text-nowrap opacity-80">{{
+            fileCount === 1 ? $gettext(`One file processed`) : $gettext(`%{n} files processed`, { n: fileCount })
+          }}</span>
+        </span>
         <span v-else-if="busy">{{ $gettext(`Importing files to originals…`) }}</span>
         <span v-else-if="completed">{{ $gettext(`Done.`) }}</span>
         <span v-else-if="$config.insufficientStorage()"
@@ -102,6 +107,7 @@ export default {
       completed: 0,
       subscriptionId: "",
       fileName: "",
+      fileCount: 0,
       eta: "",
       source: null,
       root: root,
@@ -181,6 +187,7 @@ export default {
       this.busy = true;
       this.completed = 0;
       this.fileName = "";
+      this.fileCount = 0;
 
       const ctx = this;
       $notify.blockUI("busy");
@@ -192,6 +199,7 @@ export default {
           ctx.busy = false;
           ctx.completed = 100;
           ctx.fileName = "";
+          ctx.fileCount = 0;
         })
         .catch(function (e) {
           $notify.unblockUI();
@@ -206,6 +214,7 @@ export default {
           ctx.busy = false;
           ctx.completed = 0;
           ctx.fileName = "";
+          ctx.fileCount = 0;
         });
     },
     handleEvent(ev, data) {
@@ -222,11 +231,13 @@ export default {
           this.busy = true;
           this.completed = 0;
           this.fileName = data.baseName;
+          this.fileCount += 1;
           break;
         case "completed":
           this.busy = false;
           this.completed = 100;
           this.fileName = "";
+          this.fileCount = 0;
           break;
         default:
           console.log(data);

--- a/frontend/src/page/library/index.vue
+++ b/frontend/src/page/library/index.vue
@@ -2,7 +2,12 @@
   <div class="p-tab p-tab-index">
     <v-form ref="form" class="p-form p-photo-index" validate-on="invalid-input" @submit.prevent="submit">
       <div class="form-header">
-        <span v-if="fileName" class="text-break">{{ action }} {{ fileName }}…</span>
+        <span v-if="fileName" class="text-break">
+          {{ action }} {{ fileName }}…
+          <span v-if="fileCount" class="text-nowrap opacity-80">{{
+            fileCount === 1 ? $gettext(`One file processed`) : $gettext(`%{n} files processed`, { n: fileCount })
+          }}</span>
+        </span>
         <span v-else-if="action">{{ action }}…</span>
         <span v-else-if="busy">{{ $gettext(`Indexing media and sidecar files…`) }}</span>
         <span v-else-if="completed">{{ $gettext(`Done.`) }}</span>
@@ -103,6 +108,7 @@ export default {
       subscriptionId: "",
       action: "",
       fileName: "",
+      fileCount: 0,
       eta: "",
       cleanup: false,
       source: null,
@@ -180,6 +186,7 @@ export default {
       this.busy = true;
       this.completed = 0;
       this.fileName = "";
+      this.fileCount = 0;
 
       const ctx = this;
       $notify.blockUI("busy");
@@ -199,6 +206,7 @@ export default {
           ctx.busy = false;
           ctx.completed = 100;
           ctx.fileName = "";
+          ctx.fileCount = 0;
         })
         .catch(function (e) {
           $notify.unblockUI();
@@ -213,6 +221,7 @@ export default {
           ctx.busy = false;
           ctx.completed = 0;
           ctx.fileName = "";
+          ctx.fileCount = 0;
         });
     },
     handleEvent(ev, data) {
@@ -236,6 +245,7 @@ export default {
           this.busy = true;
           this.completed = 0;
           this.fileName = data.fileName;
+          this.fileCount += 1;
           break;
         case "updating":
           if (data.step === "stacks") {
@@ -273,6 +283,7 @@ export default {
           this.busy = false;
           this.completed = 100;
           this.fileName = "";
+          this.fileCount = 0;
           break;
         default:
           console.log(data);

--- a/frontend/tests/vitest/page/library-progress.test.js
+++ b/frontend/tests/vitest/page/library-progress.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { nextTick } from "vue";
+import PTabImport from "page/library/import.vue";
+import PTabIndex from "page/library/index.vue";
+
+vi.mock("common/api", () => ({
+  default: {
+    delete: vi.fn(() => Promise.resolve({})),
+    post: vi.fn(() => Promise.resolve({})),
+    get: vi.fn(() => Promise.resolve({ data: {} })),
+  },
+}));
+
+vi.mock("common/notify", () => ({
+  default: {
+    blockUI: vi.fn(),
+    unblockUI: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function gettext(message, params = {}) {
+  return String(message).replace(/%\{(\w+)\}/g, (_, key) => (params[key] !== undefined ? String(params[key]) : ""));
+}
+
+function buildConfigMock() {
+  return {
+    loading: vi.fn(() => false),
+    load: vi.fn(() => Promise.resolve()),
+    feature: vi.fn(() => true),
+    insufficientStorage: vi.fn(() => false),
+    get: vi.fn(() => false),
+    getSettings: vi.fn(() => ({
+      disable: { settings: true },
+      import: { path: "/", move: false },
+      index: { path: "/", rescan: false },
+    })),
+    values: {
+      readonly: false,
+      disable: { settings: true },
+      count: { hidden: 0 },
+    },
+  };
+}
+
+function mountTab(component) {
+  return mount(component, {
+    global: {
+      mocks: {
+        $config: buildConfigMock(),
+        $event: {
+          subscribe: vi.fn(() => "progress-sub"),
+          unsubscribe: vi.fn(),
+          publish: vi.fn(),
+        },
+        $gettext: gettext,
+        $isRtl: false,
+        $session: { isAdmin: vi.fn(() => true) },
+        $util: { truncate: (value) => value },
+      },
+    },
+  });
+}
+
+describe("library import and index progress headers", () => {
+  it("shows how many import progress events have been received", async () => {
+    const wrapper = mountTab(PTabImport);
+    await flushPromises();
+
+    wrapper.vm.handleEvent("import.file", { baseName: "first.jpg" });
+    await nextTick();
+
+    expect(wrapper.text()).toContain("Importing first.jpg");
+    expect(wrapper.text()).toContain("One file processed");
+
+    wrapper.vm.handleEvent("import.file", { baseName: "second.jpg" });
+    await nextTick();
+
+    expect(wrapper.text()).toContain("Importing second.jpg");
+    expect(wrapper.text()).toContain("2 files processed");
+
+    wrapper.unmount();
+  });
+
+  it("shows how many index progress events have been received", async () => {
+    const wrapper = mountTab(PTabIndex);
+    await flushPromises();
+
+    wrapper.vm.handleEvent("index.indexing", { fileName: "first.jpg" });
+    await nextTick();
+
+    expect(wrapper.text()).toContain("Indexing first.jpg");
+    expect(wrapper.text()).toContain("One file processed");
+
+    wrapper.vm.handleEvent("index.indexing", { fileName: "second.jpg" });
+    await nextTick();
+
+    expect(wrapper.text()).toContain("Indexing second.jpg");
+    expect(wrapper.text()).toContain("2 files processed");
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
### Description

This adds a small processed-file count to the Library import and index progress views.

Related issue: #639

### Problem

The import and index tabs showed the current file name while work was running, but did not show any running count of how many file progress events had already been processed.

### Fix

- Track a local `fileCount` in the import and index pages.
- Reset the count when a run starts, finishes, or fails.
- Increment the count from the existing `import.file` and `index.indexing` progress events.
- Render `One file processed` / `%{n} files processed` next to the current file.
- Add Vitest coverage for the progress text in both views.

### Validation

- `cd frontend && npm run test -- tests/vitest/page/library-progress.test.js`
- `cd frontend && npm run test -- tests/vitest/page`
- `cd frontend && npx eslint --cache src/page/library/import.vue src/page/library/index.vue tests/vitest/page/library-progress.test.js`
- `git diff --check`

### Risk Notes

- This is a UI-side processed-event count only. It does not estimate total files, remaining files, ETA, or add a backend pre-scan.
- No backend, database, dependency, or CSS files are changed.
- Full `cd frontend && npm run lint` currently stops on unrelated existing Prettier formatting in `frontend/src/css/auth.css`, which this PR does not touch.
