### PR TITLE
Tests: Remove all test write activity within pkg and internal folders

### DIFF
--- a/internal/ai/vision/config_test.go
+++ b/internal/ai/vision/config_test.go
@@ -7,14 +7,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/photoprism/photoprism/internal/ai/vision/ollama"
 	"github.com/photoprism/photoprism/pkg/fs"
 )
 
 func TestOptions(t *testing.T) {
-	var configPath = fs.Abs("testdata")
-	var configFile = filepath.Join(configPath, "vision.yml")
+	configPath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(configPath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(configPath) })
+	configFile := filepath.Join(configPath, "vision.yml")
 
 	t.Run("Save", func(t *testing.T) {
 		// Regenerate the committed fixture deterministically, independent of any ambient

--- a/internal/commands/video_remux_test.go
+++ b/internal/commands/video_remux_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,10 @@ func TestVideoBuildRemuxPlans(t *testing.T) {
 		ffmpeg.SetExclude(video.NewFormats("avi"))
 		t.Cleanup(func() { ffmpeg.SetExclude(saved) })
 
-		relPath := "testdata/remux-excluded.avi"
+		filePath := filepath.Join(t.TempDir(), "testdata")
+		require.NoError(t, os.MkdirAll(filePath, fs.ModeDir))
+		t.Cleanup(func() { _ = os.RemoveAll(filePath) })
+		relPath := filepath.Join(filePath, "remux-excluded.avi")
 		absPath := fs.Abs(relPath)
 		require.NoError(t, os.WriteFile(absPath, []byte("test"), fs.ModeFile))
 		t.Cleanup(func() {

--- a/internal/config/customize/settings_test.go
+++ b/internal/config/customize/settings_test.go
@@ -2,9 +2,13 @@ package customize
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/photoprism/photoprism/pkg/fs"
 )
 
 func TestNewSettings(t *testing.T) {
@@ -79,6 +83,11 @@ func TestSettings_Load(t *testing.T) {
 	})
 }
 func TestSettings_Save(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
+	require.NoError(t, fs.Copy("testdata/settings.yml", filepath.Join(basePath, "settings.yml"), false))
+
 	t.Run("ExistingFilename", func(t *testing.T) {
 		s := NewDefaultSettings()
 
@@ -91,7 +100,7 @@ func TestSettings_Save(t *testing.T) {
 		assert.Equal(t, "onyx", s.UI.Theme)
 		assert.Equal(t, "de", s.UI.Language)
 
-		if err := s.Save("testdata/settings.yml"); err != nil {
+		if err := s.Save(filepath.Join(basePath, "settings.yml")); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -106,18 +115,18 @@ func TestSettings_Save(t *testing.T) {
 		assert.Equal(t, "onyx", s.UI.Theme)
 		assert.Equal(t, "de", s.UI.Language)
 
-		if err := s.Save("testdata/settings_tmp.yml"); err != nil {
+		if err := s.Save(filepath.Join(basePath, "settings_tmp.yml")); err != nil {
 			t.Fatal(err)
 		}
 
 		reloaded := NewDefaultSettings()
-		if err := reloaded.Load("testdata/settings_tmp.yml"); err != nil {
+		if err := reloaded.Load(filepath.Join(basePath, "settings_tmp.yml")); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, false, reloaded.UI.Scrollbar)
 		assert.Equal(t, true, reloaded.UI.ReduceMotion)
 
-		if err := os.Remove("testdata/settings_tmp.yml"); err != nil {
+		if err := os.Remove(filepath.Join(basePath, "settings_tmp.yml")); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/internal/entity/album_yaml_test.go
+++ b/internal/entity/album_yaml_test.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -48,6 +49,7 @@ func TestAlbum_Yaml(t *testing.T) {
 }
 
 func TestAlbum_SaveAsYaml(t *testing.T) {
+	workingDir := filepath.Join(t.TempDir(), "testdata")
 	t.Run("Success", func(t *testing.T) {
 		m := AlbumFixtures.Get("berlin-2019")
 
@@ -57,12 +59,12 @@ func TestAlbum_SaveAsYaml(t *testing.T) {
 			m = *found
 		}
 
-		backupPath := fs.Abs("testdata/TestAlbum_SaveAsYaml")
+		backupPath := filepath.Join(workingDir, "TestAlbum_SaveAsYaml")
 
 		fileName, relName, err := m.YamlFileName(backupPath)
 
 		assert.NoError(t, err)
-		assert.True(t, strings.HasSuffix(fileName, "internal/entity/testdata/TestAlbum_SaveAsYaml/album/as6sg6bxpogaaba9.yml"))
+		assert.True(t, strings.HasSuffix(fileName, "testdata/TestAlbum_SaveAsYaml/album/as6sg6bxpogaaba9.yml"))
 		assert.Equal(t, "album/as6sg6bxpogaaba9.yml", relName)
 
 		if err = m.SaveAsYaml(fileName); err != nil {
@@ -87,7 +89,7 @@ func TestAlbum_SaveAsYaml(t *testing.T) {
 			m = *found
 		}
 
-		backupPath := fs.Abs("testdata/TestAlbum_SaveAsYaml")
+		backupPath := filepath.Join(workingDir, "TestAlbum_SaveAsYaml")
 
 		err := m.SaveAsYaml("")
 
@@ -100,7 +102,7 @@ func TestAlbum_SaveAsYaml(t *testing.T) {
 	t.Run("NoAlbumUID", func(t *testing.T) {
 		m := Album{}
 
-		backupPath := fs.Abs("testdata/TestAlbum_SaveAsYaml")
+		backupPath := filepath.Join(workingDir, "TestAlbum_SaveAsYaml")
 
 		err := m.SaveAsYaml("")
 
@@ -155,10 +157,11 @@ func TestAlbum_YamlFileName(t *testing.T) {
 }
 
 func TestAlbum_SaveBackupYaml(t *testing.T) {
+	workingDir := filepath.Join(t.TempDir(), "testdata")
 	t.Run("Success", func(t *testing.T) {
 		m := AlbumFixtures.Get("berlin-2019")
 
-		backupPath := fs.Abs("testdata/TestAlbum_SaveBackupYaml")
+		backupPath := filepath.Join(workingDir, "TestAlbum_SaveBackupYaml")
 
 		if err := fs.MkdirAll(backupPath); err != nil {
 			t.Fatal(err)
@@ -176,7 +179,7 @@ func TestAlbum_SaveBackupYaml(t *testing.T) {
 	t.Run("NoAlbumUID", func(t *testing.T) {
 		m := Album{}
 
-		backupPath := fs.Abs("testdata/TestAlbum_SaveBackupYaml")
+		backupPath := filepath.Join(workingDir, "TestAlbum_SaveBackupYaml")
 
 		if err := fs.MkdirAll(backupPath); err != nil {
 			t.Fatal(err)

--- a/internal/entity/photo_yaml_test.go
+++ b/internal/entity/photo_yaml_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/photoprism/photoprism/pkg/fs"
 )
@@ -67,104 +68,71 @@ func TestPhoto_YamlFileName(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		m := PhotoFixtures.Get("Photo01")
 		m.PreloadFiles()
-		fileName, relative, err := m.YamlFileName("xxx", "yyy")
+		op := filepath.Join(t.TempDir(), "xxx")
+		fileName, relative, err := m.YamlFileName(op, "yyy")
 		assert.NoError(t, err)
-		assert.Equal(t, "xxx/2790/02/yyy/Photo01.yml", fileName)
+		assert.Equal(t, filepath.Join(op, "2790/02/yyy/Photo01.yml"), fileName)
 		assert.Equal(t, "2790/02/Photo01.yml", relative)
-
-		if err := os.RemoveAll("xxx"); err != nil {
-			t.Fatal(err)
-		}
 	})
 }
 
 func TestPhoto_SaveSidecarYaml(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "yaml")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
 	t.Run("Success", func(t *testing.T) {
 		m := PhotoFixtures.Get("Photo01")
 		m.PreloadFiles()
 
-		basePath := fs.Abs("testdata/yaml")
 		originalsPath := filepath.Join(basePath, "originals")
 		sidecarPath := filepath.Join(basePath, "sidecar")
 
 		t.Logf("originalsPath: %s", originalsPath)
 		t.Logf("sidecarPath: %s", sidecarPath)
 
-		if err := fs.MkdirAll(originalsPath); err != nil {
-			t.Fatal(err)
-			return
-		}
+		require.NoError(t, fs.MkdirAll(originalsPath))
+		require.NoError(t, fs.MkdirAll(sidecarPath))
 
-		if err := fs.MkdirAll(sidecarPath); err != nil {
-			t.Fatal(err)
-			return
-		}
+		require.NoError(t, m.SaveSidecarYaml(originalsPath, sidecarPath))
 
-		if err := m.SaveSidecarYaml(originalsPath, sidecarPath); err != nil {
-			t.Error(err)
-		}
-
-		if err := os.RemoveAll(basePath); err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, os.RemoveAll(originalsPath))
+		require.NoError(t, os.RemoveAll(sidecarPath))
 	})
 	t.Run("PhotoNameEmpty", func(t *testing.T) {
 		m := Photo{}
 		m.PreloadFiles()
 
-		basePath := fs.Abs("testdata/yaml")
 		originalsPath := filepath.Join(basePath, "originals")
 		sidecarPath := filepath.Join(basePath, "sidecar")
 
 		t.Logf("originalsPath: %s", originalsPath)
 		t.Logf("sidecarPath: %s", sidecarPath)
 
-		if err := fs.MkdirAll(originalsPath); err != nil {
-			t.Fatal(err)
-			return
-		}
+		require.NoError(t, fs.MkdirAll(originalsPath))
+		require.NoError(t, fs.MkdirAll(sidecarPath))
 
-		if err := fs.MkdirAll(sidecarPath); err != nil {
-			t.Fatal(err)
-			return
-		}
+		require.Error(t, m.SaveSidecarYaml(originalsPath, sidecarPath))
 
-		err := m.SaveSidecarYaml(originalsPath, sidecarPath)
-
-		assert.Error(t, err)
-
-		if err := os.RemoveAll(basePath); err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, os.RemoveAll(originalsPath))
+		require.NoError(t, os.RemoveAll(sidecarPath))
 	})
 	t.Run("PhotoUIDEmpty", func(t *testing.T) {
 		m := Photo{PhotoName: "testphoto"}
 		m.PreloadFiles()
 
-		basePath := fs.Abs("testdata/yaml")
 		originalsPath := filepath.Join(basePath, "originals")
 		sidecarPath := filepath.Join(basePath, "sidecar")
 
 		t.Logf("originalsPath: %s", originalsPath)
 		t.Logf("sidecarPath: %s", sidecarPath)
 
-		if err := fs.MkdirAll(originalsPath); err != nil {
-			t.Fatal(err)
-			return
-		}
+		require.NoError(t, fs.MkdirAll(originalsPath))
+		require.NoError(t, fs.MkdirAll(sidecarPath))
 
-		if err := fs.MkdirAll(sidecarPath); err != nil {
-			t.Fatal(err)
-			return
-		}
+		require.Error(t, m.SaveSidecarYaml(originalsPath, sidecarPath))
 
-		err := m.SaveSidecarYaml(originalsPath, sidecarPath)
-
-		assert.Error(t, err)
-
-		if err := os.RemoveAll(basePath); err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, os.RemoveAll(originalsPath))
+		require.NoError(t, os.RemoveAll(sidecarPath))
 	})
 }
 

--- a/internal/ffmpeg/extract_image_cmd_test.go
+++ b/internal/ffmpeg/extract_image_cmd_test.go
@@ -16,7 +16,7 @@ func TestExtractImageCmd(t *testing.T) {
 	opt := encode.NewPreviewImageOptions("/usr/bin/ffmpeg", time.Second*9)
 
 	srcName := fs.Abs("./testdata/25fps.vp9")
-	destName := fs.Abs("./testdata/25fps.jpg")
+	destName := filepath.Join(t.TempDir(), "25fps.jpg")
 
 	cmd := ExtractImageCmd(srcName, destName, opt)
 
@@ -33,7 +33,7 @@ func TestExtractJpegImageCmd(t *testing.T) {
 	opt := encode.NewPreviewImageOptions("/usr/bin/ffmpeg", time.Second*9)
 
 	srcName := fs.Abs("./testdata/25fps.vp9")
-	destName := fs.Abs("./testdata/25fps.jpeg")
+	destName := filepath.Join(t.TempDir(), "25fps.jpeg")
 
 	cmd := ExtractJpegImageCmd(srcName, destName, opt)
 
@@ -50,7 +50,7 @@ func TestExtractPngImageCmd(t *testing.T) {
 	opt := encode.NewPreviewImageOptions("/usr/bin/ffmpeg", time.Second*9)
 
 	srcName := fs.Abs("./testdata/25fps.vp9")
-	destName := fs.Abs("./testdata/25fps.png")
+	destName := filepath.Join(t.TempDir(), "25fps.png")
 
 	cmd := ExtractPngImageCmd(srcName, destName, opt)
 

--- a/internal/ffmpeg/remux_test.go
+++ b/internal/ffmpeg/remux_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestRemuxFile(t *testing.T) {
 	ffmpegBin := "/usr/bin/ffmpeg"
+	tempDir := t.TempDir()
 
 	t.Run("NoFilePath", func(t *testing.T) {
 		opt := encode.NewRemuxOptions(ffmpegBin, fs.VideoMp4, false)
@@ -27,9 +28,9 @@ func TestRemuxFile(t *testing.T) {
 
 		// QuickTime MOV container with HVC1 (HEVC) codec.
 		origName := fs.Abs("./testdata/30fps.mov")
-		srcName := fs.Abs("./testdata/30fps.remux-file.mov")
-		tmpName := fs.Abs("./testdata/.30fps.remux-file.mp4")
-		destName := fs.Abs("./testdata/30fps.remux-file.avc")
+		srcName := filepath.Join(tempDir, "testdata", "30fps.remux-file.mov")
+		tmpName := filepath.Join(tempDir, "testdata", "30fps.remux-file.mp4")
+		destName := filepath.Join(tempDir, "testdata", "30fps.remux-file.avc")
 
 		_ = os.Remove(srcName)
 		_ = os.Remove(tmpName)
@@ -57,6 +58,7 @@ func TestRemuxFile(t *testing.T) {
 
 func TestRemuxCmd(t *testing.T) {
 	ffmpegBin := "/usr/bin/ffmpeg"
+	tempDir := t.TempDir()
 
 	t.Run("NoSrcName", func(t *testing.T) {
 		opt := encode.NewRemuxOptions(ffmpegBin, fs.VideoMp4, false)
@@ -70,8 +72,8 @@ func TestRemuxCmd(t *testing.T) {
 		// QuickTime MOV container with HVC1 (HEVC) codec.
 		origName := fs.Abs("./testdata/30fps.mov")
 
-		srcName := fs.Abs("./testdata/30fps.remux-cmd.mov")
-		destName := fs.Abs("./testdata/30fps.remux-cmd.mp4")
+		srcName := filepath.Join(tempDir, "testdata", "30fps.remux-cmd.mov")
+		destName := filepath.Join(tempDir, "testdata", "30fps.remux-cmd.avc")
 
 		_ = os.Remove(srcName)
 		_ = os.Remove(destName)
@@ -103,7 +105,7 @@ func TestRemuxFile_DestExists_NoForce_NoOp(t *testing.T) {
 	opt := encode.NewRemuxOptions("/usr/bin/ffmpeg", fs.VideoMp4, false)
 	dir := fs.Abs("./testdata")
 	src := filepath.Join(dir, "30fps.mov")
-	dest := filepath.Join(dir, "already-there.mp4")
+	dest := filepath.Join(t.TempDir(), "already-there.mp4")
 	// Create a tiny placeholder dest file
 	_ = os.Remove(dest)
 	if err := os.WriteFile(dest, []byte("x"), fs.ModeFile); err != nil {
@@ -119,11 +121,12 @@ func TestRemuxFile_DestExists_NoForce_NoOp(t *testing.T) {
 func TestRemuxFile_TempExists_NoForce_Error(t *testing.T) {
 	opt := encode.NewRemuxOptions("/usr/bin/ffmpeg", fs.VideoMp4, false)
 	dir := fs.Abs("./testdata")
+	tempDir := t.TempDir()
 	// Use a copy to avoid modifying the original during test
-	src := filepath.Join(dir, "30fps.remux-temp.mov")
+	src := filepath.Join(tempDir, "30fps.remux-temp.mov")
 	orig := filepath.Join(dir, "30fps.mov")
-	dest := filepath.Join(dir, "30fps.remux-temp.mp4")
-	temp := filepath.Join(dir, ".30fps.remux-temp.mp4")
+	dest := filepath.Join(tempDir, "30fps.remux-temp.mp4")
+	temp := filepath.Join(tempDir, ".30fps.remux-temp.mp4")
 	// Cleanup
 	_ = os.Remove(src)
 	_ = os.Remove(dest)
@@ -144,7 +147,7 @@ func TestRemuxFile_TempExists_NoForce_Error(t *testing.T) {
 func TestRemuxCmd_VideoTag(t *testing.T) {
 	ffmpegBin := "/usr/bin/ffmpeg"
 	src := fs.Abs("./testdata/30fps.mov")
-	dest := fs.Abs("./testdata/30fps.video-tag.mp4")
+	dest := filepath.Join(t.TempDir(), "testdata/30fps.video-tag.mp4")
 
 	defer func() { _ = os.Remove(dest) }()
 
@@ -192,7 +195,7 @@ func TestRemuxCmd_ErrorPaths_And_DefaultBin(t *testing.T) {
 	// Default ffmpeg bin selected when empty
 	// Use an existing file to pass validation
 	src := fs.Abs("./testdata/30fps.mov")
-	dest := fs.Abs("./testdata/30fps.default-bin.mp4")
+	dest := filepath.Join(t.TempDir(), "testdata/30fps.default-bin.mp4")
 	_ = os.Remove(dest)
 	defer os.Remove(dest)
 	cmd, err := RemuxCmd(src, dest, opt)

--- a/internal/ffmpeg/transcode_cmd_test.go
+++ b/internal/ffmpeg/transcode_cmd_test.go
@@ -41,7 +41,7 @@ func TestTranscodeCmd(t *testing.T) {
 		opt := encode.NewVideoOptions(ffmpegBin, encode.SoftwareAvc, 1500, encode.DefaultQuality, encode.PresetFast, "", "", "")
 
 		srcName := fs.Abs("./testdata/25fps.vp9")
-		destName := fs.Abs("./testdata/25fps.avc")
+		destName := filepath.Join(t.TempDir(), "25fps.avc")
 
 		cmd, _, err := TranscodeCmd(srcName, destName, opt)
 
@@ -62,7 +62,7 @@ func TestTranscodeCmd(t *testing.T) {
 		opt := encode.NewVideoOptions(ffmpegBin, encode.VaapiAvc, 1500, encode.DefaultQuality, encode.PresetFast, "", "", "")
 
 		srcName := fs.Abs("./testdata/25fps.vp9")
-		destName := fs.Abs("./testdata/25fps.vaapi.avc")
+		destName := filepath.Join(t.TempDir(), "25fps.vaapi.avc")
 
 		cmd, _, err := TranscodeCmd(srcName, destName, opt)
 
@@ -86,7 +86,7 @@ func TestTranscodeCmd(t *testing.T) {
 
 		// QuickTime MOV container with HVC1 (HEVC) codec.
 		srcName := fs.Abs("./testdata/30fps.mov")
-		destName := fs.Abs("./testdata/30fps.intel.avc")
+		destName := filepath.Join(t.TempDir(), "30fps.intel.avc")
 
 		cmd, _, err := TranscodeCmd(srcName, destName, opt)
 
@@ -109,7 +109,7 @@ func TestTranscodeCmd(t *testing.T) {
 		opt := encode.NewVideoOptions(ffmpegBin, encode.IntelAvc, 1500, encode.DefaultQuality, encode.PresetFast, "/dev/dri/renderD128", "", "")
 
 		srcName := fs.Abs("./testdata/25fps.vp9")
-		destName := fs.Abs("./testdata/25fps.intel.avc")
+		destName := filepath.Join(t.TempDir(), "25fps.intel.avc")
 
 		cmd, _, err := TranscodeCmd(srcName, destName, opt)
 
@@ -133,7 +133,7 @@ func TestTranscodeCmd(t *testing.T) {
 
 		// QuickTime MOV container with HVC1 (HEVC) codec.
 		srcName := fs.Abs("./testdata/30fps.mov")
-		destName := fs.Abs("./testdata/30fps.nvidia.avc")
+		destName := filepath.Join(t.TempDir(), "30fps.nvidia.avc")
 
 		cmd, _, err := TranscodeCmd(srcName, destName, opt)
 
@@ -156,7 +156,7 @@ func TestTranscodeCmd(t *testing.T) {
 		opt := encode.NewVideoOptions(ffmpegBin, encode.NvidiaAvc, 1500, encode.DefaultQuality, encode.PresetFast, "", "", "")
 
 		srcName := fs.Abs("./testdata/25fps.vp9")
-		destName := fs.Abs("./testdata/25fps.nvidia.avc")
+		destName := filepath.Join(t.TempDir(), "25fps.nvidia.avc")
 
 		cmd, _, err := TranscodeCmd(srcName, destName, opt)
 
@@ -179,7 +179,7 @@ func TestTranscodeCmd(t *testing.T) {
 		opt := encode.NewVideoOptions(ffmpegBin, encode.VulkanAvc, 1500, encode.DefaultQuality, encode.PresetFast, "", "", "")
 
 		srcName := fs.Abs("./testdata/25fps.vp9")
-		destName := fs.Abs("./testdata/25fps.vulkan.avc")
+		destName := filepath.Join(t.TempDir(), "25fps.vulkan.avc")
 
 		cmd, _, err := TranscodeCmd(srcName, destName, opt)
 

--- a/internal/photoprism/backup/albums_test.go
+++ b/internal/photoprism/backup/albums_test.go
@@ -6,20 +6,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/photoprism/photoprism/pkg/fs"
 )
 
 func TestAlbums(t *testing.T) {
-	backupPath, err := filepath.Abs("./testdata/albums")
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err = os.MkdirAll(backupPath, fs.ModeDir); err != nil {
-		t.Fatal(err)
-	}
+	backupPath := filepath.Join(t.TempDir(), "testdata", "albums")
+	require.NoError(t, os.MkdirAll(backupPath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(backupPath) })
 
 	count, err := Albums(backupPath, true)
 
@@ -36,22 +31,12 @@ func TestAlbums(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, count)
-
-	if err = os.RemoveAll(backupPath); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestRestoreAlbums(t *testing.T) {
-	backupPath, err := filepath.Abs("./testdata/albums")
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err = os.MkdirAll(backupPath, fs.ModeDir); err != nil {
-		t.Fatal(err)
-	}
+	backupPath := filepath.Join(t.TempDir(), "testdata", "albums")
+	require.NoError(t, os.MkdirAll(backupPath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(backupPath) })
 
 	count, err := RestoreAlbums(backupPath, true)
 
@@ -60,8 +45,4 @@ func TestRestoreAlbums(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, count)
-
-	if err = os.RemoveAll(backupPath); err != nil {
-		t.Fatal(err)
-	}
 }

--- a/internal/photoprism/backup/database_test.go
+++ b/internal/photoprism/backup/database_test.go
@@ -5,48 +5,24 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/photoprism/photoprism/pkg/fs"
 )
 
 func TestDatabase(t *testing.T) {
 	t.Run("Force", func(t *testing.T) {
-		backupPath, err := filepath.Abs("./testdata/sqlite")
+		backupPath := filepath.Join(t.TempDir(), "testdata", "sqlite")
+		require.NoError(t, os.MkdirAll(backupPath, fs.ModeDir))
+		t.Cleanup(func() { _ = os.RemoveAll(backupPath) })
 
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err = os.MkdirAll(backupPath, fs.ModeDir); err != nil {
-			t.Fatal(err)
-		}
-
-		err = Database(backupPath, "", false, true, 2)
-
-		assert.NoError(t, err)
-
-		if err = os.RemoveAll(backupPath); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, Database(backupPath, "", false, true, 2))
 	})
 	t.Run("ForceStdOut", func(t *testing.T) {
-		backupPath, err := filepath.Abs("./testdata/sqlite")
+		backupPath := filepath.Join(t.TempDir(), "testdata", "sqlite")
+		require.NoError(t, os.MkdirAll(backupPath, fs.ModeDir))
+		t.Cleanup(func() { _ = os.RemoveAll(backupPath) })
 
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err = os.MkdirAll(backupPath, fs.ModeDir); err != nil {
-			t.Fatal(err)
-		}
-
-		err = Database(backupPath, "", true, true, 2)
-
-		assert.NoError(t, err)
-
-		if err = os.RemoveAll(backupPath); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, Database(backupPath, "", true, true, 2))
 	})
 }

--- a/internal/photoprism/backup/storage_test.go
+++ b/internal/photoprism/backup/storage_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestAlbums_InsufficientStorage(t *testing.T) {
-	backupPath, err := filepath.Abs("./testdata/albums-insufficient")
-	require.NoError(t, err)
+	backupPath := filepath.Join(t.TempDir(), "testdata", "albums-insufficient")
 	require.NoError(t, os.MkdirAll(backupPath, fs.ModeDir))
 	t.Cleanup(func() { _ = os.RemoveAll(backupPath) })
 
@@ -34,8 +33,7 @@ func TestAlbums_InsufficientStorage(t *testing.T) {
 }
 
 func TestDatabase_InsufficientStorage(t *testing.T) {
-	backupPath, err := filepath.Abs("./testdata/sqlite-insufficient")
-	require.NoError(t, err)
+	backupPath := filepath.Join(t.TempDir(), "testdata", "sqlite-insufficient")
 	require.NoError(t, os.MkdirAll(backupPath, fs.ModeDir))
 	t.Cleanup(func() { _ = os.RemoveAll(backupPath) })
 
@@ -44,7 +42,7 @@ func TestDatabase_InsufficientStorage(t *testing.T) {
 	t.Cleanup(disk.FlushFree)
 	disk.SetFree(conf.StoragePath(), 1*disk.MB, 1000*disk.MB)
 
-	err = Database(backupPath, "", false, true, 2)
+	err := Database(backupPath, "", false, true, 2)
 
 	assert.True(t, errors.Is(err, status.ErrInsufficientStorage), "expected status.ErrInsufficientStorage, got %v", err)
 }

--- a/internal/photoprism/mediafile_thumbs_test.go
+++ b/internal/photoprism/mediafile_thumbs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/photoprism/photoprism/internal/config"
 	"github.com/photoprism/photoprism/internal/thumb"
@@ -180,8 +181,11 @@ func TestMediaFile_SkipThumbnailSize(t *testing.T) {
 
 func TestMediaFile_GenerateThumbnails(t *testing.T) {
 	c := config.TestConfig()
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
 
-	thumbsPath := "./.test_mediafile_createthumbnails"
+	thumbsPath := filepath.Join(basePath, ".test_mediafile_createthumbnails")
 
 	if p, err := filepath.Abs(thumbsPath); err != nil {
 		t.Fatal(err)
@@ -288,8 +292,15 @@ func TestMediaFile_GenerateThumbnails(t *testing.T) {
 }
 
 func TestMediaFile_ChangeOrientation(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
+
+	require.NoError(t, fs.Copy("testdata/orientation.jpg", filepath.Join(basePath, "orientation.jpg"), false))
+	require.NoError(t, fs.Copy("testdata/orientation.png", filepath.Join(basePath, "orientation.png"), false))
+
 	t.Run("JPEG", func(t *testing.T) {
-		m, err := NewMediaFile("testdata/orientation.jpg")
+		m, err := NewMediaFile(filepath.Join(basePath, "orientation.jpg"))
 
 		if err != nil {
 			t.Fatal(err)
@@ -306,7 +317,7 @@ func TestMediaFile_ChangeOrientation(t *testing.T) {
 		}
 	})
 	t.Run("PNG", func(t *testing.T) {
-		m, err := NewMediaFile("testdata/orientation.png")
+		m, err := NewMediaFile(filepath.Join(basePath, "orientation.png"))
 
 		if err != nil {
 			t.Fatal(err)

--- a/internal/service/hub/hub_test.go
+++ b/internal/service/hub/hub_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -206,14 +207,15 @@ func TestConfig_Save(t *testing.T) {
 		assert.Equal(t, Status("unregistered"), c.Status)
 		assert.Equal(t, "test", c.Version)
 
-		c.FileName = "testdata/hub-save.yml"
+		testFileName := filepath.Join(t.TempDir(), "testdata/hub-save.yml")
+		c.FileName = testFileName
 
 		if err := c.Save(); err != nil {
 			t.Fatal(err)
 		}
 
 		t.Cleanup(func() {
-			if err := os.Remove("testdata/hub-save.yml"); err != nil {
+			if err := os.Remove(testFileName); err != nil {
 				t.Errorf("failed removing testdata/hub-save.yml: %v", err)
 			}
 		})
@@ -224,7 +226,7 @@ func TestConfig_Save(t *testing.T) {
 		assert.Equal(t, Status("unregistered"), c.Status)
 		assert.Equal(t, "test", c.Version)
 
-		assert.FileExists(t, "testdata/hub-save.yml")
+		assert.FileExists(t, testFileName)
 
 		if err := c.Load(); err != nil {
 			t.Log(err.Error())
@@ -237,7 +239,8 @@ func TestConfig_Save(t *testing.T) {
 		assert.Equal(t, "test", c.Version)
 	})
 	t.Run("NotExistingFilename", func(t *testing.T) {
-		c := NewConfig("test", "testdata/hub_new.yml", "zqkunt22r0bewti9", "test", "PhotoPrism/Test", "test")
+		testFileName := filepath.Join(t.TempDir(), "testdata/hub-hub_new.yml")
+		c := NewConfig("test", testFileName, "zqkunt22r0bewti9", "test", "PhotoPrism/Test", "test")
 		c.Key = "F60F5B25D59C397989E3CD374F81CDD7710A4FCA"
 		c.Secret = "foo"
 		c.Session = "bar"
@@ -254,9 +257,9 @@ func TestConfig_Save(t *testing.T) {
 		assert.Equal(t, "", c.Secret)
 		assert.Equal(t, "", c.Session)
 
-		assert.FileExists(t, "testdata/hub_new.yml")
+		assert.FileExists(t, testFileName)
 
-		if err := os.Remove("testdata/hub_new.yml"); err != nil {
+		if err := os.Remove(testFileName); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/internal/thumb/create_test.go
+++ b/internal/thumb/create_test.go
@@ -3,10 +3,12 @@ package thumb
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/photoprism/photoprism/pkg/fs"
 )
@@ -147,27 +149,31 @@ func TestSuffix(t *testing.T) {
 }
 
 func TestFileName(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
+
 	t.Run("Colors", func(t *testing.T) {
 		colorThumb := Sizes[Colors]
 
-		result, err := FileName("123456789098765432", "testdata", colorThumb.Width, colorThumb.Height, colorThumb.Options...)
+		result, err := FileName("123456789098765432", basePath, colorThumb.Width, colorThumb.Height, colorThumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "testdata/1/2/3/123456789098765432_3x3_resize.png", result)
+		assert.Equal(t, filepath.Join(basePath, "1/2/3/123456789098765432_3x3_resize.png"), result)
 	})
 	t.Run("FitNum720", func(t *testing.T) {
 		fit720 := Sizes[Fit720]
 
-		result, err := FileName("123456789098765432", "testdata", fit720.Width, fit720.Height, fit720.Options...)
+		result, err := FileName("123456789098765432", basePath, fit720.Width, fit720.Height, fit720.Options...)
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "testdata/1/2/3/123456789098765432_720x720_fit.jpg", result)
+		assert.Equal(t, filepath.Join(basePath, "1/2/3/123456789098765432_720x720_fit.jpg"), result)
 	})
 	t.Run("InvalidWidth", func(t *testing.T) {
 		colorThumb := Sizes[Colors]
@@ -219,10 +225,14 @@ func TestFileName(t *testing.T) {
 }
 
 func TestResolvedName(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
+
 	t.Run("Colors", func(t *testing.T) {
 		colorThumb := Sizes[Colors]
 
-		result, err := ResolvedName("123456789098765432", "testdata", colorThumb.Width, colorThumb.Height, colorThumb.Options...)
+		result, err := ResolvedName("123456789098765432", basePath, colorThumb.Width, colorThumb.Height, colorThumb.Options...)
 
 		assert.Error(t, err)
 		assert.Equal(t, "", result)
@@ -230,7 +240,7 @@ func TestResolvedName(t *testing.T) {
 	t.Run("FitNum720", func(t *testing.T) {
 		fit720 := Sizes[Fit720]
 
-		result, err := ResolvedName("123456789098765432", "testdata", fit720.Width, fit720.Height, fit720.Options...)
+		result, err := ResolvedName("123456789098765432", basePath, fit720.Width, fit720.Height, fit720.Options...)
 
 		assert.Error(t, err)
 		assert.Equal(t, "", result)
@@ -285,14 +295,17 @@ func TestResolvedName(t *testing.T) {
 }
 
 func TestFromFile(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(target, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(target) })
 	t.Run("Colors", func(t *testing.T) {
 		colorThumb := Sizes[Colors]
 		src := "testdata/example.gif"
-		dst := "testdata/1/2/3/123456789098765432_3x3_resize.png"
+		dst := filepath.Join(target, "/1/2/3/123456789098765432_3x3_resize.png")
 
 		assert.FileExists(t, src)
 
-		fileName, err := FromFile(src, "123456789098765432", "testdata", colorThumb.Width, colorThumb.Height, OrientationNormal, colorThumb.Options...)
+		fileName, err := FromFile(src, "123456789098765432", target, colorThumb.Width, colorThumb.Height, OrientationNormal, colorThumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -304,11 +317,11 @@ func TestFromFile(t *testing.T) {
 	t.Run("OrientationGreaterThanOne", func(t *testing.T) {
 		colorThumb := Sizes[Colors]
 		src := "testdata/example.gif"
-		dst := "testdata/1/2/3/123456789098765432_3x3_resize.png"
+		dst := filepath.Join(target, "/1/2/3/123456789098765432_3x3_resize.png")
 
 		assert.FileExists(t, src)
 
-		fileName, err := FromFile(src, "123456789098765432", "testdata", colorThumb.Width, colorThumb.Height, 3, colorThumb.Options...)
+		fileName, err := FromFile(src, "123456789098765432", target, colorThumb.Width, colorThumb.Height, 3, colorThumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -323,7 +336,7 @@ func TestFromFile(t *testing.T) {
 
 		assert.NoFileExists(t, src)
 
-		fileName, err := FromFile(src, "193456789098765432", "testdata", colorThumb.Width, colorThumb.Height, OrientationNormal, colorThumb.Options...)
+		fileName, err := FromFile(src, "193456789098765432", target, colorThumb.Width, colorThumb.Height, OrientationNormal, colorThumb.Options...)
 
 		assert.Equal(t, "", fileName)
 		assert.Error(t, err)
@@ -331,7 +344,7 @@ func TestFromFile(t *testing.T) {
 	t.Run("EmptyFilename", func(t *testing.T) {
 		colorThumb := Sizes[Colors]
 
-		fileName, err := FromFile("", "193456789098765432", "testdata", colorThumb.Width, colorThumb.Height, OrientationNormal, colorThumb.Options...)
+		fileName, err := FromFile("", "193456789098765432", target, colorThumb.Width, colorThumb.Height, OrientationNormal, colorThumb.Options...)
 
 		if err == nil {
 			t.Fatal("error expected")
@@ -342,13 +355,17 @@ func TestFromFile(t *testing.T) {
 }
 
 func TestFromCache(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
+
 	t.Run("MissingThumb", func(t *testing.T) {
 		tile50 := Sizes[Tile50]
 		src := "testdata/example.jpg"
 
 		assert.FileExists(t, src)
 
-		fileName, err := FromCache(src, "193456789098765432", "testdata", tile50.Width, tile50.Height, tile50.Options...)
+		fileName, err := FromCache(src, "193456789098765432", basePath, tile50.Width, tile50.Height, tile50.Options...)
 
 		assert.Equal(t, "", fileName)
 
@@ -362,7 +379,7 @@ func TestFromCache(t *testing.T) {
 
 		assert.NoFileExists(t, src)
 
-		fileName, err := FromCache(src, "193456789098765432", "testdata", tile50.Width, tile50.Height, tile50.Options...)
+		fileName, err := FromCache(src, "193456789098765432", basePath, tile50.Width, tile50.Height, tile50.Options...)
 
 		assert.Equal(t, "", fileName)
 		assert.Error(t, err)
@@ -397,10 +414,14 @@ func TestFromCache(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(target, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(target) })
+
 	t.Run("TileNum500", func(t *testing.T) {
 		tile500 := Sizes[Tile500]
 		src := "testdata/example.jpg"
-		dst := "testdata/example.tile_500.jpg"
+		dst := filepath.Join(target, "example.tile_500.jpg")
 
 		assert.FileExists(t, src)
 		assert.NoFileExists(t, dst)
@@ -437,7 +458,7 @@ func TestCreate(t *testing.T) {
 	t.Run("WidthHeightLessOrEqualNum150", func(t *testing.T) {
 		tile500 := Sizes[Tile500]
 		src := "testdata/example.jpg"
-		dst := "testdata/example.tile_500.jpg"
+		dst := filepath.Join(target, "example.tile_500.jpg")
 
 		assert.FileExists(t, src)
 		assert.NoFileExists(t, dst)
@@ -474,7 +495,7 @@ func TestCreate(t *testing.T) {
 	t.Run("InvalidWidth", func(t *testing.T) {
 		tile500 := Sizes[Tile500]
 		src := "testdata/example.jpg"
-		dst := "testdata/example.tile_500.jpg"
+		dst := filepath.Join(target, "example.tile_500.jpg")
 
 		assert.FileExists(t, src)
 		assert.NoFileExists(t, dst)
@@ -501,7 +522,7 @@ func TestCreate(t *testing.T) {
 	t.Run("InvalidHeight", func(t *testing.T) {
 		tile500 := Sizes[Tile500]
 		src := "testdata/example.jpg"
-		dst := "testdata/example.tile_500.jpg"
+		dst := filepath.Join(target, "example.tile_500.jpg")
 
 		assert.FileExists(t, src)
 		assert.NoFileExists(t, dst)

--- a/internal/thumb/frame/collage_test.go
+++ b/internal/thumb/frame/collage_test.go
@@ -3,6 +3,7 @@ package frame
 import (
 	"image"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/photoprism/photoprism/internal/thumb"
@@ -10,9 +11,14 @@ import (
 	"github.com/photoprism/photoprism/pkg/http/header"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCollage(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
+
 	t.Run("Polaroid", func(t *testing.T) {
 		var images []image.Image
 
@@ -23,7 +29,7 @@ func TestCollage(t *testing.T) {
 			images = append(images, img)
 		}
 
-		saveName := "testdata/test-polaroid-collage.jpg"
+		saveName := filepath.Join(basePath, "test-polaroid-collage.jpg")
 		preview, err := Collage(Polaroid, images)
 
 		assert.NoError(t, err)
@@ -46,7 +52,7 @@ func TestCollage(t *testing.T) {
 			images = append(images, img)
 		}
 
-		saveName := "testdata/test-polaroid-collage-two.jpg"
+		saveName := filepath.Join(basePath, "test-polaroid-collage-two.jpg")
 		preview, err := Collage(Polaroid, images)
 
 		assert.NoError(t, err)
@@ -62,7 +68,7 @@ func TestCollage(t *testing.T) {
 	t.Run("NoImages", func(t *testing.T) {
 		var images []image.Image
 
-		saveName := "testdata/test-no-images-collage.jpg"
+		saveName := filepath.Join(basePath, "test-no-images-collage.jpg")
 		preview, err := Collage(Polaroid, images)
 
 		assert.NoError(t, err)
@@ -85,7 +91,7 @@ func TestCollage(t *testing.T) {
 			images = append(images, img)
 		}
 
-		saveName := "testdata/test-unknown-type-collage.jpg"
+		saveName := filepath.Join(basePath, "test-unknown-type-collage.jpg")
 
 		preview, err := Collage("Unknown", images)
 

--- a/internal/thumb/frame/image_test.go
+++ b/internal/thumb/frame/image_test.go
@@ -2,6 +2,7 @@ package frame
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/photoprism/photoprism/internal/thumb"
@@ -9,14 +10,19 @@ import (
 	"github.com/photoprism/photoprism/pkg/http/header"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImage(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
+
 	t.Run("Polaroid", func(t *testing.T) {
 		img, _, err := fs.DecodeImageFile("testdata/500x500.jpg")
 		assert.NoError(t, err)
 
-		saveName := "testdata/test-image.png"
+		saveName := filepath.Join(basePath, "test-image.png")
 
 		out, err := Image(Polaroid, img, RandomAngle(30))
 
@@ -34,7 +40,7 @@ func TestImage(t *testing.T) {
 		img, _, err := fs.DecodeImageFile("testdata/500x500.jpg")
 		assert.NoError(t, err)
 
-		saveName := "testdata/test-image.png"
+		saveName := filepath.Join(basePath, "test-image.png")
 
 		out, err := Image("unknown", img, RandomAngle(30))
 

--- a/internal/thumb/frame/polaroid_test.go
+++ b/internal/thumb/frame/polaroid_test.go
@@ -2,6 +2,7 @@ package frame
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/photoprism/photoprism/internal/thumb"
@@ -9,14 +10,19 @@ import (
 	"github.com/photoprism/photoprism/pkg/http/header"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPolaroid(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
+
 	t.Run("RandomAngle", func(t *testing.T) {
 		img, _, err := fs.DecodeImageFile("testdata/500x500.jpg")
 		assert.NoError(t, err)
 
-		saveName := "testdata/test-polaroid.png"
+		saveName := filepath.Join(basePath, "test-polaroid.png")
 
 		out, err := polaroid(img, RandomAngle(30))
 

--- a/internal/thumb/jpeg_test.go
+++ b/internal/thumb/jpeg_test.go
@@ -12,12 +12,15 @@ import (
 )
 
 func TestJpeg(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
 	formats := []string{"bmp", "gif", "png", "tif"}
 
 	for _, ext := range formats {
 		t.Run(ext, func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -39,7 +42,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("OrientationFlipH", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -61,7 +64,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("OrientationFlipV", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -83,7 +86,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("OrientationRotate90", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -105,7 +108,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("OrientationRotate180", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -127,7 +130,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("OrientationTranspose", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -149,7 +152,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("OrientationTransverse", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -171,7 +174,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("OrientationUnspecified", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -193,7 +196,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("OrientationNormal", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 
@@ -215,7 +218,7 @@ func TestJpeg(t *testing.T) {
 		})
 		t.Run("InvalidOrientation", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtJpeg
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtJpeg)
 
 			assert.NoFileExists(t, dst)
 

--- a/internal/thumb/png_test.go
+++ b/internal/thumb/png_test.go
@@ -12,12 +12,15 @@ import (
 )
 
 func TestPng(t *testing.T) {
+	basePath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(basePath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(basePath) })
 	formats := []string{"bmp", "gif", "tif"}
 
 	for _, ext := range formats {
 		t.Run(ext, func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -39,7 +42,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("OrientationFlipH", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -61,7 +64,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("OrientationFlipV", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -83,7 +86,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("OrientationRotate90", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -105,7 +108,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("OrientationRotate180", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -127,7 +130,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("OrientationTranspose", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -149,7 +152,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("OrientationTransverse", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -171,7 +174,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("OrientationUnspecified", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -193,7 +196,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("OrientationNormal", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 
@@ -215,7 +218,7 @@ func TestPng(t *testing.T) {
 		})
 		t.Run("InvalidOrientation", func(t *testing.T) {
 			src := "testdata/example." + ext
-			dst := "testdata/example." + ext + fs.ExtPng
+			dst := filepath.Join(basePath, "example."+ext+fs.ExtPng)
 
 			assert.NoFileExists(t, dst)
 

--- a/internal/thumb/size_test.go
+++ b/internal/thumb/size_test.go
@@ -2,6 +2,7 @@ package thumb
 
 import (
 	"image"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,11 +120,13 @@ func TestSize_Skip(t *testing.T) {
 func TestSize_FileName(t *testing.T) {
 	size := Sizes[Fit2048]
 
-	r, err := size.FileName("193456789098765432", "testdata/cache")
+	basePath := filepath.Join(t.TempDir(), "cache")
+
+	r, err := size.FileName("193456789098765432", basePath)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, r, "testdata/cache/1/9/3/193456789098765432_2048x2048_fit.jpg")
+	assert.Equal(t, r, filepath.Join(basePath, "1/9/3/193456789098765432_2048x2048_fit.jpg"))
 }

--- a/internal/thumb/vips_rotate_test.go
+++ b/internal/thumb/vips_rotate_test.go
@@ -2,21 +2,24 @@ package thumb
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/davidbyttow/govips/v2/vips"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/photoprism/photoprism/pkg/fs"
 )
 
 func TestVipsRotate(t *testing.T) {
-	if err := os.MkdirAll("testdata/vips/rotate", fs.ModeDir); err != nil {
-		t.Fatal(err)
-	}
+	target := filepath.Join(t.TempDir(), "testdata", "vips", "rotate")
+	require.NoError(t, os.MkdirAll(target, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(target) })
+
 	t.Run("OrientationNormal", func(t *testing.T) {
 		src := "testdata/example.jpg"
-		dst := "testdata/vips/rotate/0.jpg"
+		dst := filepath.Join(target, "0.jpg")
 
 		assert.FileExists(t, src)
 
@@ -48,7 +51,7 @@ func TestVipsRotate(t *testing.T) {
 	})
 	t.Run("OrientationRotate90", func(t *testing.T) {
 		src := "testdata/example.jpg"
-		dst := "testdata/vips/rotate/90.jpg"
+		dst := filepath.Join(target, "90.jpg")
 
 		assert.FileExists(t, src)
 
@@ -80,7 +83,7 @@ func TestVipsRotate(t *testing.T) {
 	})
 	t.Run("OrientationRotate180", func(t *testing.T) {
 		src := "testdata/example.jpg"
-		dst := "testdata/vips/rotate/180.jpg"
+		dst := filepath.Join(target, "180.jpg")
 
 		assert.FileExists(t, src)
 
@@ -112,7 +115,7 @@ func TestVipsRotate(t *testing.T) {
 	})
 	t.Run("OrientationRotate270", func(t *testing.T) {
 		src := "testdata/example.jpg"
-		dst := "testdata/vips/rotate/270.jpg"
+		dst := filepath.Join(target, "270.jpg")
 
 		assert.FileExists(t, src)
 

--- a/internal/thumb/vips_test.go
+++ b/internal/thumb/vips_test.go
@@ -2,22 +2,30 @@ package thumb
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/davidbyttow/govips/v2/vips"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/photoprism/photoprism/pkg/fs"
 )
 
 func TestVips(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "testdata", "vips")
+	require.NoError(t, os.MkdirAll(target, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(target) })
 	t.Run("Colors", func(t *testing.T) {
 		colorThumb := Sizes[Colors]
 		src := "testdata/example.gif"
-		dst := "testdata/vips/1/2/3/123456789098765432_3x3_resize.png"
+		dst := filepath.Join(target, "1/2/3/123456789098765432_3x3_resize.png")
 
 		assert.FileExists(t, src)
 
-		fileName, _, err := Vips(src, nil, "123456789098765432", "testdata/vips", colorThumb.Width, colorThumb.Height, colorThumb.Options...)
+		fileName, _, err := Vips(src, nil, "123456789098765432", target, colorThumb.Width, colorThumb.Height, colorThumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -33,11 +41,11 @@ func TestVips(t *testing.T) {
 		// export and indexing succeeds.
 		colorThumb := Sizes[Colors]
 		src := "testdata/icc_profile_bad_length.jpg"
-		dst := "testdata/vips/1/4/4/144456789098765432_3x3_resize.png"
+		dst := filepath.Join(target, "1/4/4/144456789098765432_3x3_resize.png")
 
 		assert.FileExists(t, src)
 
-		fileName, _, err := Vips(src, nil, "144456789098765432", "testdata/vips", colorThumb.Width, colorThumb.Height, colorThumb.Options...)
+		fileName, _, err := Vips(src, nil, "144456789098765432", target, colorThumb.Width, colorThumb.Height, colorThumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -57,7 +65,7 @@ func TestVips(t *testing.T) {
 		// raw-pixel sampling, so an ICC chunk is wasted bytes on every photo.
 		colorThumb := Sizes[Colors]
 		src := "testdata/interop_index_srgb_icc.jpg"
-		dst := "testdata/vips/1/5/5/155456789098765432_3x3_resize.png"
+		dst := filepath.Join(target, "1/5/5/155456789098765432_3x3_resize.png")
 
 		assert.FileExists(t, src)
 
@@ -66,7 +74,7 @@ func TestVips(t *testing.T) {
 		assert.True(t, srcimg.HasICCProfile(), "fixture sanity: input must carry an ICC profile")
 		srcimg.Close()
 
-		fileName, _, err := Vips(src, nil, "155456789098765432", "testdata/vips", colorThumb.Width, colorThumb.Height, colorThumb.Options...)
+		fileName, _, err := Vips(src, nil, "155456789098765432", target, colorThumb.Width, colorThumb.Height, colorThumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -85,9 +93,9 @@ func TestVips(t *testing.T) {
 		// must preserve a valid ICC profile end-to-end. Guards against a
 		// future regression that would generalize the strip to all PNGs.
 		src := "testdata/interop_index_srgb_icc.jpg"
-		dst := "testdata/vips/1/6/6/166456789098765432_3x3_resize.png"
+		dst := filepath.Join(target, "1/6/6/166456789098765432_3x3_resize.png")
 
-		fileName, _, err := Vips(src, nil, "166456789098765432", "testdata/vips", 3, 3, ResampleResize, ResampleNearestNeighbor, ResamplePng)
+		fileName, _, err := Vips(src, nil, "166456789098765432", target, 3, 3, ResampleResize, ResampleNearestNeighbor, ResamplePng)
 
 		if err != nil {
 			t.Fatal(err)
@@ -104,11 +112,11 @@ func TestVips(t *testing.T) {
 	t.Run("InteropIndexColors", func(t *testing.T) {
 		thumb := Sizes[Tile500]
 		src := "testdata/interop_index.jpg"
-		dst := "testdata/vips/1/3/3/133456789098765432_500x500_center.jpg"
+		dst := filepath.Join(target, "1/3/3/133456789098765432_500x500_center.jpg")
 
 		assert.FileExists(t, src)
 
-		fileName, _, err := Vips(src, nil, "133456789098765432", "testdata/vips", thumb.Width, thumb.Height, thumb.Options...)
+		fileName, _, err := Vips(src, nil, "133456789098765432", target, thumb.Width, thumb.Height, thumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -127,11 +135,11 @@ func TestVips(t *testing.T) {
 	t.Run("Left224", func(t *testing.T) {
 		thumb := SizeLeft224
 		src := "testdata/fixed.jpg"
-		dst := "testdata/vips/1/2/3/123456789098765432_224x224_left.jpg"
+		dst := filepath.Join(target, "1/2/3/123456789098765432_224x224_left.jpg")
 
 		assert.FileExists(t, src)
 
-		fileName, _, err := Vips(src, nil, "123456789098765432", "testdata/vips", thumb.Width, thumb.Height, thumb.Options...)
+		fileName, _, err := Vips(src, nil, "123456789098765432", target, thumb.Width, thumb.Height, thumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -144,12 +152,12 @@ func TestVips(t *testing.T) {
 		large := Sizes[Tile500]
 		small := Sizes[Tile224]
 		srcName := "testdata/example.jpg"
-		dstLarge := "testdata/vips/1/2/3/123456789098765432_500x500_center.jpg"
-		dstSmall := "testdata/vips/1/2/3/123456789098765432_224x224_center.jpg"
+		dstLarge := filepath.Join(target, "1/2/3/123456789098765432_500x500_center.jpg")
+		dstSmall := filepath.Join(target, "1/2/3/123456789098765432_224x224_center.jpg")
 
 		assert.FileExists(t, srcName)
 
-		thumbName, thumbBuffer, err := Vips(srcName, nil, "123456789098765432", "testdata/vips", large.Width, large.Height, large.Options...)
+		thumbName, thumbBuffer, err := Vips(srcName, nil, "123456789098765432", target, large.Width, large.Height, large.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -158,7 +166,7 @@ func TestVips(t *testing.T) {
 		assert.True(t, strings.HasSuffix(thumbName, dstLarge))
 		assert.FileExists(t, dstLarge)
 
-		thumbName, _, err = Vips(srcName, thumbBuffer, "123456789098765432", "testdata/vips", small.Width, small.Height, small.Options...)
+		thumbName, _, err = Vips(srcName, thumbBuffer, "123456789098765432", target, small.Width, small.Height, small.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -186,11 +194,11 @@ func TestVips(t *testing.T) {
 	t.Run("Fit1920", func(t *testing.T) {
 		thumb := Sizes[Fit1920]
 		src := "testdata/example.jpg"
-		dst := "testdata/vips/1/2/3/123456789098765432_1920x1200_fit.jpg"
+		dst := filepath.Join(target, "1/2/3/123456789098765432_1920x1200_fit.jpg")
 
 		assert.FileExists(t, src)
 
-		fileName, _, err := Vips(src, nil, "123456789098765432", "testdata/vips", thumb.Width, thumb.Height, thumb.Options...)
+		fileName, _, err := Vips(src, nil, "123456789098765432", target, thumb.Width, thumb.Height, thumb.Options...)
 
 		if err != nil {
 			t.Fatal(err)
@@ -205,7 +213,7 @@ func TestVips(t *testing.T) {
 
 		assert.NoFileExists(t, src)
 
-		fileName, _, err := Vips(src, nil, "193456789098765432", "testdata/vips", colorThumb.Width, colorThumb.Height, colorThumb.Options...)
+		fileName, _, err := Vips(src, nil, "193456789098765432", target, colorThumb.Width, colorThumb.Height, colorThumb.Options...)
 
 		assert.Equal(t, "", fileName)
 		assert.Error(t, err)
@@ -213,7 +221,7 @@ func TestVips(t *testing.T) {
 	t.Run("EmptyFilename", func(t *testing.T) {
 		colorThumb := Sizes[Colors]
 
-		fileName, _, err := Vips("", nil, "193456789098765432", "testdata/vips", colorThumb.Width, colorThumb.Height, colorThumb.Options...)
+		fileName, _, err := Vips("", nil, "193456789098765432", target, colorThumb.Width, colorThumb.Height, colorThumb.Options...)
 
 		if err == nil {
 			t.Fatal("error expected")

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMain executes runTestMain returning it's results.  It is done this way so that defer can be used to cleanup.
@@ -155,13 +157,16 @@ func TestDirIsEmpty(t *testing.T) {
 		assert.Equal(t, false, DirIsEmpty("./xxx"))
 	})
 	t.Run("EmptyDir", func(t *testing.T) {
-		if err := os.Mkdir("./testdata/emptyDir", 0o750); err != nil {
+		testPath := filepath.Join(t.TempDir(), "testdata")
+		require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+		t.Cleanup(func() { _ = os.RemoveAll(testPath) })
+		if err := os.Mkdir(filepath.Join(testPath, "emptyDir"), 0o750); err != nil {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() {
-			assert.NoError(t, os.RemoveAll("./testdata/emptyDir"))
+			assert.NoError(t, os.RemoveAll(filepath.Join(testPath, "emptyDir")))
 		})
-		assert.Equal(t, true, DirIsEmpty("./testdata/emptyDir"))
+		assert.Equal(t, true, DirIsEmpty(filepath.Join(testPath, "emptyDir")))
 	})
 }
 

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"fmt"
-	"io/fs"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -158,11 +157,9 @@ func TestDirIsEmpty(t *testing.T) {
 	})
 	t.Run("EmptyDir", func(t *testing.T) {
 		testPath := filepath.Join(t.TempDir(), "testdata")
-		require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+		require.NoError(t, os.MkdirAll(testPath, 0o750))
 		t.Cleanup(func() { _ = os.RemoveAll(testPath) })
-		if err := os.Mkdir(filepath.Join(testPath, "emptyDir"), 0o750); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Mkdir(filepath.Join(testPath, "emptyDir"), 0o750))
 		t.Cleanup(func() {
 			assert.NoError(t, os.RemoveAll(filepath.Join(testPath, "emptyDir")))
 		})

--- a/pkg/fs/write_test.go
+++ b/pkg/fs/write_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"bytes"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -9,11 +10,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteFile(t *testing.T) {
+	testPath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
-		dir := "./testdata/_WriteFile_Success"
+		dir := filepath.Join(testPath, "_WriteFile_Success")
 		filePath := filepath.Join(dir, "notyetexisting.jpg")
 		fileData := []byte("foobar")
 
@@ -22,25 +27,23 @@ func TestWriteFile(t *testing.T) {
 		}
 
 		defer func() {
-			_ = os.Remove(filePath)
-
-			if err := os.RemoveAll(dir); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, os.Remove(filePath))
+			require.NoError(t, os.RemoveAll(dir))
 		}()
 
 		assert.True(t, PathExists(dir))
 
-		fileErr := WriteFile(filePath, fileData, ModeFile)
-
-		assert.NoError(t, fileErr)
+		require.NoError(t, WriteFile(filePath, fileData, ModeFile))
 		assert.FileExists(t, filePath)
 	})
 }
 
 func TestWriteString(t *testing.T) {
+	testPath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
-		dir := "./testdata/_WriteString_Success"
+		dir := filepath.Join(testPath, "_WriteString_Success")
 		filePath := filepath.Join(dir, PPIgnoreFilename)
 		fileData := "*"
 
@@ -49,18 +52,13 @@ func TestWriteString(t *testing.T) {
 		}
 
 		defer func() {
-			_ = os.Remove(filePath)
-
-			if err := os.RemoveAll(dir); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, os.Remove(filePath))
+			require.NoError(t, os.RemoveAll(dir))
 		}()
 
 		assert.True(t, PathExists(dir))
 
-		fileErr := WriteString(filePath, fileData)
-
-		assert.NoError(t, fileErr)
+		require.NoError(t, WriteString(filePath, fileData))
 		assert.FileExists(t, filePath)
 
 		readLines, readErr := ReadLines(filePath)
@@ -72,8 +70,11 @@ func TestWriteString(t *testing.T) {
 }
 
 func TestWriteUnixTime(t *testing.T) {
+	testPath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
-		dir := "./testdata/_WriteUnixTime_Success"
+		dir := filepath.Join(testPath, "_WriteUnixTime_Success")
 		filePath := filepath.Join(dir, PPStorageFilename)
 
 		if err := MkdirAll(dir); err != nil {
@@ -81,11 +82,8 @@ func TestWriteUnixTime(t *testing.T) {
 		}
 
 		defer func() {
-			_ = os.Remove(filePath)
-
-			if err := os.RemoveAll(dir); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, os.Remove(filePath))
+			require.NoError(t, os.RemoveAll(dir))
 		}()
 
 		assert.True(t, PathExists(dir))
@@ -104,8 +102,11 @@ func TestWriteUnixTime(t *testing.T) {
 }
 
 func TestWriteFileFromReader(t *testing.T) {
+	testPath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
-		dir := "./testdata/_WriteFileFromReader_Success"
+		dir := filepath.Join(testPath, "_WriteFileFromReader_Success")
 
 		filePath1 := filepath.Join(dir, "1.txt")
 		filePath2 := filepath.Join(dir, "2.txt")
@@ -115,12 +116,9 @@ func TestWriteFileFromReader(t *testing.T) {
 		}
 
 		defer func() {
-			_ = os.Remove(filePath1)
-			_ = os.Remove(filePath2)
-
-			if err := os.RemoveAll(dir); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, os.Remove(filePath1))
+			require.NoError(t, os.Remove(filePath2))
+			require.NoError(t, os.RemoveAll(dir))
 		}()
 
 		assert.True(t, PathExists(dir))
@@ -145,8 +143,11 @@ func TestWriteFileFromReader(t *testing.T) {
 }
 
 func TestCacheFileFromReader(t *testing.T) {
+	testPath := filepath.Join(t.TempDir(), "testdata")
+	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
-		dir := "./testdata/_CacheFileFromReader_Success"
+		dir := filepath.Join(testPath, "_CacheFileFromReader_Success")
 
 		filePath1 := filepath.Join(dir, "1.txt")
 		filePath2 := filepath.Join(dir, "2.txt")
@@ -157,13 +158,10 @@ func TestCacheFileFromReader(t *testing.T) {
 		}
 
 		defer func() {
-			_ = os.Remove(filePath1)
-			_ = os.Remove(filePath2)
-			_ = os.Remove(filePath3)
-
-			if err := os.RemoveAll(dir); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, os.Remove(filePath1))
+			require.NoError(t, os.Remove(filePath2))
+			require.NoError(t, os.Remove(filePath3))
+			require.NoError(t, os.RemoveAll(dir))
 		}()
 
 		assert.True(t, PathExists(dir))

--- a/pkg/fs/write_test.go
+++ b/pkg/fs/write_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"bytes"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -15,7 +14,7 @@ import (
 
 func TestWriteFile(t *testing.T) {
 	testPath := filepath.Join(t.TempDir(), "testdata")
-	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	require.NoError(t, os.MkdirAll(testPath, 0o750))
 	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
 		dir := filepath.Join(testPath, "_WriteFile_Success")
@@ -40,7 +39,7 @@ func TestWriteFile(t *testing.T) {
 
 func TestWriteString(t *testing.T) {
 	testPath := filepath.Join(t.TempDir(), "testdata")
-	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	require.NoError(t, os.MkdirAll(testPath, 0o750))
 	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
 		dir := filepath.Join(testPath, "_WriteString_Success")
@@ -71,7 +70,7 @@ func TestWriteString(t *testing.T) {
 
 func TestWriteUnixTime(t *testing.T) {
 	testPath := filepath.Join(t.TempDir(), "testdata")
-	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	require.NoError(t, os.MkdirAll(testPath, 0o750))
 	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
 		dir := filepath.Join(testPath, "_WriteUnixTime_Success")
@@ -103,7 +102,7 @@ func TestWriteUnixTime(t *testing.T) {
 
 func TestWriteFileFromReader(t *testing.T) {
 	testPath := filepath.Join(t.TempDir(), "testdata")
-	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	require.NoError(t, os.MkdirAll(testPath, 0o750))
 	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
 		dir := filepath.Join(testPath, "_WriteFileFromReader_Success")
@@ -144,7 +143,7 @@ func TestWriteFileFromReader(t *testing.T) {
 
 func TestCacheFileFromReader(t *testing.T) {
 	testPath := filepath.Join(t.TempDir(), "testdata")
-	require.NoError(t, os.MkdirAll(testPath, fs.ModeDir))
+	require.NoError(t, os.MkdirAll(testPath, 0o750))
 	t.Cleanup(func() { _ = os.RemoveAll(testPath) })
 	t.Run("Success", func(t *testing.T) {
 		dir := filepath.Join(testPath, "_CacheFileFromReader_Success")

--- a/pkg/media/colors/srgb_test.go
+++ b/pkg/media/colors/srgb_test.go
@@ -54,7 +54,7 @@ func TestToSRGB(t *testing.T) {
 
 		imgSRGB := ToSRGB(img, ProfileDisplayP3)
 
-		srgbFile := "./testdata/SRGB.jpg"
+		srgbFile := filepath.Join(t.TempDir(), "SRGB.jpg")
 
 		if err := writeImage(srgbFile, imgSRGB); err != nil {
 			t.Error(err)


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

These changes improve test isolation by ensuring that tests do not write to static named folders within the source code path.
This could allow tests to be run in parallel across different DBMS'.  This would require executing the tests in separate terminal sessions.

#### Related Issues

There are no related issues.

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [x] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [x] Database-related changes have been successfully tested with SQLite 3 and MariaDB 10.5.12+

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->