### PR TITLE
Metadata: Complete XMP and DCMI tags for the report #2260

### DIFF
--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -18,20 +18,24 @@ const (
 //
 // Note: the meta:"…", xmp:"…", and dc:"…" struct tags below are read by
 // internal/meta/report.go via reflection to render the metadata-source
-// columns of `photoprism show metadata-fields`. Do not delete them as
+// columns of `photoprism show metadata`. Do not delete them as
 // "vestigial" — they are documentation that ships in the CLI report.
+//
+// The xmp:"…" tags list the namespaced properties the XMP reader consults,
+// in the priority order its chains apply (internal/meta/xmp_document.go);
+// the dc:"…" tags name the Dublin Core properties among them.
 type Data struct {
 	FileName         string        `meta:"FileName"`
 	MimeType         string        `meta:"MIMEType" report:"-"`
-	DocumentID       string        `meta:"ContentIdentifier,MediaGroupUUID,BurstUUID,OriginalDocumentID,DocumentID,ImageUniqueID,DigitalImageGUID"` // see https://exiftool.org/forum/index.php?topic=14874.0
-	InstanceID       string        `meta:"InstanceID,DocumentID"`
-	CreatedAt        time.Time     `meta:"SubSecCreateDate,CreationTime,CreationDate,CreateDate,MediaCreateDate,ContentCreateDate,TrackCreateDate"`
-	TakenAt          time.Time     `meta:"SubSecDateTimeOriginal,SubSecDateTimeCreated,DateTimeOriginal,CreationTime,CreationDate,DateTimeCreated,DateTime,DateTimeDigitized" xmp:"DateCreated,CreationTime"`
+	DocumentID       string        `meta:"ContentIdentifier,MediaGroupUUID,BurstUUID,OriginalDocumentID,DocumentID,ImageUniqueID,DigitalImageGUID" xmp:"xmpMM:OriginalDocumentID,xmpMM:DocumentID,dc:identifier" dc:"identifier"` // see https://exiftool.org/forum/index.php?topic=14874.0
+	InstanceID       string        `meta:"InstanceID,DocumentID" xmp:"xmpMM:InstanceID"`
+	CreatedAt        time.Time     `meta:"SubSecCreateDate,CreationTime,CreationDate,CreateDate,MediaCreateDate,ContentCreateDate,TrackCreateDate" xmp:"xmp:CreateDate,xmpDM:CreationDate"`
+	TakenAt          time.Time     `meta:"SubSecDateTimeOriginal,SubSecDateTimeCreated,DateTimeOriginal,CreationTime,CreationDate,DateTimeCreated,DateTime,DateTimeDigitized" xmp:"photoshop:DateCreated,exif:DateTimeOriginal,xmp:CreateDate"`
 	TakenAtLocal     time.Time     `meta:"SubSecDateTimeOriginal,SubSecDateTimeCreated,DateTimeOriginal,CreationDate,DateTimeCreated,DateTime,DateTimeDigitized"`
-	TakenGps         time.Time     `meta:"GPSDateTime,GPSDateStamp"`
+	TakenGps         time.Time     `meta:"GPSDateTime,GPSDateStamp" xmp:"exif:GPSTimeStamp,exif:GPSDateStamp"`
 	TakenNs          int           `meta:"-"`
 	TimeZone         string        `meta:"-"`
-	TimeOffset       string        `meta:"OffsetTime,OffsetTimeOriginal,OffsetTimeDigitized"`
+	TimeOffset       string        `meta:"OffsetTime,OffsetTimeOriginal,OffsetTimeDigitized" xmp:"exif:OffsetTimeOriginal,exif:OffsetTime,exif:OffsetTimeDigitized"`
 	MediaType        media.Type    `meta:"-"`
 	HasThumbEmbedded bool          `meta:"ThumbnailImage,PhotoshopThumbnail" report:"-"`
 	HasVideoEmbedded bool          `meta:"EmbeddedVideoFile,MotionPhoto,MotionPhotoVideo,MicroVideo" report:"-"`
@@ -40,41 +44,41 @@ type Data struct {
 	Frames           int           `meta:"FrameCount,AnimationFrames"`
 	Pages            int           `meta:"PageCount,NPages,Pages"`
 	Codec            string        `meta:"CompressorID,VideoCodecID,CodecID,OtherFormat,VideoCodec,FileType"`
-	Title            string        `meta:"Title,Headline" xmp:"dc:title" dc:"title,title.Alt"`
-	Caption          string        `meta:"Description,ImageDescription,Caption,Caption-Abstract" xmp:"Description,Description.Alt"`
-	Subject          string        `meta:"Subject,PersonInImage,ObjectName,HierarchicalSubject,CatalogSets" xmp:"Subject"`
+	Title            string        `meta:"Title,Headline" xmp:"dc:title,photoshop:Headline" dc:"title,title.Alt"`
+	Caption          string        `meta:"Description,ImageDescription,Caption,Caption-Abstract" xmp:"dc:description,tiff:ImageDescription" dc:"description,description.Alt"`
+	Subject          string        `meta:"Subject,PersonInImage,ObjectName,HierarchicalSubject,CatalogSets" xmp:"dc:subject,Iptc4xmpExt:PersonInImage,lr:hierarchicalSubject" dc:"subject"`
 	Keywords         Keywords      `meta:"Keywords"`
 	Faces            []Face        `meta:"-"`
 	FacesDeclared    bool          `meta:"-"`
 	FacesPartial     bool          `meta:"-"`
-	Favorite         bool          `meta:"Favorite"`
-	Notes            string        `meta:"Comment,UserComment"`
-	Artist           string        `meta:"Artist,Creator,By-line,OwnerName,Owner" xmp:"Creator"`
-	Copyright        string        `meta:"Rights,Copyright,CopyrightNotice,WebStatement" xmp:"Rights,Rights.Alt"`
-	License          string        `meta:"UsageTerms,License"`
-	Projection       string        `meta:"ProjectionType"`
-	ColorProfile     string        `meta:"ICCProfileName,ProfileDescription"`
-	CameraMake       string        `meta:"CameraMake,Make" xmp:"Make"`
-	CameraModel      string        `meta:"CameraModel,Model,CameraID,UniqueCameraModel" xmp:"CameraModel,Model"`
-	CameraOwner      string        `meta:"OwnerName"`
-	CameraSerial     string        `meta:"SerialNumber"`
-	LensMake         string        `meta:"LensMake"`
-	LensModel        string        `meta:"LensModel,Lens,LensID" xmp:"LensModel,Lens"`
-	Software         string        `meta:"Software,Producer,CreatorTool,CreatorSubTool,HistorySoftwareAgent,ProcessingSoftware"`
-	Flash            bool          `meta:"FlashFired"`
-	FocalLength      int           `meta:"FocalLength,FocalLengthIn35mmFormat"`
+	Favorite         bool          `meta:"Favorite" xmp:"fstop:favorite"`
+	Notes            string        `meta:"Comment,UserComment" xmp:"exif:UserComment"`
+	Artist           string        `meta:"Artist,Creator,By-line,OwnerName,Owner" xmp:"dc:creator" dc:"creator"`
+	Copyright        string        `meta:"Rights,Copyright,CopyrightNotice,WebStatement" xmp:"dc:rights,tiff:Copyright,xmpRights:WebStatement" dc:"rights,rights.Alt"`
+	License          string        `meta:"UsageTerms,License" xmp:"xmpRights:UsageTerms"`
+	Projection       string        `meta:"ProjectionType" xmp:"GPano:ProjectionType"`
+	ColorProfile     string        `meta:"ICCProfileName,ProfileDescription" xmp:"photoshop:ICCProfile"`
+	CameraMake       string        `meta:"CameraMake,Make" xmp:"tiff:Make"`
+	CameraModel      string        `meta:"CameraModel,Model,CameraID,UniqueCameraModel" xmp:"tiff:Model"`
+	CameraOwner      string        `meta:"OwnerName" xmp:"aux:OwnerName"`
+	CameraSerial     string        `meta:"SerialNumber" xmp:"exifEX:BodySerialNumber,aux:SerialNumber"`
+	LensMake         string        `meta:"LensMake" xmp:"exifEX:LensMake"`
+	LensModel        string        `meta:"LensModel,Lens,LensID" xmp:"exifEX:LensModel,aux:Lens,aux:LensID"`
+	Software         string        `meta:"Software,Producer,CreatorTool,CreatorSubTool,HistorySoftwareAgent,ProcessingSoftware" xmp:"xmp:CreatorTool,tiff:Software"`
+	Flash            bool          `meta:"FlashFired" xmp:"exif:Flash/exif:Fired"`
+	FocalLength      int           `meta:"FocalLength,FocalLengthIn35mmFormat" xmp:"exif:FocalLength,exif:FocalLengthIn35mmFilm"`
 	FocalDistance    float64       `meta:"HyperfocalDistance"`
-	Exposure         string        `meta:"ExposureTime,ShutterSpeedValue,ShutterSpeed,TargetExposureTime"`
-	Aperture         float32       `meta:"ApertureValue,Aperture"`
-	FNumber          float32       `meta:"FNumber"`
-	Iso              int           `meta:"ISO"`
+	Exposure         string        `meta:"ExposureTime,ShutterSpeedValue,ShutterSpeed,TargetExposureTime" xmp:"exif:ExposureTime,exif:ShutterSpeedValue"`
+	Aperture         float32       `meta:"ApertureValue,Aperture" xmp:"exif:ApertureValue"`
+	FNumber          float32       `meta:"FNumber" xmp:"exif:FNumber"`
+	Iso              int           `meta:"ISO" xmp:"exifEX:PhotographicSensitivity,exif:ISOSpeedRatings"`
 	ImageType        int           `meta:"HDRImageType"`
 	GPSPosition      string        `meta:"GPSPosition"`
-	GPSLatitude      string        `meta:"GPSLatitude"`
-	GPSLongitude     string        `meta:"GPSLongitude"`
+	GPSLatitude      string        `meta:"GPSLatitude" xmp:"exif:GPSLatitude"`
+	GPSLongitude     string        `meta:"GPSLongitude" xmp:"exif:GPSLongitude"`
 	Lat              float64       `meta:"-"`
 	Lng              float64       `meta:"-"`
-	Altitude         float64       `meta:"GlobalAltitude,GPSAltitude"`
+	Altitude         float64       `meta:"GlobalAltitude,GPSAltitude" xmp:"exif:GPSAltitude"`
 	Width            int           `meta:"ImageWidth,PixelXDimension,ExifImageWidth,SourceImageWidth"`
 	Height           int           `meta:"ImageHeight,ImageLength,PixelYDimension,ExifImageHeight,SourceImageHeight"`
 	Orientation      int           `meta:"-"`

--- a/internal/meta/report_test.go
+++ b/internal/meta/report_test.go
@@ -1,0 +1,80 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// reportRows indexes a Report result by field name for easier assertions.
+func reportRows(t *testing.T) map[string][]string {
+	t.Helper()
+
+	rows, cols := Report(&Data{})
+
+	assert.Equal(t, []string{"Field", "Type", "Exiftool", "Adobe XMP", "DCMI"}, cols)
+	assert.NotEmpty(t, rows)
+
+	result := make(map[string][]string, len(rows))
+
+	for _, row := range rows {
+		assert.Len(t, row, len(cols))
+		result[row[0]] = row
+	}
+
+	return result
+}
+
+func TestReport(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		rows := reportRows(t)
+		assert.Equal(t, "text", rows["Title"][1])
+		assert.Equal(t, "timestamp", rows["TakenAt"][1])
+		assert.Equal(t, "flag", rows["Flash"][1])
+		assert.Equal(t, "list", rows["Keywords"][1])
+	})
+	t.Run("XmpTags", func(t *testing.T) {
+		rows := reportRows(t)
+		assert.Equal(t, "dc:title, photoshop:Headline", rows["Title"][3])
+		assert.Equal(t, "photoshop:DateCreated, exif:DateTimeOriginal, xmp:CreateDate", rows["TakenAt"][3])
+		assert.Equal(t, "tiff:Model", rows["CameraModel"][3])
+		assert.Equal(t, "exifEX:LensModel, aux:Lens, aux:LensID", rows["LensModel"][3])
+		assert.Equal(t, "xmpRights:UsageTerms", rows["License"][3])
+	})
+	t.Run("GpsFromXmp", func(t *testing.T) {
+		// The XMP reader supplies coordinates, so these must not report as
+		// Exiftool-only, which would read as "XMP GPS is unsupported".
+		rows := reportRows(t)
+		assert.Equal(t, "exif:GPSLatitude", rows["GPSLatitude"][3])
+		assert.Equal(t, "exif:GPSLongitude", rows["GPSLongitude"][3])
+		assert.Equal(t, "exif:GPSAltitude", rows["Altitude"][3])
+	})
+	t.Run("DcmiTags", func(t *testing.T) {
+		rows := reportRows(t)
+		assert.Equal(t, "title, title.Alt", rows["Title"][4])
+		assert.Equal(t, "description, description.Alt", rows["Caption"][4])
+		assert.Equal(t, "rights, rights.Alt", rows["Copyright"][4])
+		assert.Equal(t, "creator", rows["Artist"][4])
+		assert.Equal(t, "subject", rows["Subject"][4])
+		assert.Equal(t, "identifier", rows["DocumentID"][4])
+	})
+	t.Run("ExcludedFields", func(t *testing.T) {
+		// Fields tagged meta:"-" or report:"-" have no row at all.
+		rows := reportRows(t)
+		for _, name := range []string{"Lat", "Lng", "TakenNs", "TimeZone", "Orientation", "MimeType", "Warning"} {
+			assert.NotContains(t, rows, name)
+		}
+	})
+	t.Run("KeywordsHaveNoXmpSource", func(t *testing.T) {
+		// XMP contributes only derived keywords (flash/panorama/hdr); dc:subject
+		// maps to Subject instead, so Keywords reports no XMP source.
+		rows := reportRows(t)
+		assert.Empty(t, rows["Keywords"][3])
+		assert.NotEmpty(t, rows["Subject"][3])
+	})
+	t.Run("InvalidType", func(t *testing.T) {
+		rows, cols := Report("not a struct")
+		assert.Empty(t, rows)
+		assert.Len(t, cols, 5)
+	})
+}


### PR DESCRIPTION
Completes the `xmp:` and `dc:` struct tags on `meta.Data` so the metadata
compatibility report reflects what the XMP reader actually supports.

The tags are read only by `internal/meta/report.go` via reflection, which
renders `photoprism show metadata` and the published compatibility table.
`report.go` is their sole consumer, so this changes documentation output
only — parsing is driven by the `meta:` tags and by the XPath chains in
`internal/meta/xmp_document.go`, neither of which is touched.

### Changes

- `xmp:` tags: 9 fields to 32, transcribed from the reader's priority
  chains and namespaced, so `exif:` / `exifEX:` / `aux:` are distinguishable.
- Corrections, not just additions: `TakenAt` claimed `DateCreated,CreationTime`
  but resolves `photoshop:DateCreated -> exif:DateTimeOriginal -> xmp:CreateDate`;
  `CameraModel` claimed `CameraModel,Model` but only reads `tiff:Model`.
- `GPSLatitude` / `GPSLongitude` now report `exif:GPSLatitude` / `exif:GPSLongitude`.
  The reader populates coordinates from XMP; the empty cells read as
  "XMP GPS is unsupported", which is wrong.
- `dc:` tags: 1 field to 6, covering the Dublin Core properties the reader
  consults.
- Adds `internal/meta/report_test.go`, matching `internal/thumb/report_test.go`.
- Corrects the doc comment, which named a `show metadata-fields` command
  that does not exist.

### Not included

`Lat`, `Lng`, `TakenNs`, `TimeZone` and `Orientation` are tagged `meta:"-"`,
so `Report()` emits no row for them. Surfacing them means changing the
report filter, which is a separate call about whether computed fields
belong in a user-facing table.

The test pins the tag values but cannot mechanically verify them against
the chains, which are unexported compiled expressions. It catches typos
and deletions, not semantic drift.

The published table at https://www.photoprism.app/kb/metadata/ is a pasted
copy; regenerated in photoprism/photoprism-web#4.

### Acceptance Criteria

- [x] Every field the XMP reader populates and that `Report()` emits a row
      for carries an `xmp:` tag. (MUST)
- [x] Tag values match the reader's priority chains in order. (MUST)
- [x] No parsing behavior changes. (MUST)
- [x] `go test ./internal/meta/...` passes. (MUST)
