### PR TITLE
Index: Serialize indexing of byte-identical files to avoid duplicates #5607

### DIFF
--- a/internal/photoprism/index_filehash.go
+++ b/internal/photoprism/index_filehash.go
@@ -1,0 +1,40 @@
+package photoprism
+
+import "sync"
+
+// fileHashLock serializes indexing of files that share the same content hash.
+type fileHashLock struct {
+	sync.Mutex
+	refs int
+}
+
+// fileHashLocksMutex guards fileHashLocks.
+var fileHashLocksMutex sync.Mutex
+
+// fileHashLocks tracks the per-hash locks currently held or awaited by indexing workers.
+var fileHashLocks = make(map[string]*fileHashLock)
+
+// lockFileHash acquires the indexing lock for the given file hash and returns the function that releases it.
+// Entries are reference counted and removed on release, so the map only holds in-flight hashes.
+func lockFileHash(fileHash string) (unlock func()) {
+	fileHashLocksMutex.Lock()
+	l, found := fileHashLocks[fileHash]
+	if !found {
+		l = &fileHashLock{}
+		fileHashLocks[fileHash] = l
+	}
+	l.refs++
+	fileHashLocksMutex.Unlock()
+
+	l.Lock()
+
+	return func() {
+		l.Unlock()
+		fileHashLocksMutex.Lock()
+		l.refs--
+		if l.refs == 0 {
+			delete(fileHashLocks, fileHash)
+		}
+		fileHashLocksMutex.Unlock()
+	}
+}

--- a/internal/photoprism/index_filehash_test.go
+++ b/internal/photoprism/index_filehash_test.go
@@ -1,0 +1,62 @@
+package photoprism
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLockFileHash verifies that lockFileHash serializes concurrent holders of
+// the same hash and removes map entries once the last holder releases.
+func TestLockFileHash(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		unlock := lockFileHash("abc123")
+		assert.Len(t, fileHashLocks, 1)
+		unlock()
+		assert.Len(t, fileHashLocks, 0)
+	})
+	// Callers skip the lock for empty hashes; this is a defensive contract check.
+	t.Run("EmptyHash", func(t *testing.T) {
+		unlock := lockFileHash("")
+		assert.Len(t, fileHashLocks, 1)
+		unlock()
+		assert.Len(t, fileHashLocks, 0)
+	})
+	t.Run("DistinctKeysDoNotBlock", func(t *testing.T) {
+		unlockFirst := lockFileHash("hash-one")
+		unlockSecond := lockFileHash("hash-two")
+		assert.Len(t, fileHashLocks, 2)
+		unlockSecond()
+		unlockFirst()
+		assert.Len(t, fileHashLocks, 0)
+	})
+	t.Run("Contention", func(t *testing.T) {
+		const workers = 8
+		var wg sync.WaitGroup
+		var inCriticalSection int32
+		var entered int32
+
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				unlock := lockFileHash("contended")
+				defer unlock()
+
+				if !atomic.CompareAndSwapInt32(&inCriticalSection, 0, 1) {
+					t.Error("two goroutines entered the critical section for the same hash")
+				}
+
+				atomic.AddInt32(&entered, 1)
+				atomic.StoreInt32(&inCriticalSection, 0)
+			}()
+		}
+
+		wg.Wait()
+
+		assert.Equal(t, int32(workers), entered)
+		assert.Len(t, fileHashLocks, 0)
+	})
+}

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -98,6 +98,13 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 	// Try to find existing file by hash. Skip this for sidecar files, and files outside the originals folder.
 	if !fileExists && !m.IsSidecar() && m.Root() == entity.RootOriginals {
 		fileHash = m.Hash()
+
+		// Hold a per-hash lock until indexing is complete, so concurrent workers
+		// cannot miss the lookup below and index byte-identical files twice.
+		if fileHash != "" {
+			defer lockFileHash(fileHash)()
+		}
+
 		fileQuery = entity.UnscopedDb().First(&file, "file_hash = ?", fileHash)
 
 		indFileName := ""

--- a/internal/photoprism/index_mediafile_test.go
+++ b/internal/photoprism/index_mediafile_test.go
@@ -1,6 +1,9 @@
 package photoprism
 
 import (
+	"fmt"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,6 +87,109 @@ func TestIndex_MediaFile(t *testing.T) {
 		result := ind.MediaFile(nil, indexOpt, "blue-go-video.mp4", "")
 		assert.Equal(t, IndexStatus("failed"), result.Status)
 	})
+}
+
+// TestIndex_UserMediaFile_ParallelDuplicates verifies that byte-identical files indexed
+// concurrently by multiple workers result in exactly one photo and N-1 duplicate records.
+func TestIndex_UserMediaFile_ParallelDuplicates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	// The package-wide PHOTOPRISM_TEST_DSN points all test configs at one shared
+	// SQLite file, so the database must be isolated for reliable row counts.
+	t.Setenv("PHOTOPRISM_TEST_DSN", filepath.Join(t.TempDir(), "index-dup-race.db"))
+
+	cfg := config.NewMinimalTestConfigWithDb("index-dup-race", filepath.Join(t.TempDir(), "storage"))
+
+	// MediaFile.Root() resolves paths against the package-level config, so it
+	// must point to the test config for files to be detected as originals.
+	oldCfg := Config()
+	SetConfig(cfg)
+
+	t.Cleanup(func() {
+		SetConfig(oldCfg)
+		oldCfg.RegisterDb()
+	})
+
+	testFile, err := NewMediaFile("testdata/flash.jpg")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const numCopies = 3
+
+	copyNames := make([]string, numCopies)
+
+	for i := range copyNames {
+		copyNames[i] = filepath.Join(cfg.OriginalsPath(), fmt.Sprintf("folder%d", i), "flash.jpg")
+
+		if copyErr := testFile.Copy(copyNames[i], false); copyErr != nil {
+			t.Fatal(copyErr)
+		}
+	}
+
+	ind := NewIndex(cfg, NewConvert(cfg), NewFiles(), NewPhotos())
+	indexOpt := IndexOptionsSingle(cfg)
+
+	// The test database is seeded with entity fixtures, so all row counts are compared as deltas.
+	var basePhotos, baseFiles, baseDuplicates int
+
+	assert.NoError(t, entity.UnscopedDb().Model(&entity.Photo{}).Count(&basePhotos).Error)
+	assert.NoError(t, entity.UnscopedDb().Model(&entity.File{}).Count(&baseFiles).Error)
+	assert.NoError(t, entity.UnscopedDb().Model(&entity.Duplicate{}).Count(&baseDuplicates).Error)
+
+	mediaFiles := make([]*MediaFile, numCopies)
+
+	for i, name := range copyNames {
+		if mediaFiles[i], err = NewMediaFile(name); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	results := make([]IndexResult, numCopies)
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	for i := range mediaFiles {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i] = ind.UserMediaFile(mediaFiles[i], indexOpt, "", "", entity.OwnerUnknown)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	added, duplicates := 0, 0
+
+	for _, result := range results {
+		switch result.Status {
+		case IndexAdded:
+			added++
+		case IndexDuplicate:
+			duplicates++
+		default:
+			t.Fatalf("unexpected index result %s (%v)", result.Status, result.Err)
+		}
+	}
+
+	assert.Equal(t, 1, added)
+	assert.Equal(t, numCopies-1, duplicates)
+
+	var photoCount, fileCount, duplicateCount int
+
+	assert.NoError(t, entity.UnscopedDb().Model(&entity.Photo{}).Count(&photoCount).Error)
+	assert.NoError(t, entity.UnscopedDb().Model(&entity.File{}).Count(&fileCount).Error)
+	assert.NoError(t, entity.UnscopedDb().Model(&entity.Duplicate{}).Count(&duplicateCount).Error)
+
+	assert.Equal(t, basePhotos+1, photoCount)
+	assert.Equal(t, baseFiles+1, fileCount)
+	assert.Equal(t, baseDuplicates+numCopies-1, duplicateCount)
 }
 
 func TestIndexResult_Archived(t *testing.T) {


### PR DESCRIPTION
Fixes #5607

### Problem

The indexer's duplicate check performs a hash lookup in `UserMediaFile()` and inserts the resulting Photo and File rows roughly 950 lines later, with no synchronization and no unique index on `files.file_hash` (a unique index is not an option because existing databases contain duplicate and empty-string hashes). With `PHOTOPRISM_INDEX_WORKERS > 1`, workers processing byte-identical files in different folders can all miss the lookup before any of them commits, creating one Photo per copy instead of one Photo plus duplicate records.

### Fix

A process-wide, reference-counted per-hash mutex (`lockFileHash` in `internal/photoprism/index_filehash.go`) is held from the hash lookup until `UserMediaFile()` returns, so byte-identical files are indexed strictly one at a time. The waiting worker then finds the committed File row by hash and takes the existing `AddDuplicate` path, returning `IndexDuplicate` exactly as sequential indexing does. Map entries are removed when the last holder releases, so memory use stays bounded on large libraries. Files with an empty hash (unreadable) skip the lock. The import flow is covered as well, since `ImportWorker` indexes through the same `UserMediaFile` call.

Locking is always outermost relative to the entity-layer mutexes, and each goroutine holds at most one hash lock, so no new lock-ordering cycles are introduced. For libraries without duplicates the overhead is one map operation and mutex pair per file. Indexing remains parallel across distinct files; only identical content serializes. Runs that previously required `PHOTOPRISM_INDEX_WORKERS=1` as a workaround can use the default worker count again.

Not covered (unchanged behavior): two separate processes sharing one database can still race, and near-duplicate stacking continues to rely on `photo.Merge`.

### Tests

- `TestIndex_UserMediaFile_ParallelDuplicates` indexes three byte-identical copies concurrently and asserts one `IndexAdded`, two `IndexDuplicate`, and exact row deltas (+1 photo, +1 file, +2 duplicates). It fails deterministically without the lock (3 photos, 0 duplicates) and passes with it.
- `TestLockFileHash` covers serialization under contention and map cleanup after release.
- Verified with `go test -race ./internal/photoprism -run 'TestIndex|TestImport|TestUserImport|TestLockFileHash'`, `golangci-lint` (0 issues), and `gofmt`.
