### PR TITLE
Discover memories from this day in previous years

### DIFF
--- a/frontend/src/component/photo/toolbar.vue
+++ b/frontend/src/component/photo/toolbar.vue
@@ -212,6 +212,25 @@
                 >
                 </v-select>
               </v-col>
+              <v-col cols="12" sm="6" md="3" class="p-day-select">
+                <v-select
+                  :model-value="filter.day"
+                  :label="$gettext('Day')"
+                  :menu-props="{ maxHeight: 346 }"
+                  single-line
+                  variant="solo-filled"
+                  :density="density"
+                  :items="dayOptions()"
+                  item-title="text"
+                  item-value="value"
+                  @update:model-value="
+                    (v) => {
+                      onUpdate({ day: v });
+                    }
+                  "
+                >
+                </v-select>
+              </v-col>
               <!-- v-col cols="12" sm="6" md="3" class="p-lens-select">
                 <v-select @change="dropdownChange"
                           :label="labels.lens"
@@ -361,6 +380,7 @@ export default {
         colors: [{ Slug: "", Name: this.$gettext("All Colors") }],
         categories: [{ Slug: "", Name: this.$gettext("All Categories") }],
         months: [{ value: 0, text: this.$gettext("All Months") }],
+        days: [{ value: 0, text: this.$gettext("All Days") }],
         years: [{ value: 0, text: this.$gettext("All Years") }],
       },
       dialog: {
@@ -494,6 +514,9 @@ export default {
     },
     monthOptions() {
       return this.all.months.concat(options.Months());
+    },
+    dayOptions() {
+      return this.all.days.concat(options.Days());
     },
     yearOptions() {
       return this.all.years.concat(options.IndexedYears());

--- a/frontend/src/page/discover.vue
+++ b/frontend/src/page/discover.vue
@@ -27,7 +27,7 @@
         </v-tabs-window-item>
 
         <v-tabs-window-item>
-          <p-tab-discover-todo></p-tab-discover-todo>
+          <p-tab-discover-season></p-tab-discover-season>
         </v-tabs-window-item>
 
         <v-tabs-window-item>
@@ -40,12 +40,14 @@
 
 <script>
 import tabColors from "page/discover/colors.vue";
+import tabSeason from "page/discover/season.vue";
 import tabTodo from "page/discover/todo.vue";
 
 export default {
   name: "PPageDiscover",
   components: {
     "p-tab-discover-colors": tabColors,
+    "p-tab-discover-season": tabSeason,
     "p-tab-discover-todo": tabTodo,
   },
   props: {

--- a/frontend/src/page/discover/season.vue
+++ b/frontend/src/page/discover/season.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="p-tab p-tab-discover-season">
+    <div class="pa-2 text-center">
+      <v-row class="p-season" justify="center">
+        <v-col cols="12" sm="8" md="6" lg="4" class="pa-2">
+          <v-card :to="{ name: 'browse', query: memoriesQuery }" class="clickable py-3" color="surface" variant="elevated">
+            <v-card-text>
+              <v-icon size="48" color="primary" class="mb-3">mdi-calendar-heart</v-icon>
+              <div class="text-h6">{{ $gettext(`On This Day`) }}</div>
+              <div class="text-body-2 mt-2">
+                {{ $gettextInterpolate($gettext(`Memories from %{date}`), { date: todayLabel }) }}
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "PTabDiscoverSeason",
+  data() {
+    const today = new Date();
+
+    return {
+      readonly: this.$config.get("readonly"),
+      today,
+    };
+  },
+  computed: {
+    memoriesQuery() {
+      return {
+        month: this.today.getMonth() + 1,
+        day: this.today.getDate(),
+        order: "oldest",
+      };
+    },
+    todayLabel() {
+      return this.today.toLocaleDateString(undefined, {
+        month: "long",
+        day: "numeric",
+      });
+    },
+  },
+};
+</script>

--- a/frontend/src/page/photos.vue
+++ b/frontend/src/page/photos.vue
@@ -112,6 +112,7 @@ export default {
     const lens = query["lens"] ? parseInt(query["lens"]) : 0;
     const year = query["year"] ? parseInt(query["year"]) : 0;
     const month = query["month"] ? parseInt(query["month"]) : 0;
+    const day = query["day"] ? parseInt(query["day"]) : 0;
     const color = query["color"] ? query["color"] : "";
     const label = query["label"] ? query["label"] : "";
     const latlng = query["latlng"] ? query["latlng"] : "";
@@ -125,6 +126,7 @@ export default {
       latlng: latlng,
       year: year,
       month: month,
+      day: day,
       color: color,
       order: order,
       reverse: this.sortReverse(),
@@ -214,6 +216,7 @@ export default {
       this.filter.lens = query["lens"] ? parseInt(query["lens"]) : 0;
       this.filter.year = query["year"] ? parseInt(query["year"]) : 0;
       this.filter.month = query["month"] ? parseInt(query["month"]) : 0;
+      this.filter.day = query["day"] ? parseInt(query["day"]) : 0;
       this.filter.color = query["color"] ? query["color"] : "";
       this.filter.label = query["label"] ? query["label"] : "";
       this.filter.latlng = query["latlng"] ? query["latlng"] : "";

--- a/frontend/tests/vitest/component/photo/toolbar.test.js
+++ b/frontend/tests/vitest/component/photo/toolbar.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { shallowMount, config as VTUConfig } from "@vue/test-utils";
 import PPhotoToolbar from "component/photo/toolbar.vue";
 import * as contexts from "options/contexts";
@@ -13,6 +13,7 @@ function mountToolbar({
     camera: 0,
     year: 0,
     month: 0,
+    day: 0,
     color: "",
     label: "",
     order: "newest",
@@ -255,6 +256,19 @@ describe("component/photo/toolbar", () => {
     });
   });
 
+  describe("date options", () => {
+    it("provides all days for the day filter", () => {
+      const { wrapper } = mountToolbar();
+
+      const days = wrapper.vm.dayOptions();
+
+      expect(days[0]).toEqual({ value: 0, text: "All Days" });
+      expect(days[1]).toEqual({ value: 1, text: "01" });
+      expect(days[31]).toEqual({ value: 31, text: "31" });
+      expect(days[32]).toEqual({ value: -1, text: "Unknown" });
+    });
+  });
+
   describe("delete actions", () => {
     it("deleteAll opens confirmation dialog only when delete is allowed", () => {
       const allowAll = vi.fn(() => true);
@@ -342,5 +356,4 @@ describe("component/photo/toolbar", () => {
     });
   });
 });
-
 

--- a/frontend/tests/vitest/page/discover-season.test.js
+++ b/frontend/tests/vitest/page/discover-season.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { shallowMount, config as VTUConfig } from "@vue/test-utils";
+
+import PTabDiscoverSeason from "page/discover/season.vue";
+import "../fixtures";
+
+describe("page/discover/season.vue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-07T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("links to browse photos from today's month and day", () => {
+    const wrapper = shallowMount(PTabDiscoverSeason, {
+      global: {
+        mocks: {
+          $config: VTUConfig.global.mocks.$config,
+          $gettext: (text) => text,
+          $gettextInterpolate: (text, values) => text.replace("%{date}", values.date),
+        },
+      },
+    });
+
+    expect(wrapper.vm.memoriesQuery).toEqual({
+      month: 6,
+      day: 7,
+      order: "oldest",
+    });
+    expect(wrapper.vm.todayLabel).toBe("June 7");
+  });
+});

--- a/frontend/tests/vitest/page/photos.date-filter.test.js
+++ b/frontend/tests/vitest/page/photos.date-filter.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+
+import PPagePhotos from "page/photos.vue";
+
+function configMock() {
+  return {
+    getSettings: vi.fn(() => ({
+      features: {
+        edit: true,
+        places: true,
+        private: false,
+        review: false,
+      },
+    })),
+    allow: vi.fn(() => true),
+    deny: vi.fn(() => false),
+  };
+}
+
+function newStub(query = {}) {
+  return {
+    $route: {
+      name: "browse",
+      query,
+    },
+    $config: configMock(),
+    $clipboard: {
+      selection: [],
+    },
+    staticFilter: {},
+    embedded: false,
+    getViewType: vi.fn(() => "cards"),
+    sortOrder: vi.fn(() => "newest"),
+    sortReverse: vi.fn(() => false),
+  };
+}
+
+describe("page/photos.vue date filters", () => {
+  it("initializes month and day from route query parameters", () => {
+    const state = PPagePhotos.data.call(newStub({ month: "6", day: "7" }));
+
+    expect(state.filter.month).toBe(6);
+    expect(state.filter.day).toBe(7);
+  });
+
+  it("defaults the day filter to all days when no query parameter is set", () => {
+    const state = PPagePhotos.data.call(newStub({ month: "6" }));
+
+    expect(state.filter.month).toBe(6);
+    expect(state.filter.day).toBe(0);
+  });
+});
+


### PR DESCRIPTION
## Summary

- add a Discover > Season "On This Day" card that opens Browse with today's month/day and oldest-first ordering
- wire the existing day filter into Browse route initialization and route updates
- expose the day filter in the photo toolbar beside the existing month filter so date-scoped searches can be viewed and cleared

Fixes #720

## Verification

- npm --workspace frontend exec eslint -- src/page/discover.vue src/page/discover/season.vue src/page/photos.vue src/component/photo/toolbar.vue tests/vitest/component/photo/toolbar.test.js tests/vitest/page/photos.date-filter.test.js tests/vitest/page/discover-season.test.js
- npm --workspace frontend run test -- tests/vitest/component/photo/toolbar.test.js tests/vitest/page/photos.date-filter.test.js tests/vitest/page/discover-season.test.js
- npm --workspace frontend run build-dev
