### PR TITLE
Search: instantly open gallery instead of waiting for view request to finish

### DIFF
--- a/frontend/src/component/lightbox.vue
+++ b/frontend/src/component/lightbox.vue
@@ -649,6 +649,14 @@ export default {
         }
       }
 
+      let shownLocally = false;
+      const localThumbs = Thumb.fromPhotos(view.results);
+
+      if (localThumbs.length > index) {
+        this.showThumbs(localThumbs, index, { collection, context });
+        shownLocally = true;
+      }
+
       // Fetch photos from server API.
       view.lightbox.loading = true;
 
@@ -662,7 +670,9 @@ export default {
         .then((response) => {
           const count = response && response.data ? response.data.length : 0;
           if (count === 0) {
-            view.$notify.warn(view.$gettext("No pictures found"));
+            if (!shownLocally) {
+              view.$notify.warn(view.$gettext("No pictures found"));
+            }
             view.lightbox.dirty = true;
             view.lightbox.complete = false;
             return;
@@ -687,8 +697,12 @@ export default {
 
           view.lightbox.results = Thumb.wrap(response.data);
 
-          // Show pictures.
-          this.showThumbs(view.lightbox.results, i, { collection, context });
+          // Show pictures, unless the lightbox is already open with the
+          // locally available results — then the fetched batch is only kept
+          // for the next opening.
+          if (!shownLocally) {
+            this.showThumbs(view.lightbox.results, i, { collection, context });
+          }
           view.lightbox.dirty = false;
         })
         .catch(() => {


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

These changes make opening an image preview instant to make the UI feel more responsive.

I host PhotoPrism on a personal NAS with a decent AM4 CPU and Ethernet and even on LAN I have to wait a solid second for any image I select to pop up.

#### Related Issues

None(?)

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [X] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->