### PR TITLE
Helm: Allow referencing external secret for database password

### DIFF
--- a/setup/charts/plus/README.md
+++ b/setup/charts/plus/README.md
@@ -72,6 +72,27 @@ ingress:
 
 Because TLS typically terminates at the ingress or proxy layer, the chart keeps `PHOTOPRISM_DISABLE_TLS` set to `true`. Only enable PhotoPrism’s internal TLS if your cluster design requires end-to-end encryption and you manage the certificates yourself.
 
+## Database Password
+
+You can provide the database password in two ways:
+
+1. **External secret** – set `database.passwordSecretName` to reference a pre-existing Kubernetes Secret. By default the
+   chart looks for a `PHOTOPRISM_DATABASE_PASSWORD` key; set `database.passwordSecretKey` to use a different key name:
+   ```yaml
+   database:
+     passwordSecretName: my-db-credentials
+     # passwordSecretKey: DB_PASSWORD  # optional, defaults to PHOTOPRISM_DATABASE_PASSWORD
+   ```
+2. **Inline** – set `database.password` directly (the chart stores it in its managed Secret and references it via
+   `secretKeyRef`):
+   ```yaml
+   database:
+     password: "changeme"
+   ```
+
+If both are set, `database.passwordSecretName` takes precedence. If neither is set, no password env var is injected (
+suitable for SQLite).
+
 ## Security Tips
 
 - When `adminPassword` is left blank, a random password is generated and stored in `secret/<release>-photoprism-secrets`.

--- a/setup/charts/plus/templates/statefulset.yaml
+++ b/setup/charts/plus/templates/statefulset.yaml
@@ -97,14 +97,19 @@ spec:
             - name: PHOTOPRISM_DATABASE_USER
               value: {{ $dbUser | quote }}
             {{- end }}
-            {{- $dbPassword := trim (default "" .Values.database.password) -}}
-            {{- if ne $dbPassword "" }}
+            {{- if .Values.database.passwordSecretName }}
+            - name: PHOTOPRISM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.passwordSecretName | quote }}
+                  key: {{ (default "PHOTOPRISM_DATABASE_PASSWORD" .Values.database.passwordSecretKey) | quote }}
+            {{- else if ne (trim (default "" .Values.database.password)) "" }}
             - name: PHOTOPRISM_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ printf "%s-secrets" (include "photoprism-plus.fullname" .) }}
                   key: PHOTOPRISM_DATABASE_PASSWORD
-            {{- end }}
+            {{- end}}
             - name: PHOTOPRISM_DATABASE_TIMEOUT
               value: {{ printf "%v" .Values.database.timeout | quote }}
             - name: PHOTOPRISM_DATABASE_CONNS

--- a/setup/charts/plus/values.yaml
+++ b/setup/charts/plus/values.yaml
@@ -156,6 +156,8 @@ database:
   name: "photoprism"
   user: "photoprism"
   password: ""
+  passwordSecretName: ""
+  passwordSecretKey: ""
   timeout: 15
   conns: 0
   connsIdle: 0


### PR DESCRIPTION
### Description

Allow the database password to be sourced from an existing Kubernetes secret
via a new `database.passwordSecretName` value, instead of requiring the
auto-generated `<release>-secrets` secret. This lets users manage credentials
externally (e.g. via Sealed Secrets, External Secrets Operator, or manual
pre-provisioned secrets).

When `database.password` is set directly, it is injected as a plain `value`.
When `database.passwordSecretName` is set instead, the password is read from
that secret via `secretKeyRef`. If neither is set, the env var is omitted
entirely.

### Acceptance Criteria

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [x] Documentation has been / will be updated, especially as it relates to new configuration options or potentially disruptive changes

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->