### PR TITLE
Tests: Ensure that moments-003 selects the correct moments album

### DIFF
--- a/frontend/tests/acceptance/acceptance-public/moment.js
+++ b/frontend/tests/acceptance/acceptance-public/moment.js
@@ -137,8 +137,10 @@ test.meta("testID", "moments-003").meta({ mode: "public" })(
     await album.openAlbumWithUid(HolidayAlbumUid);
     const InitialPhotoCountHoliday = await photo.getPhotoCount("all");
     await menu.openPage("moments");
-    const SecondMomentUid = await album.getNthAlbumUid("all", 1);
-    await album.openAlbumWithUid(SecondMomentUid);
+    await toolbar.search("Greece 2019");
+    const GreeceMomentUid = await album.getNthAlbumUid("all", 0);
+    await menu.openPage("moments");
+    await album.openAlbumWithUid(GreeceMomentUid);
     const PhotoCountInMoment = await photo.getPhotoCount("all");
     const FirstPhotoUid = await photo.getNthPhotoUid("image", 0);
     const SecondPhotoUid = await photo.getNthPhotoUid("image", 1);
@@ -148,7 +150,7 @@ test.meta("testID", "moments-003").meta({ mode: "public" })(
     const SixthPhotoUid = await photo.getNthPhotoUid("image", 5);
     const SeventhPhotoUid = await photo.getNthPhotoUid("image", 6);
     await menu.openPage("moments");
-    await album.selectAlbumFromUID(SecondMomentUid);
+    await album.selectAlbumFromUID(GreeceMomentUid);
     await contextmenu.triggerContextMenuAction("clone", ["Holiday", "NotYetExistingAlbumForMoment"]); // NotYetExistingAlbumForMoment happens to be long enough to be the middle of the text box (which causes it to be removed when Holiday is added), so put it second.
     await menu.openPage("albums");
     const AlbumCountAfterCreation = await album.getAlbumCount("all");
@@ -186,7 +188,7 @@ test.meta("testID", "moments-003").meta({ mode: "public" })(
     await t.expect(AlbumCountAfterDelete).eql(AlbumCount);
 
     await menu.openPage("moments");
-    await album.openAlbumWithUid(SecondMomentUid);
+    await album.openAlbumWithUid(GreeceMomentUid);
     await photo.checkPhotoVisibility(FirstPhotoUid, true);
     await photo.checkPhotoVisibility(SecondPhotoUid, true);
   }


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

These changes fix the Acceptance test moments-003 (Common: Create/delete album-clone from moment) which can fail if the test executes AFTER the moments backend process has run.  This process is triggered by a timer and may or may not execute before this test is run.  (ie. you have to be lucky for this test to fail as I was today)

In acceptance the moments process does the following (manually executed from command line to show impact), which adds 2 new named moments to the database, and causes the test to select the wrong moment, and then fail.
The Germany 2020 moment is the one that breaks the test, because it sorts before Greece 2019.
```
DEBU[2026-07-31T06:57:40Z] moments: analyzing 103 photos and 8 videos, with threshold 7 
INFO[2026-07-31T06:57:40Z] moments: added 'June 2020' (public:true year:2020 month:6) 
INFO[2026-07-31T06:57:40Z] moments: added 'June 2015' (public:true year:2015 month:6) 
INFO[2026-07-31T06:57:40Z] moments: added 'September 2014' (public:true year:2014 month:9) 
INFO[2026-07-31T06:57:40Z] moments: added 'December 2013' (public:true year:2013 month:12) 
INFO[2026-07-31T06:57:40Z] moments: added 'South Africa 2013' (public:true country:za year:2013) 
INFO[2026-07-31T06:57:40Z] moments: added 'Germany 2020' (public:true country:de year:2020) 
INFO[2026-07-31T06:57:40Z] moments: added KwaZulu-Natal (public:true country:za state:"KwaZulu-Natal") 
INFO[2026-07-31T06:57:40Z] moments: added Rheinland-Pfalz (public:true country:de state:"Rheinland-Pfalz") 
INFO[2026-07-31T06:57:40Z] completed in 300.268377ms                    
```

#### Related Issues

There are no related issues.

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [x] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->