### PR TITLE
Photos: Add manual picture stacking

### DIFF
--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -67,6 +67,18 @@
           @click.stop="edit"
         ></v-btn>
         <v-btn
+          v-if="canEdit && context !== contexts.Archive && context !== contexts.Hidden"
+          key="action-stack"
+          :title="$gettext('Stack Pictures')"
+          icon="mdi-image-multiple"
+          color="edit"
+          variant="elevated"
+          density="comfortable"
+          :disabled="selection.length < 2 || busy"
+          class="action-stack"
+          @click.stop="batchStack"
+        ></v-btn>
+        <v-btn
           v-if="canTogglePrivate && context !== contexts.Archive && context !== contexts.Hidden"
           key="action-private"
           :title="$gettext('Change private flag')"
@@ -251,6 +263,28 @@ export default {
       $notify.success(this.$gettext("Selection approved"));
       this.selection.forEach((uid) => Photo.evictCache(uid));
       this.clearClipboard();
+    },
+    // batchStack submits the current selection for non-destructive stacking.
+    batchStack() {
+      if (this.busy || !this.canEdit || this.selection.length < 2) {
+        return;
+      }
+
+      this.busy = true;
+
+      $api
+        .post("batch/photos/stack", { photos: this.selection })
+        .then(() => this.onStacked())
+        .finally(() => {
+          this.busy = false;
+        });
+    },
+    // onStacked clears stale client state after the stack was persisted.
+    onStacked() {
+      $notify.success(this.$gettext("Pictures stacked"));
+      this.selection.forEach((uid) => Photo.evictCache(uid));
+      this.clearClipboard();
+      this.refresh();
     },
     archivePhotos() {
       if (!this.canArchive) {

--- a/frontend/tests/vitest/component/photo/clipboard.test.js
+++ b/frontend/tests/vitest/component/photo/clipboard.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { shallowMount } from "@vue/test-utils";
+import { flushPromises, shallowMount } from "@vue/test-utils";
+import $api from "common/api";
+import $notify from "common/notify";
+import Photo from "model/photo";
 import PPhotoClipboard from "component/photo/clipboard.vue";
 
 const baseFeatures = {
@@ -100,5 +103,28 @@ describe("component/photo/clipboard", () => {
       album: wrapper.vm.album,
       index: 0,
     });
+  });
+
+  it("stacks the selected pictures and refreshes the view", async () => {
+    const refresh = vi.fn();
+    const post = vi.spyOn($api, "post").mockResolvedValue({});
+    const notify = vi.spyOn($notify, "success").mockImplementation(() => {});
+    const evictCache = vi.spyOn(Photo, "evictCache").mockImplementation(() => {});
+    const { wrapper, clipboard } = mountClipboard();
+
+    await wrapper.setProps({ refresh });
+    wrapper.vm.batchStack();
+    await flushPromises();
+
+    expect(post).toHaveBeenCalledWith("batch/photos/stack", { photos: clipboard.selection });
+    expect(notify).toHaveBeenCalledWith("Pictures stacked");
+    expect(evictCache).toHaveBeenCalledTimes(clipboard.selection.length);
+    expect(clipboard.clear).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(wrapper.vm.busy).toBe(false);
+
+    post.mockRestore();
+    notify.mockRestore();
+    evictCache.mockRestore();
   });
 });

--- a/internal/api/batch_photos.go
+++ b/internal/api/batch_photos.go
@@ -278,6 +278,120 @@ func BatchPhotosApprove(router *gin.RouterGroup) {
 	})
 }
 
+// BatchPhotosStack manually combines selected pictures into a non-destructive file stack.
+//
+//	@Summary	manually combines selected pictures into a file stack
+//	@Id			BatchPhotosStack
+//	@Tags		Photos, Stacks
+//	@Accept		json
+//	@Produce	json
+//	@Success	200					{object}	i18n.Response
+//	@Failure	400,401,403,404,429,500	{object}	i18n.Response
+//	@Param		photos					body		form.Selection	true	"Photo Selection"
+//	@Router		/api/v1/batch/photos/stack [post]
+func BatchPhotosStack(router *gin.RouterGroup) {
+	router.POST("/batch/photos/stack", func(c *gin.Context) {
+		s := Auth(c, acl.ResourcePhotos, acl.ActionUpdate)
+
+		if s.Abort(c) {
+			return
+		}
+
+		conf := get.Config()
+
+		if conf.ReadOnly() || !conf.Settings().Features.Edit {
+			AbortFeatureDisabled(c)
+			return
+		}
+
+		var frm form.Selection
+
+		LimitRequestBodyBytes(c, MaxSelectionRequestBytes)
+
+		if err := c.BindJSON(&frm); err != nil {
+			if IsRequestBodyTooLarge(err) {
+				AbortRequestTooLarge(c, i18n.ErrBadRequest)
+				return
+			}
+
+			AbortBadRequest(c, err)
+			return
+		}
+
+		requested := append([]string(nil), frm.Photos...)
+		uniqueRequested := make([]string, 0, len(requested))
+		requestedSet := make(map[string]struct{}, len(requested))
+
+		for _, uid := range requested {
+			if uid == "" {
+				continue
+			} else if _, exists := requestedSet[uid]; exists {
+				continue
+			}
+
+			requestedSet[uid] = struct{}{}
+			uniqueRequested = append(uniqueRequested, uid)
+		}
+
+		if len(uniqueRequested) < 2 {
+			Abort(c, http.StatusBadRequest, i18n.ErrNoItemsSelected)
+			return
+		}
+
+		frm.Photos = uniqueRequested
+
+		if !restrictPhotoSelection(c, s, &frm) {
+			return
+		}
+
+		allowed := make(map[string]struct{}, len(frm.Photos))
+
+		for _, uid := range frm.Photos {
+			allowed[uid] = struct{}{}
+		}
+
+		if len(allowed) != len(uniqueRequested) {
+			AbortForbidden(c)
+			return
+		}
+
+		frm.Photos = frm.Photos[:0]
+
+		for _, uid := range uniqueRequested {
+			if _, ok := allowed[uid]; ok {
+				frm.Photos = append(frm.Photos, uid)
+			}
+		}
+
+		log.Infof("photos: stacking %s", clean.Log(frm.String()))
+
+		original, stacked, err := entity.StackPhotos(frm.Photos)
+
+		if err != nil {
+			log.Errorf("stack: %s", err)
+			AbortSaveFailed(c)
+			return
+		}
+
+		stackedUIDs := stacked.UIDs()
+
+		SaveSidecarYaml(&original)
+		entity.UpdateCountsAsync()
+		query.UpdateCoversAsync()
+		UpdateClientConfig()
+		FlushCoverCache()
+		event.EntitiesUpdated("photos", []string{original.PhotoUID})
+		event.EntitiesDeleted("photos", stackedUIDs)
+
+		c.JSON(http.StatusOK, gin.H{
+			"code":    http.StatusOK,
+			"message": i18n.NewResponse(http.StatusOK, i18n.MsgChangesSaved).Message,
+			"photo":   original.PhotoUID,
+			"stacked": stackedUIDs,
+		})
+	})
+}
+
 // BatchPhotosPrivate toggles private state of multiple photos.
 //
 //	@Summary	toggles private state of multiple photos

--- a/internal/api/batch_photos_test.go
+++ b/internal/api/batch_photos_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 
+	"github.com/photoprism/photoprism/internal/entity"
 	"github.com/photoprism/photoprism/pkg/i18n"
+	"github.com/photoprism/photoprism/pkg/media"
+	"github.com/photoprism/photoprism/pkg/rnd"
 )
 
 func TestBatchPhotosArchive(t *testing.T) {
@@ -100,6 +103,99 @@ func TestBatchPhotosRestore(t *testing.T) {
 		BatchPhotosRestore(router)
 		r := PerformRequestWithBody(app, "POST", "/api/v1/batch/photos/restore", `{"photos": 123}`)
 		assert.Equal(t, http.StatusBadRequest, r.Code)
+	})
+}
+
+func TestBatchPhotosStack(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		primary := entity.NewPhoto(true)
+		primary.PhotoUID = rnd.GenerateUID(entity.PhotoUID)
+		primary.PhotoPath = "api-stack"
+		primary.PhotoName = "Primary"
+		primary.PhotoType = entity.MediaImage
+		primary.TypeSrc = entity.SrcAuto
+
+		if err := primary.Create(); err != nil {
+			t.Fatal(err)
+		}
+
+		secondary := entity.NewPhoto(true)
+		secondary.PhotoUID = rnd.GenerateUID(entity.PhotoUID)
+		secondary.PhotoPath = "api-stack"
+		secondary.PhotoName = "Secondary"
+		secondary.PhotoType = entity.MediaImage
+		secondary.TypeSrc = entity.SrcAuto
+
+		if err := secondary.Create(); err != nil {
+			t.Fatal(err)
+		}
+
+		primaryFile := entity.File{
+			PhotoID:     primary.ID,
+			PhotoUID:    primary.PhotoUID,
+			FileUID:     rnd.GenerateUID(entity.FileUID),
+			FileName:    "api-stack/" + primary.PhotoUID + ".jpg",
+			FileRoot:    entity.RootOriginals,
+			FileHash:    "api-stack-primary-" + primary.PhotoUID,
+			FileType:    "jpg",
+			MediaType:   media.Image.String(),
+			FilePrimary: true,
+		}
+
+		if err := primaryFile.Create(); err != nil {
+			t.Fatal(err)
+		}
+
+		secondaryFile := entity.File{
+			PhotoID:     secondary.ID,
+			PhotoUID:    secondary.PhotoUID,
+			FileUID:     rnd.GenerateUID(entity.FileUID),
+			FileName:    "api-stack/" + secondary.PhotoUID + ".jpg",
+			FileRoot:    entity.RootOriginals,
+			FileHash:    "api-stack-secondary-" + secondary.PhotoUID,
+			FileType:    "jpg",
+			MediaType:   media.Image.String(),
+			FilePrimary: true,
+		}
+
+		if err := secondaryFile.Create(); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Cleanup(func() {
+			fileUIDs := []string{primaryFile.FileUID, secondaryFile.FileUID}
+			photoIDs := []uint{primary.ID, secondary.ID}
+
+			_ = entity.UnscopedDb().Where("file_uid IN (?)", fileUIDs).Delete(entity.File{}).Error
+			_ = entity.UnscopedDb().Where("photo_id IN (?)", photoIDs).Delete(entity.Details{}).Error
+			_ = entity.UnscopedDb().Where("id IN (?)", photoIDs).Delete(entity.Photo{}).Error
+		})
+
+		app, router, _ := NewApiTest()
+		BatchPhotosStack(router)
+
+		body := fmt.Sprintf(`{"photos":["%s","%s"]}`, primary.PhotoUID, secondary.PhotoUID)
+		response := PerformRequestWithBody(app, http.MethodPost, "/api/v1/batch/photos/stack", body)
+
+		assert.Equal(t, http.StatusOK, response.Code)
+		assert.Equal(t, primary.PhotoUID, gjson.Get(response.Body.String(), "photo").String())
+		assert.Equal(t, secondary.PhotoUID, gjson.Get(response.Body.String(), "stacked.0").String())
+
+		var files entity.Files
+		assert.NoError(t, entity.UnscopedDb().Where("file_uid IN (?)", []string{primaryFile.FileUID, secondaryFile.FileUID}).Find(&files).Error)
+		assert.Len(t, files, 2)
+		for _, file := range files {
+			assert.Equal(t, primary.ID, file.PhotoID)
+		}
+	})
+
+	t.Run("RequiresTwoPictures", func(t *testing.T) {
+		app, router, _ := NewApiTest()
+		BatchPhotosStack(router)
+
+		response := PerformRequestWithBody(app, http.MethodPost, "/api/v1/batch/photos/stack", `{"photos":["ps6sg6be2lvl0yh8"]}`)
+
+		assert.Equal(t, http.StatusBadRequest, response.Code)
 	})
 }
 

--- a/internal/entity/photo_merge.go
+++ b/internal/entity/photo_merge.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/jinzhu/gorm"
@@ -11,6 +12,131 @@ import (
 )
 
 var photoMergeMutex = sync.Mutex{}
+
+// StackPhotos combines the selected pictures into the first picture without moving or deleting files.
+func StackPhotos(photoUIDs []string) (original Photo, stacked Photos, err error) {
+	photoMergeMutex.Lock()
+	defer photoMergeMutex.Unlock()
+
+	uids := make([]string, 0, len(photoUIDs))
+	seen := make(map[string]struct{}, len(photoUIDs))
+
+	for _, uid := range photoUIDs {
+		if uid == "" {
+			continue
+		} else if _, exists := seen[uid]; exists {
+			continue
+		}
+
+		seen[uid] = struct{}{}
+		uids = append(uids, uid)
+	}
+
+	if len(uids) < 2 {
+		return original, stacked, fmt.Errorf("stack: at least two pictures are required")
+	}
+
+	var selected Photos
+
+	if findErr := UnscopedDb().Where("photo_uid IN (?) AND deleted_at IS NULL", uids).Find(&selected).Error; findErr != nil {
+		return original, stacked, findErr
+	}
+
+	byUID := make(map[string]*Photo, len(selected))
+
+	for _, photo := range selected {
+		if photo != nil {
+			byUID[photo.PhotoUID] = photo
+		}
+	}
+
+	if len(byUID) != len(uids) {
+		return original, stacked, fmt.Errorf("stack: selection contains missing pictures")
+	}
+
+	primary := byUID[uids[0]]
+
+	if primary == nil || !primary.HasID() {
+		return original, stacked, fmt.Errorf("stack: primary picture not found")
+	}
+
+	original = *primary
+	tx := UnscopedDb().Begin()
+
+	if tx.Error != nil {
+		return Photo{}, stacked, tx.Error
+	}
+
+	rollback := func(stackErr error) (Photo, Photos, error) {
+		_ = tx.Rollback().Error
+		return Photo{}, Photos{}, stackErr
+	}
+
+	if updateErr := tx.Exec("UPDATE photos SET photo_stack = ? WHERE id = ?", IsStacked, original.ID).Error; updateErr != nil {
+		return rollback(updateErr)
+	}
+
+	for _, uid := range uids[1:] {
+		photo := byUID[uid]
+
+		if updateErr := tx.Exec("UPDATE files SET photo_id = ?, photo_uid = ?, file_primary = 0 WHERE photo_id = ?", original.ID, original.PhotoUID, photo.ID).Error; updateErr != nil {
+			return rollback(updateErr)
+		}
+
+		deleted := Now()
+
+		if updateErr := tx.Exec("UPDATE photos SET photo_quality = -1, deleted_at = ? WHERE id = ?", deleted, photo.ID).Error; updateErr != nil {
+			return rollback(updateErr)
+		}
+
+		switch DbDialect() {
+		case dsn.DriverMySQL:
+			if updateErr := tx.Exec("UPDATE IGNORE photos_keywords SET photo_id = ? WHERE photo_id = ?", original.ID, photo.ID).Error; updateErr != nil {
+				return rollback(updateErr)
+			}
+			if updateErr := tx.Exec("UPDATE IGNORE photos_labels SET photo_id = ? WHERE photo_id = ?", original.ID, photo.ID).Error; updateErr != nil {
+				return rollback(updateErr)
+			}
+			if updateErr := tx.Exec("UPDATE IGNORE photos_albums SET photo_uid = ? WHERE photo_uid = ?", original.PhotoUID, photo.PhotoUID).Error; updateErr != nil {
+				return rollback(updateErr)
+			}
+		case dsn.DriverSQLite3:
+			if updateErr := tx.Exec("UPDATE OR IGNORE photos_keywords SET photo_id = ? WHERE photo_id = ?", original.ID, photo.ID).Error; updateErr != nil {
+				return rollback(updateErr)
+			}
+			if updateErr := tx.Exec("UPDATE OR IGNORE photos_labels SET photo_id = ? WHERE photo_id = ?", original.ID, photo.ID).Error; updateErr != nil {
+				return rollback(updateErr)
+			}
+			if updateErr := tx.Exec("UPDATE OR IGNORE photos_albums SET photo_uid = ? WHERE photo_uid = ?", original.PhotoUID, photo.PhotoUID).Error; updateErr != nil {
+				return rollback(updateErr)
+			}
+		default:
+			return rollback(fmt.Errorf("stack: unsupported database dialect %s", DbDialect()))
+		}
+
+		photo.DeletedAt = &deleted
+		photo.PhotoQuality = -1
+		stacked = append(stacked, photo)
+	}
+
+	if commitErr := tx.Commit().Error; commitErr != nil {
+		return Photo{}, Photos{}, commitErr
+	}
+
+	original.PhotoStack = IsStacked
+
+	if primaryErr := original.ResolvePrimary(); primaryErr != nil {
+		return original, stacked, primaryErr
+	}
+
+	if typeErr := original.SyncMediaTypeFromFiles(SrcFile); typeErr != nil {
+		return original, stacked, typeErr
+	}
+
+	File{PhotoID: original.ID, PhotoUID: original.PhotoUID}.RegenerateIndex()
+
+	return original, stacked, nil
+}
 
 // ResolvePrimary ensures only one associated file remains marked as primary, delegating to the file helper.
 func (m *Photo) ResolvePrimary() error {

--- a/internal/entity/photo_merge.go
+++ b/internal/entity/photo_merge.go
@@ -89,29 +89,8 @@ func StackPhotos(photoUIDs []string) (original Photo, stacked Photos, err error)
 			return rollback(updateErr)
 		}
 
-		switch DbDialect() {
-		case dsn.DriverMySQL:
-			if updateErr := tx.Exec("UPDATE IGNORE photos_keywords SET photo_id = ? WHERE photo_id = ?", original.ID, photo.ID).Error; updateErr != nil {
-				return rollback(updateErr)
-			}
-			if updateErr := tx.Exec("UPDATE IGNORE photos_labels SET photo_id = ? WHERE photo_id = ?", original.ID, photo.ID).Error; updateErr != nil {
-				return rollback(updateErr)
-			}
-			if updateErr := tx.Exec("UPDATE IGNORE photos_albums SET photo_uid = ? WHERE photo_uid = ?", original.PhotoUID, photo.PhotoUID).Error; updateErr != nil {
-				return rollback(updateErr)
-			}
-		case dsn.DriverSQLite3:
-			if updateErr := tx.Exec("UPDATE OR IGNORE photos_keywords SET photo_id = ? WHERE photo_id = ?", original.ID, photo.ID).Error; updateErr != nil {
-				return rollback(updateErr)
-			}
-			if updateErr := tx.Exec("UPDATE OR IGNORE photos_labels SET photo_id = ? WHERE photo_id = ?", original.ID, photo.ID).Error; updateErr != nil {
-				return rollback(updateErr)
-			}
-			if updateErr := tx.Exec("UPDATE OR IGNORE photos_albums SET photo_uid = ? WHERE photo_uid = ?", original.PhotoUID, photo.PhotoUID).Error; updateErr != nil {
-				return rollback(updateErr)
-			}
-		default:
-			return rollback(fmt.Errorf("stack: unsupported database dialect %s", DbDialect()))
+		if moveErr := moveStackAssociations(tx, &original, photo); moveErr != nil {
+			return rollback(moveErr)
 		}
 
 		photo.DeletedAt = &deleted
@@ -136,6 +115,65 @@ func StackPhotos(photoUIDs []string) (original Photo, stacked Photos, err error)
 	File{PhotoID: original.ID, PhotoUID: original.PhotoUID}.RegenerateIndex()
 
 	return original, stacked, nil
+}
+
+// moveStackAssociations transfers keyword, label, and album relations to the
+// primary photo, removing duplicate source rows before updating the remainder.
+func moveStackAssociations(tx *gorm.DB, primary, secondary *Photo) error {
+	if tx == nil || primary == nil || secondary == nil {
+		return fmt.Errorf("stack: photo associations require a transaction and two pictures")
+	}
+
+	var statements []struct {
+		query string
+		args  []any
+	}
+
+	switch DbDialect() {
+	case dsn.DriverMySQL:
+		statements = []struct {
+			query string
+			args  []any
+		}{
+			{"DELETE source FROM photos_keywords AS source INNER JOIN photos_keywords AS target ON target.photo_id = ? AND target.keyword_id = source.keyword_id WHERE source.photo_id = ?", []any{primary.ID, secondary.ID}},
+			{"DELETE source FROM photos_labels AS source INNER JOIN photos_labels AS target ON target.photo_id = ? AND target.label_id = source.label_id WHERE source.photo_id = ?", []any{primary.ID, secondary.ID}},
+			{"DELETE source FROM photos_albums AS source INNER JOIN photos_albums AS target ON target.photo_uid = ? AND target.album_uid = source.album_uid WHERE source.photo_uid = ?", []any{primary.PhotoUID, secondary.PhotoUID}},
+		}
+	case dsn.DriverSQLite3:
+		statements = []struct {
+			query string
+			args  []any
+		}{
+			{"DELETE FROM photos_keywords WHERE photo_id = ? AND EXISTS (SELECT 1 FROM photos_keywords AS target WHERE target.photo_id = ? AND target.keyword_id = photos_keywords.keyword_id)", []any{secondary.ID, primary.ID}},
+			{"DELETE FROM photos_labels WHERE photo_id = ? AND EXISTS (SELECT 1 FROM photos_labels AS target WHERE target.photo_id = ? AND target.label_id = photos_labels.label_id)", []any{secondary.ID, primary.ID}},
+			{"DELETE FROM photos_albums WHERE photo_uid = ? AND EXISTS (SELECT 1 FROM photos_albums AS target WHERE target.photo_uid = ? AND target.album_uid = photos_albums.album_uid)", []any{secondary.PhotoUID, primary.PhotoUID}},
+		}
+	default:
+		return fmt.Errorf("stack: unsupported database dialect %s", DbDialect())
+	}
+
+	statements = append(statements,
+		struct {
+			query string
+			args  []any
+		}{"UPDATE photos_keywords SET photo_id = ? WHERE photo_id = ?", []any{primary.ID, secondary.ID}},
+		struct {
+			query string
+			args  []any
+		}{"UPDATE photos_labels SET photo_id = ? WHERE photo_id = ?", []any{primary.ID, secondary.ID}},
+		struct {
+			query string
+			args  []any
+		}{"UPDATE photos_albums SET photo_uid = ? WHERE photo_uid = ?", []any{primary.PhotoUID, secondary.PhotoUID}},
+	)
+
+	for _, statement := range statements {
+		if err := tx.Exec(statement.query, statement.args...).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // ResolvePrimary ensures only one associated file remains marked as primary, delegating to the file helper.

--- a/internal/entity/photo_merge_test.go
+++ b/internal/entity/photo_merge_test.go
@@ -267,11 +267,57 @@ func TestStackPhotos(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var keywords []Keyword
+	if err := Db().Limit(2).Find(&keywords).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(keywords) < 2 {
+		t.Fatal("stack test requires two keyword fixtures")
+	}
+
+	var labels []Label
+	if err := Db().Limit(2).Find(&labels).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(labels) < 2 {
+		t.Fatal("stack test requires two label fixtures")
+	}
+
+	var albums []Album
+	if err := Db().Limit(2).Find(&albums).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(albums) < 2 {
+		t.Fatal("stack test requires two album fixtures")
+	}
+
+	relations := []interface{}{
+		NewPhotoKeyword(primary.ID, keywords[0].ID),
+		NewPhotoKeyword(secondary.ID, keywords[0].ID),
+		NewPhotoKeyword(secondary.ID, keywords[1].ID),
+		NewPhotoLabel(primary.ID, labels[0].ID, 0, SrcManual),
+		NewPhotoLabel(secondary.ID, labels[0].ID, 5, SrcAuto),
+		NewPhotoLabel(secondary.ID, labels[1].ID, 10, SrcAuto),
+		NewPhotoAlbum(primary.PhotoUID, albums[0].AlbumUID),
+		NewPhotoAlbum(secondary.PhotoUID, albums[0].AlbumUID),
+		NewPhotoAlbum(secondary.PhotoUID, albums[1].AlbumUID),
+	}
+
+	for _, relation := range relations {
+		if err := Db().Create(relation).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	t.Cleanup(func() {
 		fileUIDs := []string{primaryFile.FileUID, secondaryFile.FileUID}
 		photoIDs := []uint{primary.ID, secondary.ID}
+		photoUIDs := []string{primary.PhotoUID, secondary.PhotoUID}
 
 		_ = UnscopedDb().Where("file_uid IN (?)", fileUIDs).Delete(File{}).Error
+		_ = UnscopedDb().Where("photo_id IN (?)", photoIDs).Delete(PhotoKeyword{}).Error
+		_ = UnscopedDb().Where("photo_id IN (?)", photoIDs).Delete(PhotoLabel{}).Error
+		_ = UnscopedDb().Where("photo_uid IN (?)", photoUIDs).Delete(PhotoAlbum{}).Error
 		_ = UnscopedDb().Where("photo_id IN (?)", photoIDs).Delete(Details{}).Error
 		_ = UnscopedDb().Where("id IN (?)", photoIDs).Delete(Photo{}).Error
 	})
@@ -318,6 +364,27 @@ func TestStackPhotos(t *testing.T) {
 		assert.NoError(t, UnscopedDb().First(&refreshedSecondary, "id = ?", secondary.ID).Error)
 		assert.Equal(t, -1, refreshedSecondary.PhotoQuality)
 		assert.NotNil(t, refreshedSecondary.DeletedAt)
+
+		var keywordRelations []PhotoKeyword
+		assert.NoError(t, UnscopedDb().Where("photo_id IN (?)", []uint{primary.ID, secondary.ID}).Find(&keywordRelations).Error)
+		assert.Len(t, keywordRelations, 2)
+		for _, relation := range keywordRelations {
+			assert.Equal(t, primary.ID, relation.PhotoID)
+		}
+
+		var labelRelations []PhotoLabel
+		assert.NoError(t, UnscopedDb().Where("photo_id IN (?)", []uint{primary.ID, secondary.ID}).Find(&labelRelations).Error)
+		assert.Len(t, labelRelations, 2)
+		for _, relation := range labelRelations {
+			assert.Equal(t, primary.ID, relation.PhotoID)
+		}
+
+		var albumRelations []PhotoAlbum
+		assert.NoError(t, UnscopedDb().Where("photo_uid IN (?)", []string{primary.PhotoUID, secondary.PhotoUID}).Find(&albumRelations).Error)
+		assert.Len(t, albumRelations, 2)
+		for _, relation := range albumRelations {
+			assert.Equal(t, primary.PhotoUID, relation.PhotoUID)
+		}
 	})
 }
 

--- a/internal/entity/photo_merge_test.go
+++ b/internal/entity/photo_merge_test.go
@@ -210,6 +210,117 @@ func TestPhoto_Merge(t *testing.T) {
 	})
 }
 
+func TestStackPhotos(t *testing.T) {
+	primary := NewPhoto(true)
+	primary.PhotoUID = rnd.GenerateUID(PhotoUID)
+	primary.PhotoPath = "manual-stack"
+	primary.PhotoName = "Primary"
+	primary.PhotoType = MediaImage
+	primary.TypeSrc = SrcAuto
+	primary.PhotoQuality = 5
+
+	if err := primary.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	secondary := NewPhoto(true)
+	secondary.PhotoUID = rnd.GenerateUID(PhotoUID)
+	secondary.PhotoPath = "manual-stack"
+	secondary.PhotoName = "Secondary"
+	secondary.PhotoType = MediaImage
+	secondary.TypeSrc = SrcAuto
+	secondary.PhotoQuality = 4
+
+	if err := secondary.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	primaryFile := File{
+		PhotoID:     primary.ID,
+		PhotoUID:    primary.PhotoUID,
+		FileUID:     rnd.GenerateUID(FileUID),
+		FileName:    "manual-stack/" + primary.PhotoUID + ".jpg",
+		FileRoot:    RootOriginals,
+		FileHash:    "manual-stack-primary-" + primary.PhotoUID,
+		FileType:    "jpg",
+		MediaType:   media.Image.String(),
+		FilePrimary: true,
+	}
+
+	if err := primaryFile.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	secondaryFile := File{
+		PhotoID:     secondary.ID,
+		PhotoUID:    secondary.PhotoUID,
+		FileUID:     rnd.GenerateUID(FileUID),
+		FileName:    "manual-stack/" + secondary.PhotoUID + ".jpg",
+		FileRoot:    RootOriginals,
+		FileHash:    "manual-stack-secondary-" + secondary.PhotoUID,
+		FileType:    "jpg",
+		MediaType:   media.Image.String(),
+		FilePrimary: true,
+	}
+
+	if err := secondaryFile.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		fileUIDs := []string{primaryFile.FileUID, secondaryFile.FileUID}
+		photoIDs := []uint{primary.ID, secondary.ID}
+
+		_ = UnscopedDb().Where("file_uid IN (?)", fileUIDs).Delete(File{}).Error
+		_ = UnscopedDb().Where("photo_id IN (?)", photoIDs).Delete(Details{}).Error
+		_ = UnscopedDb().Where("id IN (?)", photoIDs).Delete(Photo{}).Error
+	})
+
+	t.Run("RequiresCompleteSelection", func(t *testing.T) {
+		_, _, err := StackPhotos([]string{primary.PhotoUID, rnd.GenerateUID(PhotoUID)})
+
+		assert.Error(t, err)
+
+		var count int
+		assert.NoError(t, UnscopedDb().Model(File{}).Where("photo_id = ?", primary.ID).Count(&count).Error)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		original, stacked, err := StackPhotos([]string{primary.PhotoUID, secondary.PhotoUID})
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, primary.PhotoUID, original.PhotoUID)
+		assert.Equal(t, []string{secondary.PhotoUID}, stacked.UIDs())
+
+		var files Files
+		assert.NoError(t, UnscopedDb().Where("file_uid IN (?)", []string{primaryFile.FileUID, secondaryFile.FileUID}).Find(&files).Error)
+		assert.Len(t, files, 2)
+
+		primaryCount := 0
+		for _, file := range files {
+			assert.Equal(t, primary.ID, file.PhotoID)
+			assert.Equal(t, primary.PhotoUID, file.PhotoUID)
+			if file.FilePrimary {
+				primaryCount++
+			}
+		}
+		assert.Equal(t, 1, primaryCount)
+
+		var refreshedPrimary Photo
+		assert.NoError(t, UnscopedDb().First(&refreshedPrimary, "id = ?", primary.ID).Error)
+		assert.Equal(t, IsStacked, refreshedPrimary.PhotoStack)
+
+		var refreshedSecondary Photo
+		assert.NoError(t, UnscopedDb().First(&refreshedSecondary, "id = ?", secondary.ID).Error)
+		assert.Equal(t, -1, refreshedSecondary.PhotoQuality)
+		assert.NotNil(t, refreshedSecondary.DeletedAt)
+	})
+}
+
 func TestPhoto_SyncMediaTypeFromFiles(t *testing.T) {
 	t.Run("NoMainFiles", func(t *testing.T) {
 		photo := NewPhoto(true)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -200,6 +200,7 @@ func registerRoutes(router *gin.Engine, conf *config.Config) {
 	api.BatchLabelsDelete(APIv1)
 	api.BatchPhotosEdit(APIv1)
 	api.BatchPhotosApprove(APIv1)
+	api.BatchPhotosStack(APIv1)
 	api.BatchPhotosArchive(APIv1)
 	api.BatchPhotosRestore(APIv1)
 	api.BatchPhotosPrivate(APIv1)


### PR DESCRIPTION
## Summary

Adds non-destructive manual photo stacking for issue #28.

- adds a **Stack** action when at least two photos are selected
- preserves the first selected photo as the stack's primary record
- moves secondary file records onto the primary photo without touching physical media files
- migrates keywords, labels, and albums, then soft-deletes secondary photo records
- rejects partial/unauthorized selections atomically and refreshes counts, covers, cache, and clients after success

## Proof

- `go test ./internal/entity -run '^TestStackPhotos$' -count=1`
- `go test ./internal/api -run '^TestBatchPhotosStack$' -count=1`
- `vitest run tests/vitest/component/photo/clipboard.test.js` (Node 22; 4 tests)
- focused ESLint for the component and test
- `git diff --check`

Closes #28