### PR TITLE
Metadata: Add 5-star photo ratings #713

### DIFF
--- a/frontend/src/component/photo/edit/details.vue
+++ b/frontend/src/component/photo/edit/details.vue
@@ -34,6 +34,17 @@
                 density="comfortable"
                 class="input-caption"
               ></v-textarea>
+              <v-rating
+                v-model="view.model.Rating"
+                :disabled="disabled"
+                :aria-label="$pgettext('Photo', 'Rating')"
+                clearable
+                hover
+                density="comfortable"
+                size="small"
+                active-color="amber"
+                class="input-rating"
+              ></v-rating>
             </v-col>
           </v-row>
           <v-row dense>

--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -53,6 +53,8 @@ export class Photo extends RestModel {
       TypeSrc: "",
       Stack: 0,
       Favorite: false,
+      Rating: 0,
+      RatingSrc: "",
       Private: false,
       Scan: false,
       Panorama: false,
@@ -1316,6 +1318,17 @@ export class Photo extends RestModel {
 
     if (typeof values.Caption === "string") {
       values.CaptionSrc = src.Manual;
+    }
+
+    if (typeof values.Rating === "number") {
+      // Clearing the stars reverts to "never rated" so ratings can be
+      // imported from metadata again; picking 1-5 stars is a manual edit.
+      if (values.Rating > 0) {
+        values.RatingSrc = src.Manual;
+      } else {
+        values.Rating = 0;
+        values.RatingSrc = "";
+      }
     }
 
     if (values.Lat || values.Lng || values.Country) {

--- a/frontend/tests/vitest/model/photo-rating.test.js
+++ b/frontend/tests/vitest/model/photo-rating.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import MockAdapter from "axios-mock-adapter";
+import $api from "common/api";
+import { Photo } from "model/photo";
+
+// Echo the request body back so update() resolves with the values it sent.
+const Mock = new MockAdapter($api);
+Mock.onPut(/photos\//).reply((config) => [200, JSON.parse(config.data)]);
+
+describe("model/photo rating", () => {
+  it("declares unrated defaults", () => {
+    const photo = new Photo();
+    expect(photo.Rating).toBe(0);
+    expect(photo.RatingSrc).toBe("");
+  });
+
+  it("keeps assigned rating values", () => {
+    const photo = new Photo({ ID: 2, UID: "pqbcf5j446s0futz", Rating: 4, RatingSrc: "meta" });
+    expect(photo.Rating).toBe(4);
+    expect(photo.RatingSrc).toBe("meta");
+  });
+
+  it("round-trips rating through getValues", () => {
+    const photo = new Photo({ ID: 3, UID: "pqbcf5j446s0fut0", Rating: 5, RatingSrc: "manual" });
+    const values = photo.getValues(false);
+    expect(values.Rating).toBe(5);
+    expect(values.RatingSrc).toBe("manual");
+  });
+
+  it("stamps the manual source when stars are picked", async () => {
+    const photo = new Photo({ ID: 4, UID: "pqbcf5j446s0fut1", Rating: 0, RatingSrc: "" });
+    photo.Rating = 4;
+    await photo.update();
+    const sent = JSON.parse(Mock.history.put.at(-1).data);
+    expect(sent.Rating).toBe(4);
+    expect(sent.RatingSrc).toBe("manual");
+  });
+
+  it("clearing the stars reverts to never rated", async () => {
+    const photo = new Photo({ ID: 5, UID: "pqbcf5j446s0fut2", Rating: 3, RatingSrc: "manual" });
+    photo.Rating = 0;
+    await photo.update();
+    const sent = JSON.parse(Mock.history.put.at(-1).data);
+    expect(sent.Rating).toBe(0);
+    expect(sent.RatingSrc).toBe("");
+  });
+
+  it("treats a null rating from the input as a cleared rating", async () => {
+    const photo = new Photo({ ID: 6, UID: "pqbcf5j446s0fut3", Rating: 2, RatingSrc: "manual" });
+    photo.Rating = null;
+    await photo.update();
+    const sent = JSON.parse(Mock.history.put.at(-1).data);
+    expect(sent.Rating).toBe(0);
+    expect(sent.RatingSrc).toBe("");
+  });
+});

--- a/internal/api/photos_test.go
+++ b/internal/api/photos_test.go
@@ -121,6 +121,46 @@ func TestUpdatePhoto(t *testing.T) {
 	})
 }
 
+func TestUpdatePhotoRating(t *testing.T) {
+	t.Run("SetAndClear", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		UpdatePhoto(router)
+
+		// Set a manual 4-star rating.
+		r := PerformRequestWithBody(app, "PUT", "/api/v1/photos/ps6sg6be2lvl0y13", `{"Rating": 4, "RatingSrc": "manual"}`)
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, int64(4), gjson.Get(r.Body.String(), "Rating").Int())
+		assert.Equal(t, "manual", gjson.Get(r.Body.String(), "RatingSrc").String())
+
+		// Verify the rating was persisted and outranks metadata imports.
+		m := entity.FindPhoto(entity.Photo{PhotoUID: "ps6sg6be2lvl0y13"})
+		assert.Equal(t, 4, m.PhotoRating)
+		assert.Equal(t, entity.SrcManual, m.RatingSrc)
+		m.SetRating(2, entity.SrcMeta)
+		assert.Equal(t, 4, m.PhotoRating)
+
+		// Clear the rating so the photo counts as never rated again.
+		r = PerformRequestWithBody(app, "PUT", "/api/v1/photos/ps6sg6be2lvl0y13", `{"Rating": 0, "RatingSrc": ""}`)
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, int64(0), gjson.Get(r.Body.String(), "Rating").Int())
+
+		// A cleared source lets metadata ratings be imported again.
+		m = entity.FindPhoto(entity.Photo{PhotoUID: "ps6sg6be2lvl0y13"})
+		assert.Equal(t, 0, m.PhotoRating)
+		assert.Equal(t, "", m.RatingSrc)
+		m.SetRating(3, entity.SrcMeta)
+		assert.Equal(t, 3, m.PhotoRating)
+		assert.Equal(t, entity.SrcMeta, m.RatingSrc)
+	})
+	t.Run("OutOfRange", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		UpdatePhoto(router)
+		r := PerformRequestWithBody(app, "PUT", "/api/v1/photos/ps6sg6be2lvl0y13", `{"Rating": 9}`)
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, int64(5), gjson.Get(r.Body.String(), "Rating").Int())
+	})
+}
+
 func TestGetPhotoDownload(t *testing.T) {
 	t.Run("OriginalMissing", func(t *testing.T) {
 		app, router, conf := NewApiTest()

--- a/internal/entity/photo.go
+++ b/internal/entity/photo.go
@@ -64,6 +64,8 @@ type Photo struct {
 	OriginalName     string        `gorm:"type:VARBINARY(755);" json:"OriginalName" yaml:"OriginalName,omitempty"`
 	PhotoStack       int8          `json:"Stack" yaml:"Stack,omitempty"`
 	PhotoFavorite    bool          `json:"Favorite" yaml:"Favorite,omitempty"`
+	PhotoRating      int           `gorm:"type:SMALLINT" json:"Rating" yaml:"Rating,omitempty"`
+	RatingSrc        string        `gorm:"type:VARBINARY(8);" json:"RatingSrc" yaml:"RatingSrc,omitempty"`
 	PhotoPrivate     bool          `json:"Private" yaml:"Private,omitempty"`
 	PhotoScan        bool          `json:"Scan" yaml:"Scan,omitempty"`
 	PhotoPanorama    bool          `json:"Panorama" yaml:"Panorama,omitempty"`
@@ -879,6 +881,15 @@ func (m *Photo) NormalizeValues() (normalized bool) {
 
 	if timeZone := tz.Name(m.TimeZone); timeZone != m.TimeZone {
 		m.TimeZone = timeZone
+		normalized = true
+	}
+
+	// Keep the star rating within the supported range of 0 to 5.
+	if m.PhotoRating < RatingMin {
+		m.PhotoRating = RatingMin
+		normalized = true
+	} else if m.PhotoRating > RatingMax {
+		m.PhotoRating = RatingMax
 		normalized = true
 	}
 

--- a/internal/entity/photo_rating.go
+++ b/internal/entity/photo_rating.go
@@ -1,0 +1,41 @@
+package entity
+
+// Star rating range: 0 means unrated, 1 to 5 stars otherwise. RatingSrc
+// distinguishes photos that have never been rated (empty source) from photos
+// that were explicitly rated 0 stars (non-empty source), so both states
+// remain queryable without a nullable column.
+const (
+	RatingMin = 0
+	RatingMax = 5
+)
+
+// HasRating reports whether a rating has been assigned from any source,
+// including an explicit rating of 0 stars.
+func (m *Photo) HasRating() bool {
+	return m.RatingSrc != ""
+}
+
+// GetRating returns the star rating from 0 to 5.
+func (m *Photo) GetRating() int {
+	return m.PhotoRating
+}
+
+// GetRatingSrc returns the rating source, if any.
+func (m *Photo) GetRatingSrc() string {
+	return m.RatingSrc
+}
+
+// SetRating stores the star rating when the value is within range and the
+// source priority is sufficient, following the same rules as SetCaption.
+func (m *Photo) SetRating(rating int, source string) {
+	if rating < RatingMin || rating > RatingMax {
+		return
+	}
+
+	if (SrcPriority[source] < SrcPriority[m.RatingSrc]) && m.HasRating() {
+		return
+	}
+
+	m.PhotoRating = rating
+	m.RatingSrc = source
+}

--- a/internal/entity/photo_rating_test.go
+++ b/internal/entity/photo_rating_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/photoprism/photoprism/pkg/time/tz"
 )
 
 func TestPhoto_SetRating(t *testing.T) {
@@ -74,19 +76,19 @@ func TestPhoto_SetRating(t *testing.T) {
 
 func TestPhoto_NormalizeRating(t *testing.T) {
 	t.Run("ClampAboveMax", func(t *testing.T) {
-		m := Photo{PhotoRating: 9}
+		m := Photo{TimeZone: tz.Local, PhotoRating: 9}
 
 		assert.True(t, m.NormalizeValues())
 		assert.Equal(t, 5, m.PhotoRating)
 	})
 	t.Run("ClampBelowMin", func(t *testing.T) {
-		m := Photo{PhotoRating: -3}
+		m := Photo{TimeZone: tz.Local, PhotoRating: -3}
 
 		assert.True(t, m.NormalizeValues())
 		assert.Equal(t, 0, m.PhotoRating)
 	})
 	t.Run("InRangeUnchanged", func(t *testing.T) {
-		m := Photo{PhotoRating: 5}
+		m := Photo{TimeZone: tz.Local, PhotoRating: 5}
 
 		assert.False(t, m.NormalizeValues())
 		assert.Equal(t, 5, m.PhotoRating)

--- a/internal/entity/photo_rating_test.go
+++ b/internal/entity/photo_rating_test.go
@@ -1,0 +1,94 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPhoto_SetRating(t *testing.T) {
+	t.Run("Unrated", func(t *testing.T) {
+		m := Photo{}
+
+		assert.False(t, m.HasRating())
+		assert.Equal(t, 0, m.GetRating())
+		assert.Equal(t, "", m.GetRatingSrc())
+	})
+	t.Run("Meta", func(t *testing.T) {
+		m := Photo{}
+
+		m.SetRating(4, SrcMeta)
+
+		assert.True(t, m.HasRating())
+		assert.Equal(t, 4, m.GetRating())
+		assert.Equal(t, SrcMeta, m.GetRatingSrc())
+	})
+	t.Run("LowerPriorityIsIgnored", func(t *testing.T) {
+		m := Photo{PhotoRating: 4, RatingSrc: SrcMeta}
+
+		m.SetRating(2, SrcEstimate)
+
+		assert.Equal(t, 4, m.GetRating())
+		assert.Equal(t, SrcMeta, m.GetRatingSrc())
+	})
+	t.Run("SamePriorityWins", func(t *testing.T) {
+		m := Photo{PhotoRating: 4, RatingSrc: SrcMeta}
+
+		m.SetRating(2, SrcMeta)
+
+		assert.Equal(t, 2, m.GetRating())
+	})
+	t.Run("ExplicitZeroStaysDistinguishable", func(t *testing.T) {
+		m := Photo{PhotoRating: 4, RatingSrc: SrcMeta}
+
+		m.SetRating(0, SrcManual)
+
+		assert.True(t, m.HasRating())
+		assert.Equal(t, 0, m.GetRating())
+		assert.Equal(t, SrcManual, m.GetRatingSrc())
+
+		// A lower-priority source must not override the explicit 0 stars.
+		m.SetRating(5, SrcMeta)
+
+		assert.Equal(t, 0, m.GetRating())
+		assert.Equal(t, SrcManual, m.GetRatingSrc())
+	})
+	t.Run("ManualWinsOverMeta", func(t *testing.T) {
+		m := Photo{PhotoRating: 4, RatingSrc: SrcMeta}
+
+		m.SetRating(3, SrcManual)
+
+		assert.Equal(t, 3, m.GetRating())
+		assert.Equal(t, SrcManual, m.GetRatingSrc())
+	})
+	t.Run("OutOfRangeIsIgnored", func(t *testing.T) {
+		m := Photo{PhotoRating: 3, RatingSrc: SrcManual}
+
+		m.SetRating(6, SrcAdmin)
+		m.SetRating(-1, SrcAdmin)
+
+		assert.Equal(t, 3, m.GetRating())
+		assert.Equal(t, SrcManual, m.GetRatingSrc())
+	})
+}
+
+func TestPhoto_NormalizeRating(t *testing.T) {
+	t.Run("ClampAboveMax", func(t *testing.T) {
+		m := Photo{PhotoRating: 9}
+
+		assert.True(t, m.NormalizeValues())
+		assert.Equal(t, 5, m.PhotoRating)
+	})
+	t.Run("ClampBelowMin", func(t *testing.T) {
+		m := Photo{PhotoRating: -3}
+
+		assert.True(t, m.NormalizeValues())
+		assert.Equal(t, 0, m.PhotoRating)
+	})
+	t.Run("InRangeUnchanged", func(t *testing.T) {
+		m := Photo{PhotoRating: 5}
+
+		assert.False(t, m.NormalizeValues())
+		assert.Equal(t, 5, m.PhotoRating)
+	})
+}

--- a/internal/entity/search/photos.go
+++ b/internal/entity/search/photos.go
@@ -596,6 +596,11 @@ func searchPhotos(frm form.SearchPhotos, sess *entity.Session, resultCols string
 		s = s.Where("photos.photo_favorite = 1")
 	}
 
+	// Filter by minimum star rating.
+	if frm.Rating > 0 {
+		s = s.Where("photos.photo_rating >= ?", frm.Rating)
+	}
+
 	// Filter by scan flag.
 	if txt.No(frm.Scan) {
 		s = s.Where("photos.photo_scan = 0")

--- a/internal/entity/search/photos_filter_rating_test.go
+++ b/internal/entity/search/photos_filter_rating_test.go
@@ -1,0 +1,102 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/photoprism/photoprism/internal/form"
+)
+
+func TestPhotosQueryRating(t *testing.T) {
+	var f0 form.SearchPhotos
+
+	f0.Merged = true
+
+	// Parse query string and filter.
+	if err := f0.ParseQueryString(); err != nil {
+		t.Fatal(err)
+	}
+
+	photos0, _, err := Photos(f0)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	all := len(photos0)
+
+	t.Run("MinimumOneStar", func(t *testing.T) {
+		var f form.SearchPhotos
+
+		f.Query = "rating:1"
+		f.Merged = true
+
+		if err := f.ParseQueryString(); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, 1, f.Rating)
+
+		photos, _, err := Photos(f)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The default fixtures carry no explicit star ratings.
+		assert.Len(t, photos, 0)
+	})
+	t.Run("HigherMinimumIsSubset", func(t *testing.T) {
+		var f1 form.SearchPhotos
+
+		f1.Query = "rating:1"
+		f1.Merged = true
+
+		if err := f1.ParseQueryString(); err != nil {
+			t.Fatal(err)
+		}
+
+		photos1, _, err1 := Photos(f1)
+
+		if err1 != nil {
+			t.Fatal(err1)
+		}
+
+		var f5 form.SearchPhotos
+
+		f5.Query = "rating:5"
+		f5.Merged = true
+
+		if err := f5.ParseQueryString(); err != nil {
+			t.Fatal(err)
+		}
+
+		photos5, _, err5 := Photos(f5)
+
+		if err5 != nil {
+			t.Fatal(err5)
+		}
+
+		assert.LessOrEqual(t, len(photos5), len(photos1))
+		assert.LessOrEqual(t, len(photos1), all)
+	})
+	t.Run("ZeroMeansNoFilter", func(t *testing.T) {
+		var f form.SearchPhotos
+
+		f.Query = "rating:0"
+		f.Merged = true
+
+		if err := f.ParseQueryString(); err != nil {
+			t.Fatal(err)
+		}
+
+		photos, _, err := Photos(f)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Len(t, photos, all)
+	})
+}

--- a/internal/entity/search/photos_geo.go
+++ b/internal/entity/search/photos_geo.go
@@ -494,6 +494,11 @@ func UserPhotosGeo(frm form.SearchPhotosGeo, sess *entity.Session) (results GeoR
 		s = s.Where("photos.photo_favorite = 1")
 	}
 
+	// Filter by minimum star rating.
+	if frm.Rating > 0 {
+		s = s.Where("photos.photo_rating >= ?", frm.Rating)
+	}
+
 	// Filter by scan flag.
 	if txt.No(frm.Scan) {
 		s = s.Where("photos.photo_scan = 0")

--- a/internal/entity/search/photos_geojson_result.go
+++ b/internal/entity/search/photos_geojson_result.go
@@ -22,6 +22,7 @@ type GeoResult struct {
 	TakenAtLocal   time.Time     `json:"TakenAtLocal" select:"photos.taken_at_local"`
 	TimeZone       string        `json:"TimeZone" select:"photos.time_zone"`
 	PhotoFavorite  bool          `json:"Favorite,omitempty" select:"photos.photo_favorite"`
+	PhotoRating    int           `json:"Rating,omitempty" select:"photos.photo_rating"`
 	PhotoPanorama  bool          `json:"Panorama,omitempty" select:"photos.photo_panorama"`
 	PhotoDuration  time.Duration `json:"Duration,omitempty" select:"photos.photo_duration"`
 	FileID         uint          `json:"-" select:"files.id AS file_id"` // File
@@ -95,6 +96,10 @@ func (photos GeoResults) GeoJSON() ([]byte, error) {
 
 		if p.PhotoFavorite {
 			props["Favorite"] = true
+		}
+
+		if p.PhotoRating > 0 {
+			props["Rating"] = p.PhotoRating
 		}
 
 		feat := geojson.NewPointFeature([]float64{p.Lng(), p.Lat()})

--- a/internal/entity/search/photos_results.go
+++ b/internal/entity/search/photos_results.go
@@ -38,6 +38,8 @@ type Photo struct {
 	PhotoCountry     string        `json:"Country" select:"photos.photo_country"`
 	PhotoStack       int8          `json:"Stack" select:"photos.photo_stack"`
 	PhotoFavorite    bool          `json:"Favorite" select:"photos.photo_favorite"`
+	PhotoRating      int           `json:"Rating" select:"photos.photo_rating"`
+	RatingSrc        string        `json:"RatingSrc,omitempty" select:"photos.rating_src"`
 	PhotoPrivate     bool          `json:"Private" select:"photos.photo_private"`
 	PhotoIso         int           `json:"Iso" select:"photos.photo_iso"`
 	PhotoFocalLength int           `json:"FocalLength" select:"photos.photo_focal_length"`

--- a/internal/form/photo.go
+++ b/internal/form/photo.go
@@ -43,6 +43,8 @@ type Photo struct {
 	Details          Details   `json:"Details"`
 	PhotoStack       int8      `json:"Stack"`
 	PhotoFavorite    bool      `json:"Favorite"`
+	PhotoRating      int       `json:"Rating"`
+	RatingSrc        string    `json:"RatingSrc"`
 	PhotoPrivate     bool      `json:"Private"`
 	PhotoScan        bool      `json:"Scan"`
 	PhotoPanorama    bool      `json:"Panorama"`

--- a/internal/form/search_photos.go
+++ b/internal/form/search_photos.go
@@ -89,6 +89,7 @@ type SearchPhotos struct {
 	Album       string    `form:"album" example:"album:berlin" notes:"Album UID or name, supports * wildcards"`                                                                          // Album UIDs or name
 	Albums      string    `form:"albums" example:"albums:\"South Africa & Birds\"" notes:"Album names, combinable with & or |"`                                                          // Multi search with and/or
 	Quality     int       `form:"quality" notes:"Minimum quality score (1-7)"`                                                                                                           // Photo quality score
+	Rating      int       `form:"rating" example:"rating:3" notes:"Minimum number of stars (1-5)"`                                                                                       // Minimum star rating
 	Added       time.Time `form:"added" example:"added:\"2006-01-02T15:04:05Z\"" time_format:"2006-01-02T15:04:05Z07:00" notes:"Finds content added at or after this time"`              // Pictures added at or after this time
 	Updated     time.Time `form:"updated" example:"updated:\"2006-01-02T15:04:05Z\"" time_format:"2006-01-02T15:04:05Z07:00" notes:"Finds content updated at or after this time"`        // Pictures updated at or after this time
 	Edited      time.Time `form:"edited" example:"edited:\"2006-01-02T15:04:05Z\"" time_format:"2006-01-02T15:04:05Z07:00" notes:"Finds content edited at or after this time"`           // Pictures edited at or after this time

--- a/internal/form/search_photos_geo.go
+++ b/internal/form/search_photos_geo.go
@@ -50,6 +50,7 @@ type SearchPhotosGeo struct {
 	Private     bool      `form:"private" notes:"Finds private content only (except when public:true)"`
 	Review      bool      `form:"review" notes:"Finds content in review"`
 	Quality     int       `form:"quality" notes:"Minimum quality score (1-7)"`
+	Rating      int       `form:"rating" example:"rating:3" notes:"Minimum number of stars (1-5)"`
 	Face        string    `form:"face" notes:"Find pictures with a specific face ID, you can also specify yes, no, new, or a face type"`
 	Faces       string    `form:"faces" example:"faces:yes faces:3" notes:"Minimum number of detected faces (yes means 1)"` // Find or exclude faces if detected.
 	Near        string    `form:"near" example:"near:pqbcf5j446s0futy" notes:"Finds nearby pictures (UID)"`

--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -45,6 +45,7 @@ type Data struct {
 	Subject          string        `meta:"Subject,PersonInImage,ObjectName,HierarchicalSubject,CatalogSets" xmp:"Subject"`
 	Keywords         Keywords      `meta:"Keywords"`
 	Favorite         bool          `meta:"Favorite"`
+	Rating           int           `meta:"Rating" xmp:"Rating"`
 	Notes            string        `meta:"Comment,UserComment"`
 	Artist           string        `meta:"Artist,Creator,By-line,OwnerName,Owner" xmp:"Creator"`
 	Copyright        string        `meta:"Rights,Copyright,CopyrightNotice,WebStatement" xmp:"Rights,Rights.Alt"`

--- a/internal/meta/rating_test.go
+++ b/internal/meta/rating_test.go
@@ -1,0 +1,40 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSON_Rating(t *testing.T) {
+	t.Run("Rated", func(t *testing.T) {
+		data, err := JSON("testdata/rating.json", "")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, 4, data.Rating)
+	})
+}
+
+func TestXMP_Rating(t *testing.T) {
+	t.Run("AttributeForm", func(t *testing.T) {
+		data, err := XMP("testdata/rating.xmp")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, 3, data.Rating)
+	})
+	t.Run("RejectedIsUnrated", func(t *testing.T) {
+		data, err := XMP("testdata/rating_rejected.xmp")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, 0, data.Rating)
+	})
+}

--- a/internal/meta/testdata/rating.json
+++ b/internal/meta/testdata/rating.json
@@ -1,0 +1,8 @@
+[{
+  "SourceFile": "testdata/rating.jpg",
+  "ExifToolVersion": 12.76,
+  "FileName": "rating.jpg",
+  "FileType": "JPEG",
+  "MIMEType": "image/jpeg",
+  "Rating": 4
+}]

--- a/internal/meta/testdata/rating.xmp
+++ b/internal/meta/testdata/rating.xmp
@@ -1,0 +1,9 @@
+<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="XMP Core 4.4.0-Exiv2">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+    xmp:Rating="3"/>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>

--- a/internal/meta/testdata/rating_rejected.xmp
+++ b/internal/meta/testdata/rating_rejected.xmp
@@ -1,0 +1,9 @@
+<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="XMP Core 4.4.0-Exiv2">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+   <xmp:Rating>-1</xmp:Rating>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>

--- a/internal/meta/xmp.go
+++ b/internal/meta/xmp.go
@@ -190,6 +190,12 @@ func (data *Data) XMP(fileName string) (err error) {
 
 	data.Favorite = doc.Favorite()
 
+	// Star rating from xmp:Rating; 0 means the sidecar carries no rating,
+	// so the embedded value (if any) is kept.
+	if v := doc.Rating(); v != 0 {
+		data.Rating = v
+	}
+
 	// Auto-derive keywords from projection and caption text so XMP-only
 	// photos surface in the same searches as EXIF-indexed photos. Mirrors
 	// the EXIF and ExifTool JSON flows (exif.go's ProjectionType/ImageDescription

--- a/internal/meta/xmp_document.go
+++ b/internal/meta/xmp_document.go
@@ -284,6 +284,11 @@ var (
 	// xmpFavoriteAttr: F-Stop favorite attribute on rdf:Description.
 	xmpFavoriteAttr = mustCompile("//rdf:Description/@fstop:favorite")
 
+	// xmpRatingChain: xmp:Rating — the 0–5 star rating written by digiKam,
+	// Lightroom, darktable, and cameras with a rate button. digiKam emits
+	// the attribute form, Adobe applications the element form.
+	xmpRatingChain = chainXPath{elemOrAttr("xmp:Rating")}
+
 	// xmpGPSLatitudeChain reads exif:GPSLatitude; sign composition
 	// with GPSLatitudeRef happens in Lat().
 	xmpGPSLatitudeChain    = chainXPath{elemOrAttr("exif:GPSLatitude")}
@@ -588,6 +593,23 @@ func (doc *XmpDocument) Favorite() bool {
 		return strings.TrimSpace(n.InnerText()) == "1"
 	}
 	return false
+}
+
+// Rating returns the star rating from 1 to 5, or 0 when the file is
+// unrated. Values outside the star range — including -1, which some
+// applications use for "rejected" — are treated as unrated.
+// Priority: xmp:Rating (element or attribute form).
+func (doc *XmpDocument) Rating() int {
+	val := xmpRatingChain.firstNonEmpty(doc.doc)
+	if val == "" {
+		return 0
+	}
+	if f, ok := parseRational(val); ok {
+		if n := int(math.Round(f)); n >= 1 && n <= 5 {
+			return n
+		}
+	}
+	return 0
 }
 
 // License returns the XMP license statement.

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -486,6 +486,11 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			photo.SetCoordinates(data.Lat, data.Lng, data.Altitude, entity.SrcXmp)
 			photo.SetCameraSerial(data.CameraSerial)
 
+			// Update the star rating if the sidecar carries one.
+			if data.Rating > 0 {
+				photo.SetRating(data.Rating, entity.SrcXmp)
+			}
+
 			// Update metadata details.
 			details.SetKeywords(data.Keywords.String(), entity.SrcXmp)
 			details.SetNotes(data.Notes, entity.SrcXmp)
@@ -558,6 +563,11 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			photo.SetTakenAt(data.TakenAt, data.TakenAtLocal, data.TimeZone, entity.SrcMeta)
 			photo.SetCoordinates(data.Lat, data.Lng, data.Altitude, entity.SrcMeta)
 			photo.SetCameraSerial(data.CameraSerial)
+
+			// Update the star rating from embedded metadata.
+			if data.Rating > 0 {
+				photo.SetRating(data.Rating, entity.SrcMeta)
+			}
 
 			// Update metadata details.
 			details.SetKeywords(data.Keywords.String(), entity.SrcMeta)
@@ -742,6 +752,11 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			photo.SetCoordinates(data.Lat, data.Lng, data.Altitude, entity.SrcMeta)
 			photo.SetCameraSerial(data.CameraSerial)
 
+			// Update the star rating from embedded metadata.
+			if data.Rating > 0 {
+				photo.SetRating(data.Rating, entity.SrcMeta)
+			}
+
 			// Update metadata details.
 			details.SetKeywords(data.Keywords.String(), entity.SrcMeta)
 			details.SetNotes(data.Notes, entity.SrcMeta)
@@ -869,6 +884,11 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			photo.SetTakenAt(data.TakenAt, data.TakenAtLocal, data.TimeZone, entity.SrcMeta)
 			photo.SetCoordinates(data.Lat, data.Lng, data.Altitude, entity.SrcMeta)
 			photo.SetCameraSerial(data.CameraSerial)
+
+			// Update the star rating from embedded metadata.
+			if data.Rating > 0 {
+				photo.SetRating(data.Rating, entity.SrcMeta)
+			}
 
 			// Update metadata details.
 			details.SetKeywords(data.Keywords.String(), entity.SrcMeta)


### PR DESCRIPTION
### Description

These changes implement the 5-star rating requested in #713, following the approach @graciousgrey described there: ratings are read from metadata during indexing, flow through the existing source-priority rules, and manual edits made in PhotoPrism always take precedence over re-imports.

**Backend**

- `photos.photo_rating` (0-5) with a paired `photos.rating_src` column, so photos that were explicitly rated 0 stars stay distinguishable from photos that were never rated (no nullable column needed). Both columns are added by GORM auto-migration; no SQL migration files are required.
- `Photo.SetRating(rating, src)` mirrors the `SetCaption` source-priority pattern; out-of-range values are ignored and `NormalizeValues()` clamps the field on form saves.
- Import: `xmp:Rating` is read by the XMP sidecar reader (element and attribute form; `-1`/"rejected" and out-of-range values are treated as unrated per the XMP spec), and the `Rating` tag is read from ExifTool JSON / embedded Exif. Wired into indexing for images, RAW, videos, and XMP sidecars.
- Search: `rating:N` filters by minimum stars (like `quality:`), in both regular and geo search; `Rating`/`RatingSrc` are included in photo results and the GeoJSON feature properties.
- Ratings are written to the YAML sidecar backups and restored from them.

**Frontend**

- Star rating control in the photo edit dialog (clearable Vuetify `v-rating`).
- Picking 1-5 stars saves a `manual` rating; **clearing the stars reverts the photo to "never rated"** (empty rating source) rather than storing a manual 0, so ratings can be picked up from file metadata again on the next index. This felt like the least surprising behavior for "remove my rating" — happy to change it if you'd prefer an explicit manual zero.

**Out of scope here**, per the discussion in #713: writing ratings back to Exif/XMP, and the batch edit dialog / photo viewer sidebar you offered to pick up during review — glad to take a shot at either as a follow-up if useful.

#### Related Issues

- Implements #713

### Acceptance Criteria

- [ ] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work (pending the browser and MariaDB checks below)
- [x] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [ ] Documentation has been / will be updated (docs PR to follow if the feature is accepted)
- [ ] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers
- [ ] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+ (SQLite done; MariaDB pending)

### Tests

New coverage: `internal/entity/photo_rating_test.go` (priority gating, explicit-zero semantics, clamping), `internal/meta/rating_test.go` + testdata (ExifTool JSON, XMP attribute form, XMP rejected), `internal/entity/search/photos_filter_rating_test.go`, `internal/api` `TestUpdatePhotoRating` (full round-trip: set → persisted → outranks metadata → cleared → metadata importable again → out-of-range clamped), and `frontend/tests/vitest/model/photo-rating.test.js` (manual stamping and clear-to-never-rated).

Run in the `photoprism/develop` container (SQLite driver): `go test` for `internal/entity`, `internal/entity/search`, `internal/api` (rating cases), `internal/meta`, `internal/form` — all pass; `gofmt`/`go vet` clean. Frontend: photo model vitest suites pass (127 tests incl. the new ones), `eslint` clean. Still pending before I check the remaining boxes: MariaDB run and the three-browser UI pass.