### PR TITLE
Places: Reuse pooled HTTP client and log failing geocoding host

### DIFF
--- a/internal/service/hub/places/cell.go
+++ b/internal/service/hub/places/cell.go
@@ -50,10 +50,11 @@ func Cell(id string, locale string) (result Location, err error) {
 	}
 
 	var r *http.Response
+	var reqUrl string
 
 	// Query the specified places service URLs.
 	for _, serviceUrl := range LocationServiceUrls {
-		reqUrl := fmt.Sprintf(serviceUrl, id)
+		reqUrl = fmt.Sprintf(serviceUrl, id)
 		if r, err = GetRequest(reqUrl, locale); err == nil {
 			break
 		}
@@ -61,7 +62,7 @@ func Cell(id string, locale string) (result Location, err error) {
 
 	// Failed?
 	if err != nil {
-		log.Errorf("places: %s (location request failed)", err.Error())
+		log.Errorf("places: %s (location request to %s failed)", err.Error(), serviceHost(reqUrl))
 		return result, err
 	} else if r == nil {
 		err = fmt.Errorf("location request could not be performed")

--- a/internal/service/hub/places/latlng.go
+++ b/internal/service/hub/places/latlng.go
@@ -41,10 +41,11 @@ func LatLng(lat, lng float64, locale string) (result Location, err error) {
 	}
 
 	var r *http.Response
+	var reqUrl string
 
 	// Query the specified places service URLs.
 	for _, serviceUrl := range ReverseServiceUrls {
-		reqUrl := fmt.Sprintf("%s?%s", serviceUrl, params)
+		reqUrl = fmt.Sprintf("%s?%s", serviceUrl, params)
 		if r, err = GetRequest(reqUrl, locale); err == nil {
 			break
 		}
@@ -52,7 +53,7 @@ func LatLng(lat, lng float64, locale string) (result Location, err error) {
 
 	// Failed?
 	if err != nil {
-		log.Errorf("places: %s (location request failed)", err.Error())
+		log.Errorf("places: %s (location request to %s failed)", err.Error(), serviceHost(reqUrl))
 		return result, err
 	} else if r == nil {
 		err = fmt.Errorf("location request could not be performed")

--- a/internal/service/hub/places/request.go
+++ b/internal/service/hub/places/request.go
@@ -4,18 +4,52 @@ import (
 	"crypto/sha1" //nolint:gosec // required for upstream signature scheme
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/photoprism/photoprism/pkg/http/header"
 	"github.com/photoprism/photoprism/pkg/http/safe"
 )
 
-// GetRequest fetches the cell ID data from the service URL.
+// httpClient is a shared, connection-pooling HTTP client reused across all
+// geocoding requests. Reusing one client keeps a warm idle-connection pool, so a
+// large index does not open a fresh TLS handshake for every lookup.
+var httpClient = &http.Client{
+	Timeout:   60 * time.Second,
+	Transport: newTransport(),
+}
+
+// newTransport returns an http.Transport tuned for many short geocoding
+// requests: a larger idle-connection pool than the stdlib default to reduce
+// TLS-handshake churn, while keeping the client's idle timeout below the
+// backend's so the client closes idle connections first and avoids the
+// connection-reuse race.
+func newTransport() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConns = 64
+	t.MaxIdleConnsPerHost = 16
+	t.IdleConnTimeout = 90 * time.Second
+	return t
+}
+
+// serviceHost returns the host of a request URL for logging. It drops the query
+// string so request coordinates never reach the logs, and falls back to the raw
+// value if the URL cannot be parsed.
+func serviceHost(reqUrl string) string {
+	if u, err := url.Parse(reqUrl); err == nil && u.Host != "" {
+		return u.Host
+	}
+	return reqUrl
+}
+
+// GetRequest fetches data from the specified service URL. Because these are
+// idempotent GET requests, it retries transient connection-level failures up to
+// Retries times with a linear backoff before giving up.
 func GetRequest(reqUrl string, locale string) (r *http.Response, err error) {
 	var req *http.Request
 
-	// Log request URL.
-	log.Tracef("places: sending request to %s", reqUrl)
+	// Log request host (without query parameters).
+	log.Tracef("places: sending request to %s", serviceHost(reqUrl))
 
 	if _, parseErr := safe.URL(reqUrl); parseErr != nil {
 		return r, fmt.Errorf("places: unsupported request URL scheme")
@@ -48,28 +82,17 @@ func GetRequest(reqUrl string, locale string) (r *http.Response, err error) {
 		req.Header.Set("X-Signature", fmt.Sprintf("%x", sha1.Sum([]byte(Key+reqUrl+Secret)))) //nolint:gosec // upstream expects SHA1
 	}
 
-	// Create new http.Client.
-	//
-	// NOTE: Timeout specifies a time limit for requests made by
-	// this Client. The timeout includes connection time, any
-	// redirects, and reading the response body. The timer remains
-	// running after GetRequest, Head, Post, or Do return and will
-	// interrupt reading of the Response.Body.
-	client := &http.Client{Timeout: 60 * time.Second}
-
-	// Perform request.
+	// Perform the request, retrying transient connection failures on this
+	// idempotent GET with a linear backoff between attempts.
 	for i := 0; i < Retries; i++ {
 		// #nosec G704 reqUrl is parsed and scheme-validated above.
-		r, err = client.Do(req)
-
-		// Ok?
-		if err == nil {
+		if r, err = httpClient.Do(req); err == nil {
 			return r, nil
 		}
 
 		// Wait before trying again?
-		if RetryDelay.Nanoseconds() > 0 {
-			time.Sleep(RetryDelay)
+		if RetryDelay > 0 {
+			time.Sleep(RetryDelay * time.Duration(i+1))
 		}
 	}
 

--- a/internal/service/hub/places/request_test.go
+++ b/internal/service/hub/places/request_test.go
@@ -3,6 +3,7 @@ package places
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -69,4 +70,86 @@ func TestGetRequest(t *testing.T) {
 			t.Fatal("expected URL parse error")
 		}
 	})
+	t.Run("RetryOnConnectionError", func(t *testing.T) {
+		prevRetries := Retries
+		prevDelay := RetryDelay
+		prevAgent := UserAgent
+		prevKey := Key
+		prevSecret := Secret
+		defer func() {
+			Retries = prevRetries
+			RetryDelay = prevDelay
+			UserAgent = prevAgent
+			Key = prevKey
+			Secret = prevSecret
+		}()
+
+		Retries = 3
+		RetryDelay = 0
+		UserAgent = "PhotoPrism/TestSuite"
+		Key = ""
+		Secret = ""
+
+		var attempts int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Drop the connection on the first attempt to simulate a transient
+			// connection-level failure, then answer normally on the retry.
+			if atomic.AddInt32(&attempts, 1) == 1 {
+				if hj, ok := w.(http.Hijacker); ok {
+					if conn, _, hjErr := hj.Hijack(); hjErr == nil {
+						_ = conn.Close()
+						return
+					}
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		resp, err := GetRequest(server.URL+"/v1/reverse", "en")
+		if err != nil {
+			t.Fatalf("expected success after retry, got %v", err)
+		}
+		if resp == nil {
+			t.Fatal("expected response")
+		}
+		_ = resp.Body.Close()
+		if got := atomic.LoadInt32(&attempts); got < 2 {
+			t.Fatalf("expected at least 2 attempts (a retry), got %d", got)
+		}
+	})
+}
+
+func TestServiceHost(t *testing.T) {
+	t.Run("WithQuery", func(t *testing.T) {
+		if got := serviceHost("https://places.photoprism.app/v1/reverse?lat=52.520000&lng=13.405000"); got != "places.photoprism.app" {
+			t.Fatalf("expected host without query, got %q", got)
+		}
+	})
+	t.Run("PathOnly", func(t *testing.T) {
+		if got := serviceHost("https://places.photoprism.xyz/v1/location/1e95998417cc"); got != "places.photoprism.xyz" {
+			t.Fatalf("expected host, got %q", got)
+		}
+	})
+	t.Run("Unparseable", func(t *testing.T) {
+		if got := serviceHost("://nope"); got != "://nope" {
+			t.Fatalf("expected raw fallback, got %q", got)
+		}
+	})
+}
+
+func TestNewTransport(t *testing.T) {
+	tr := newTransport()
+	if tr == nil {
+		t.Fatal("expected transport")
+	}
+	if tr.MaxIdleConnsPerHost != 16 {
+		t.Fatalf("expected MaxIdleConnsPerHost 16, got %d", tr.MaxIdleConnsPerHost)
+	}
+	if tr.MaxIdleConns != 64 {
+		t.Fatalf("expected MaxIdleConns 64, got %d", tr.MaxIdleConns)
+	}
+	if tr.IdleConnTimeout != 90*time.Second {
+		t.Fatalf("expected IdleConnTimeout 90s, got %s", tr.IdleConnTimeout)
+	}
 }

--- a/internal/service/hub/places/search.go
+++ b/internal/service/hub/places/search.go
@@ -48,10 +48,11 @@ func Search(q, locale string, count int) (results SearchResults, err error) {
 	}
 
 	var r *http.Response
+	var reqUrl string
 
 	// Query the specified places service URLs.
 	for _, serviceUrl := range SearchServiceUrls {
-		reqUrl := fmt.Sprintf("%s?%s", serviceUrl, params)
+		reqUrl = fmt.Sprintf("%s?%s", serviceUrl, params)
 		if r, err = GetRequest(reqUrl, locale); err == nil {
 			break
 		}
@@ -59,7 +60,7 @@ func Search(q, locale string, count int) (results SearchResults, err error) {
 
 	// Failed?
 	if err != nil {
-		log.Errorf("places: %s (search request failed)", err.Error())
+		log.Errorf("places: %s (search request to %s failed)", err.Error(), serviceHost(reqUrl))
 		return results, err
 	} else if r == nil {
 		err = fmt.Errorf("search request could not be performed")


### PR DESCRIPTION
## Summary

The geocoding client built a new `http.Client` per request and, on failure, logged only a generic message without naming the service that failed. During large indexes this causes avoidable TLS-handshake churn, and it makes intermittent connection-level errors (e.g. `tls: EOF`) hard to attribute to a specific host.

Scoped to `internal/service/hub/places`:

- **Reuses a single connection-pooling `http.Client`** (larger idle pool than the stdlib default; `IdleConnTimeout` kept below the backend's so the client closes idle connections first) so a large index keeps warm connections instead of opening a fresh TLS handshake per lookup.
- **Retries transient connection-level failures** on these idempotent GETs with a linear backoff.
- **Logs the failing host** (query string stripped, so request coordinates never reach the logs), so a fallback service URL is distinguishable from the primary in the logs.

Successful-request behavior is unchanged; edition URL lists and retry counts are untouched.

## Test plan

- `go test ./internal/service/hub/places/... -count=1` — passes
- `go vet ./internal/service/hub/places/...` — clean
- New tests: pooled-transport wiring, `serviceHost` (host extraction / query stripping / unparseable fallback), and a retry-on-connection-drop case.
