### PR TITLE
Portal: Add app.vue alias to vitest config for hooks unit tests

### DIFF
--- a/frontend/vitest.config.portal.js
+++ b/frontend/vitest.config.portal.js
@@ -34,6 +34,7 @@ export default defineConfig({
       { find: "model/cluster-node", replacement: path.resolve(__dirname, "../portal/frontend/model/cluster-node.js") },
       { find: "common/instance-grants", replacement: path.resolve(__dirname, "../portal/frontend/common/instance-grants.js") },
       { find: "common/user-format", replacement: path.resolve(__dirname, "../portal/frontend/common/user-format.js") },
+      { find: "app.vue", replacement: path.resolve(__dirname, "./src/app.vue") },
       { find: "app", replacement: path.resolve(__dirname, "./src/app") },
       { find: "common", replacement: path.resolve(__dirname, "./src/common") },
       { find: "component", replacement: path.resolve(__dirname, "./src/component") },


### PR DESCRIPTION
This pull request adds a new alias to the Vite configuration in `frontend/vitest.config.portal.js`, allowing the import of `app.vue` using a simplified path.

Configuration update:

* Added a path alias so that `"app.vue"` now resolves directly to `./src/app.vue`, making imports cleaner and more consistent.