### PR TITLE
RAW: Preserve embedded preview orientation

### DIFF
--- a/internal/photoprism/convert_command.go
+++ b/internal/photoprism/convert_command.go
@@ -11,11 +11,12 @@ import (
 // ConvertCmd represents a command to be executed for converting a MediaFile.
 // including any options to be used for this.
 type ConvertCmd struct {
-	Cmd          *exec.Cmd
-	Orientation  media.Orientation
-	VerifyImage  bool
-	RejectStderr []string
-	Projection   projection.Type
+	Cmd               *exec.Cmd
+	Orientation       media.Orientation
+	SourceOrientation int
+	VerifyImage       bool
+	RejectStderr      []string
+	Projection        projection.Type
 }
 
 // String returns the conversion command as string e.g. for logging.
@@ -36,6 +37,15 @@ func (c *ConvertCmd) WithOrientation(o media.Orientation) *ConvertCmd {
 // ResetOrientation resets the media Orientation after successful conversion.
 func (c *ConvertCmd) ResetOrientation() *ConvertCmd {
 	return c.WithOrientation(media.ResetOrientation)
+}
+
+// WithSourceOrientation copies the source file's EXIF orientation to the converted image.
+func (c *ConvertCmd) WithSourceOrientation(o int) *ConvertCmd {
+	if o >= 1 && o <= 8 {
+		c.SourceOrientation = o
+	}
+
+	return c
 }
 
 // WithImageVerification marks the command's output for a decode check before acceptance,

--- a/internal/photoprism/convert_command_test.go
+++ b/internal/photoprism/convert_command_test.go
@@ -40,6 +40,16 @@ func TestNewConvertCmd(t *testing.T) {
 		assert.Same(t, result, result.WithImageVerification())
 		assert.True(t, result.VerifyImage)
 	})
+	t.Run("WithSourceOrientation", func(t *testing.T) {
+		result := NewConvertCmd(
+			exec.Command("exiftool", "-q", "-q", "-b", "-JpgFromRaw", "file.cr3"),
+		)
+		assert.Zero(t, result.SourceOrientation)
+		assert.Same(t, result, result.WithSourceOrientation(8))
+		assert.Equal(t, 8, result.SourceOrientation)
+		assert.Same(t, result, result.WithSourceOrientation(9))
+		assert.Equal(t, 8, result.SourceOrientation)
+	})
 	t.Run("WithStderrRejection", func(t *testing.T) {
 		result := NewConvertCmd(
 			exec.Command("rawtherapee-cli", "-o", "file.jpg", "-c", "file.cr3"),

--- a/internal/photoprism/convert_image.go
+++ b/internal/photoprism/convert_image.go
@@ -84,6 +84,7 @@ func (w *Convert) ToImage(f *MediaFile, force bool) (result *MediaFile, err erro
 
 	fileName := f.RelName(w.conf.OriginalsPath())
 	fileOrientation := media.KeepOrientation
+	sourceOrientation := 0
 	fileProjection := projection.Unknown
 	xmpName := fs.SidecarXMP.Find(f.FileName(), false)
 
@@ -220,6 +221,7 @@ func (w *Convert) ToImage(f *MediaFile, force bool) (result *MediaFile, err erro
 
 		log.Infof("convert: %s created in %s (%s)", clean.Log(filepath.Base(imageName)), time.Since(start), filepath.Base(cmd.Path))
 		fileOrientation = c.Orientation
+		sourceOrientation = c.SourceOrientation
 		fileProjection = c.Projection
 		break
 	}
@@ -238,6 +240,12 @@ func (w *Convert) ToImage(f *MediaFile, force bool) (result *MediaFile, err erro
 	if fileOrientation == media.ResetOrientation {
 		if err = result.ChangeOrientation(1); err != nil {
 			log.Warnf("convert: %s in %s (change orientation)", err, clean.Log(result.RootRelName()))
+		}
+	} else if sourceOrientation > 1 {
+		if err = result.ChangeOrientation(sourceOrientation); err != nil {
+			log.Warnf("convert: %s in %s (copy source orientation)", err, clean.Log(result.RootRelName()))
+		} else if result, err = NewMediaFile(imageName); err != nil {
+			return result, err
 		}
 	}
 

--- a/internal/photoprism/convert_image_jpeg.go
+++ b/internal/photoprism/convert_image_jpeg.go
@@ -113,8 +113,8 @@ func (w *Convert) JpegConvertCmds(f *MediaFile, jpegName string, xmpName string)
 		// and the only option when RAW rendering is disabled. Colors stay correct for sensors they
 		// cannot identify (recent Canon CR3 bodies otherwise come out magenta). Skipped if unusable.
 		if w.conf.ExifToolEnabled() && raw.PreviewExtAllowed(fileExt) {
-			result = append(result, NewConvertCmd(raw.ExifToolJpgFromRawCmd(w.conf.ExifToolBin(), f.FileName())).WithImageVerification())
-			result = append(result, NewConvertCmd(raw.ExifToolPreviewImageCmd(w.conf.ExifToolBin(), f.FileName())).WithImageVerification())
+			result = append(result, NewConvertCmd(raw.ExifToolJpgFromRawCmd(w.conf.ExifToolBin(), f.FileName())).WithImageVerification().WithSourceOrientation(f.Orientation()))
+			result = append(result, NewConvertCmd(raw.ExifToolPreviewImageCmd(w.conf.ExifToolBin(), f.FileName())).WithImageVerification().WithSourceOrientation(f.Orientation()))
 		}
 	}
 

--- a/internal/photoprism/convert_image_test.go
+++ b/internal/photoprism/convert_image_test.go
@@ -143,6 +143,37 @@ func TestConvert_ToImage(t *testing.T) {
 
 		_ = os.Remove(jpgFilename)
 	})
+	t.Run("RawEmbeddedPreviewOrientation", func(t *testing.T) {
+		if !cnf.ExifToolEnabled() {
+			t.Skip("ExifTool must be available for the RAW embedded-preview fallback")
+		}
+
+		disableRaw := cnf.Options().DisableRaw
+		cnf.Options().DisableRaw = true
+		rawFile := filepath.Join(cnf.OriginalsPath(), "portrait-preview-orientation.dng")
+
+		t.Cleanup(func() {
+			cnf.Options().DisableRaw = disableRaw
+			_ = os.Remove(rawFile)
+		})
+
+		require.NoError(t, fs.Copy(filepath.Join(samplesPath, "canon_eos_6d.dng"), rawFile, true))
+		// #nosec G204 -- arguments are the configured ExifTool binary and a test fixture path.
+		require.NoError(t, exec.Command(cnf.ExifToolBin(), "-q", "-overwrite_original", "-n", "-Orientation=8", rawFile).Run())
+
+		rawMediaFile, err := NewMediaFile(rawFile)
+		require.NoError(t, err)
+		assert.Equal(t, 8, rawMediaFile.Orientation())
+
+		preview, err := convert.ToImage(rawMediaFile, true)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = preview.Remove() })
+		assert.Equal(t, 8, preview.Orientation())
+
+		img, err := thumb.Open(preview.FileName(), preview.Orientation())
+		require.NoError(t, err)
+		assert.Less(t, img.Bounds().Dx(), img.Bounds().Dy(), "preview must render in portrait orientation")
+	})
 	t.Run("Svg", func(t *testing.T) {
 		svgFile := fs.Abs("./testdata/agpl.svg")
 
@@ -610,6 +641,8 @@ func TestConvert_JpegConvertCmds_RawEmbeddedPreview(t *testing.T) {
 	assert.GreaterOrEqual(t, jpgFromRaw, 0, "expected a -JpgFromRaw extraction command")
 	assert.GreaterOrEqual(t, previewImage, 0, "expected a -PreviewImage extraction command")
 	assert.Less(t, jpgFromRaw, previewImage, "JpgFromRaw must be tried before PreviewImage")
+	assert.Equal(t, mediaFile.Orientation(), cmds[jpgFromRaw].SourceOrientation, "JpgFromRaw must preserve the RAW orientation")
+	assert.Equal(t, mediaFile.Orientation(), cmds[previewImage].SourceOrientation, "PreviewImage must preserve the RAW orientation")
 	if cnf.RawTherapeeEnabled() {
 		assert.GreaterOrEqual(t, rawTherapee, 0, "expected a RawTherapee command")
 		assert.Less(t, rawTherapee, jpgFromRaw, "RawTherapee must be tried before the embedded preview")


### PR DESCRIPTION
### Description

Preserves the source RAW file's EXIF orientation when PhotoPrism falls back to
an embedded JPEG preview extracted with ExifTool.

ExifTool's binary `JpgFromRaw` and `PreviewImage` extraction returns the JPEG
pixels without the RAW container's orientation metadata. As a result, a
portrait RAW file can produce a valid landscape preview that is later displayed
with incorrect geometry.

This change:

- carries the source orientation on the two embedded-preview conversion
  commands;
- writes EXIF orientations 2 through 8 to the generated preview and reloads the
  `MediaFile` so cached metadata and the content hash reflect the change; and
- adds a regression using PhotoPrism's public `canon_eos_6d.dng` fixture that
  forces orientation 8 and verifies both the generated metadata and portrait
  rendering.

No personal media is included.

#### Related Issues

- Follow-up to #5673
- Related embedded-preview discussion: #5333

### Acceptance Criteria

- [x] The existing embedded-preview fallback preserves source RAW orientation
      without changing other converter paths.
- [x] Automated command-level and public-fixture regression tests cover the new
      behavior.
- [x] Documentation changes are not required because this fixes internal
      conversion behavior and adds no configuration, API, database, or UI
      surface.

### Validation

- `go test ./internal/photoprism -run '^(TestNewConvertCmd|TestConvert_ToImage|TestConvert_JpegConvertCmds_RawEmbeddedPreview|TestConvert_JpegConvertCmds_RawDisabled)$' -count=1`
- `golangci-lint run ./internal/photoprism/...`
- `make fmt-go`
- `git diff --check`

The full `internal/photoprism` package suite was also attempted in
`photoprism/develop:260824-resolute` after rebasing onto upstream commit
`afeddb6`. It is not green because
`TestFaces_repairDegenerateRadius/SkipsRowsTheMatcherExcludes` still fails; the
same failure was reproduced separately on an unmodified upstream worktree at
commit `7eb8d2d`. The focused conversion tests and lint checks above pass.

### AI Assistance

AI tools assisted with diagnosis, drafting, and test setup. The human
contributor reviewed, tested, and understands the implementation and can discuss
and maintain it.
