### PR TITLE
[codex] People: Add search mode for selected faces

### DIFF
--- a/frontend/src/component/people/clipboard.vue
+++ b/frontend/src/component/people/clipboard.vue
@@ -18,6 +18,20 @@
           </v-btn>
         </template>
 
+        <v-btn-toggle v-if="selection.length > 1" v-model="searchMode" mandatory density="compact" rounded="pill" variant="elevated" class="action-search-mode">
+          <v-btn value="or" density="compact" class="action-search-or">OR</v-btn>
+          <v-btn value="and" density="compact" class="action-search-and">AND</v-btn>
+        </v-btn-toggle>
+        <v-btn
+          key="action-search"
+          :title="$gettext('Search')"
+          icon="mdi-magnify"
+          color="primary"
+          density="comfortable"
+          class="action-search"
+          :disabled="!canSearch || selection.length === 0"
+          @click.stop="search()"
+        ></v-btn>
         <v-btn
           key="action-download"
           :title="$gettext('Download')"
@@ -73,10 +87,12 @@ export default {
   data() {
     return {
       canManage: this.$config.allow("people", "manage"),
+      canSearch: this.$config.allow("photos", "search") && this.$config.feature("search"),
       canDownload: this.$config.allow("people", "download") && this.$config.feature("download"),
       canAddAlbums: this.$config.allow("albums", "create") && this.$config.feature("albums"),
       features: this.$config.getSettings().features,
       expanded: false,
+      searchMode: "or",
       dialog: {
         delete: false,
         album: false,
@@ -89,6 +105,21 @@ export default {
     clearClipboard() {
       this.clearSelection();
       this.expanded = false;
+    },
+    // search opens selected people in photo search with the selected operator.
+    search() {
+      if (!this.canSearch || this.selection.length === 0) {
+        return;
+      }
+
+      const subjects = this.selection.filter((uid) => uid).join(this.searchMode === "and" ? "&" : "|");
+
+      if (!subjects) {
+        return;
+      }
+
+      this.$router.push({ name: "all", query: { q: `subject:${subjects}` } });
+      this.clearClipboard();
     },
     addToAlbum(ppidOrList) {
       if (!ppidOrList) {

--- a/frontend/tests/vitest/component/people/clipboard.test.js
+++ b/frontend/tests/vitest/component/people/clipboard.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import PPeopleClipboard from "component/people/clipboard.vue";
+
+function mountClipboard({ selection = ["subj1", "subj2"], allow = vi.fn(() => true), feature = vi.fn(() => true) } = {}) {
+  const router = {
+    push: vi.fn(),
+  };
+
+  const clearSelection = vi.fn();
+
+  const wrapper = shallowMount(PPeopleClipboard, {
+    props: {
+      selection,
+      clearSelection,
+    },
+    global: {
+      mocks: {
+        $config: {
+          allow,
+          feature,
+          getSettings: () => ({ features: { albums: true, download: true, search: true } }),
+        },
+        $gettext: (msg) => msg,
+        $isRtl: false,
+        $router: router,
+      },
+      stubs: {
+        "v-speed-dial": { template: "<div><slot></slot></div>" },
+        "v-btn-toggle": { template: '<div v-bind="$attrs"><slot></slot></div>' },
+        "v-btn": { template: '<button v-bind="$attrs"><slot></slot></button>' },
+        "p-photo-album-dialog": true,
+      },
+    },
+  });
+
+  return { wrapper, router, clearSelection };
+}
+
+describe("component/people/clipboard", () => {
+  it("shows the search mode toggle only for multi-person selections", () => {
+    const { wrapper } = mountClipboard();
+    const { wrapper: singleWrapper } = mountClipboard({ selection: ["subj1"] });
+
+    expect(wrapper.find(".action-search-mode").exists()).toBe(true);
+    expect(singleWrapper.find(".action-search-mode").exists()).toBe(false);
+  });
+
+  it("searches selected people with a subject OR query", () => {
+    const { wrapper, router, clearSelection } = mountClipboard();
+
+    wrapper.vm.search();
+
+    expect(wrapper.vm.searchMode).toBe("or");
+    expect(router.push).toHaveBeenCalledWith({ name: "all", query: { q: "subject:subj1|subj2" } });
+    expect(clearSelection).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.expanded).toBe(false);
+  });
+
+  it("searches selected people with a subject AND query", () => {
+    const { wrapper, router, clearSelection } = mountClipboard();
+
+    wrapper.vm.searchMode = "and";
+    wrapper.vm.search();
+
+    expect(router.push).toHaveBeenCalledWith({ name: "all", query: { q: "subject:subj1&subj2" } });
+    expect(clearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not search when no people are selected", () => {
+    const { wrapper, router, clearSelection } = mountClipboard({ selection: [] });
+
+    wrapper.vm.search();
+
+    expect(router.push).not.toHaveBeenCalled();
+    expect(clearSelection).not.toHaveBeenCalled();
+  });
+
+  it("does not search when photo search permission is denied", () => {
+    const allow = vi.fn((resource, action) => !(resource === "photos" && action === "search"));
+    const { wrapper, router, clearSelection } = mountClipboard({ allow });
+
+    wrapper.vm.search();
+
+    expect(router.push).not.toHaveBeenCalled();
+    expect(clearSelection).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a compact OR/AND mode toggle to the selected-people mobile action menu.
- Route selected face searches through existing `subject:` query operators, using OR by default and AND when selected.
- Cover toggle visibility, OR/AND query generation, empty selections, and denied search permission with component tests.

## Validation

- `npm run fmt` from `frontend/` with Node 22.15.0
- `TZ=UTC BUILD_ENV=development NODE_ENV=development BABEL_ENV=test ../node_modules/.bin/vitest run tests/vitest/component/people`
- `../node_modules/.bin/eslint src/component/people/clipboard.vue tests/vitest/component/people/clipboard.test.js`
- `../node_modules/.bin/webpack --node-env=development`
- `git diff --check`

## Notes

- No database or API changes.
- No documentation updates needed; this exposes existing `subject:` search operator behavior in the selected-people UI.