### PR TITLE
Download: Fix download button doing nothing if photoprism is misconfigured

### DIFF
--- a/frontend/src/component/lightbox.vue
+++ b/frontend/src/component/lightbox.vue
@@ -3304,9 +3304,15 @@ export default {
         return;
       }
 
-      this.$notify.success(this.$gettext("Downloading…"));
+      new Photo().find(this.model.UID).then((p) => {
+        const { downloaded, skipped } = p.downloadAll();
 
-      new Photo().find(this.model.UID).then((p) => p.downloadAll());
+        if (downloaded > 0) {
+          this.$notify.success(this.$gettext("Downloading…"));
+        } else if (skipped > 0) {
+          this.$notify.warn(this.$gettext("No files to download: all files are excluded by the download settings"));
+        }
+      });
     },
     onEdit() {
       this.pauseLightbox();

--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -395,12 +395,22 @@ export default {
         case 1:
           new Photo()
             .find(this.selection[0])
-            .then((p) => p.downloadAll())
+            .then((p) => {
+              const { downloaded, skipped } = p.downloadAll();
+
+              if (downloaded > 0) {
+                $notify.success(this.$gettext("Downloading…"));
+              } else if (skipped > 0) {
+                $notify.warn(this.$gettext("No files to download: all files are excluded by the download settings"));
+              }
+            })
             .finally(() => {
               this.busy = false;
             });
           break;
         default:
+          $notify.success(this.$gettext("Downloading…"));
+
           $api
             .post("zip", { photos: this.selection })
             .then((r) => {
@@ -410,8 +420,6 @@ export default {
               this.busy = false;
             });
       }
-
-      $notify.success(this.$gettext("Downloading…"));
 
       this.expanded = false;
     },

--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -12,6 +12,7 @@ import countries from "options/countries.json";
 import { $gettext } from "common/gettext";
 import { PhotoClipboard } from "common/clipboard";
 import download from "common/download";
+import $notify from "common/notify";
 import * as src from "common/src";
 import * as media from "common/media";
 import * as formats from "options/formats";
@@ -771,6 +772,9 @@ export class Photo extends RestModel {
       return;
     }
 
+    let downloaded = 0;
+    let skipped = 0;
+
     this.Files.forEach((file) => {
       if (!file || !file.Hash) {
         return;
@@ -782,6 +786,7 @@ export class Photo extends RestModel {
         if ($config.debug) {
           console.log(`download: skipped ${file.Root} file ${file.Name}`);
         }
+        skipped++;
         return;
       }
 
@@ -791,6 +796,7 @@ export class Photo extends RestModel {
         if ($config.debug) {
           console.log(`download: skipped sidecar file ${file.Name}`);
         }
+        skipped++;
         return;
       }
 
@@ -799,6 +805,7 @@ export class Photo extends RestModel {
         if ($config.debug) {
           console.log(`download: skipped raw file ${file.Name}`);
         }
+        skipped++;
         return;
       }
 
@@ -808,11 +815,17 @@ export class Photo extends RestModel {
         if ($config.debug) {
           console.log(`download: skipped video sidecar ${file.Name}`);
         }
+        skipped++;
         return;
       }
 
       download(`${$config.apiUri}/dl/${file.Hash}?t=${token}`, this.fileBase(file.Name));
+      downloaded++;
     });
+
+    if (downloaded === 0 && skipped > 0) {
+      $notify.warn($gettext("No files to download: all files are excluded by the download settings"));
+    }
   }
 
   calculateSize(width, height) {

--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -12,7 +12,6 @@ import countries from "options/countries.json";
 import { $gettext } from "common/gettext";
 import { PhotoClipboard } from "common/clipboard";
 import download from "common/download";
-import $notify from "common/notify";
 import * as src from "common/src";
 import * as media from "common/media";
 import * as formats from "options/formats";
@@ -749,12 +748,13 @@ export class Photo extends RestModel {
   }
 
   // Downloads all related files if they exist and depending on the settings.
+  // Returns { downloaded, skipped } so a prompt can be shown to report download status
   downloadAll() {
     const s = $config.getSettings();
 
     if (!s || !s.features || !s.download || !s.features.download || s.download.disabled) {
       console.log("download: disabled in settings", s.features, s.download);
-      return;
+      return { downloaded: 0, skipped: 0 };
     }
 
     const token = $config.downloadToken;
@@ -765,11 +765,12 @@ export class Photo extends RestModel {
 
       if (hash) {
         download(`/${$config.apiUri}/dl/${hash}?t=${token}`, this.baseName(false));
+        return { downloaded: 1, skipped: 0 };
       } else if ($config.debug) {
         console.log("download: failed, empty file hash", this);
       }
 
-      return;
+      return { downloaded: 0, skipped: 0 };
     }
 
     let downloaded = 0;
@@ -823,9 +824,7 @@ export class Photo extends RestModel {
       downloaded++;
     });
 
-    if (downloaded === 0 && skipped > 0) {
-      $notify.warn($gettext("No files to download: all files are excluded by the download settings"));
-    }
+    return { downloaded, skipped };
   }
 
   calculateSize(width, height) {

--- a/frontend/tests/vitest/component/lightbox.basic.test.js
+++ b/frontend/tests/vitest/component/lightbox.basic.test.js
@@ -6,6 +6,7 @@ import PLightbox from "component/lightbox.vue";
 import Photo from "model/photo";
 import Thumb from "model/thumb";
 import Album from "model/album";
+import Rest from "model/rest";
 import $util from "common/util";
 import { buildNamespace } from "common/storage";
 import { FaceMarkerDisplay, FaceMarkerEdit } from "options/face-marker";
@@ -1292,6 +1293,65 @@ describe("PLightbox (low-mock, jsdom-friendly)", () => {
       expect(evictSpy).not.toHaveBeenCalled();
       removeSpy.mockRestore();
       evictSpy.mockRestore();
+    });
+  });
+
+  describe("onDownload wiring", () => {
+    const warnMessage = "No files to download: all files are excluded by the download settings";
+
+    const makeCtx = (wrapper, model) => ({
+      ...wrapper.vm,
+      canDownload: true,
+      pauseSlideshow: vi.fn(),
+      model,
+      $notify: { ...wrapper.vm.$notify, success: vi.fn(), warn: vi.fn() },
+      $gettext: VTUConfig.global.mocks.$gettext,
+      log: vi.fn(),
+    });
+
+    // Rest.prototype.find is the shared fetch used by new Photo().find();
+    // stubbing it resolves onDownload with a Photo whose downloadAll()
+    // return value drives the prompt decision.
+    const stubPhotoFind = (found) => {
+      const findSpy = vi.spyOn(Rest.prototype, "find").mockResolvedValue(found);
+      const dlSpy = vi.spyOn(found, "downloadAll");
+      return { findSpy, dlSpy };
+    };
+
+    it("shows the Downloading prompt when downloadAll started a download", async () => {
+      const wrapper = mountLightbox();
+      const found = new Photo({ UID: "ps6sg6be2lvl0yh7" });
+      const { findSpy, dlSpy } = stubPhotoFind(found);
+      dlSpy.mockReturnValue({ downloaded: 1, skipped: 0 });
+      const ctx = makeCtx(wrapper, new Thumb({ UID: "ps6sg6be2lvl0yh7", DownloadUrl: "/api/v1/dl/abc?t=2lbh9x09" }));
+
+      wrapper.vm.$options.methods.onDownload.call(ctx);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(findSpy).toHaveBeenCalledWith("ps6sg6be2lvl0yh7");
+      expect(dlSpy).toHaveBeenCalledTimes(1);
+      expect(ctx.pauseSlideshow).toHaveBeenCalledTimes(1);
+      expect(ctx.$notify.success).toHaveBeenCalledWith("Downloading…");
+      expect(ctx.$notify.warn).not.toHaveBeenCalled();
+      findSpy.mockRestore();
+    });
+
+    it("warns instead when every file was excluded and no download started", async () => {
+      const wrapper = mountLightbox();
+      const found = new Photo({ UID: "ps6sg6be2lvl0yh7" });
+      const { findSpy, dlSpy } = stubPhotoFind(found);
+      dlSpy.mockReturnValue({ downloaded: 0, skipped: 1 });
+      const ctx = makeCtx(wrapper, new Thumb({ UID: "ps6sg6be2lvl0yh7", DownloadUrl: "/api/v1/dl/abc?t=2lbh9x09" }));
+
+      wrapper.vm.$options.methods.onDownload.call(ctx);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(dlSpy).toHaveBeenCalledTimes(1);
+      expect(ctx.$notify.success).not.toHaveBeenCalled();
+      expect(ctx.$notify.warn).toHaveBeenCalledWith(warnMessage);
+      findSpy.mockRestore();
     });
   });
 

--- a/frontend/tests/vitest/component/photo/clipboard.test.js
+++ b/frontend/tests/vitest/component/photo/clipboard.test.js
@@ -106,11 +106,6 @@ describe("component/photo/clipboard", () => {
     });
   });
 
-  // downloadAll() reports { downloaded, skipped }; the clipboard picks the
-  // prompt: "Downloading…" when a download started, a warning when every
-  // file of the single selected photo was excluded by the download
-  // settings. Multi-photo downloads always produce a zip, so they keep the
-  // unconditional prompt.
   describe("download() prompt", () => {
     const warnMessage = "No files to download: all files are excluded by the download settings";
 

--- a/frontend/tests/vitest/component/photo/clipboard.test.js
+++ b/frontend/tests/vitest/component/photo/clipboard.test.js
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { shallowMount } from "@vue/test-utils";
 import PPhotoClipboard from "component/photo/clipboard.vue";
+import Photo from "model/photo";
+import Rest from "model/rest";
+import $notify from "common/notify";
+import $api from "common/api";
 
 const baseFeatures = {
   edit: true,
@@ -99,6 +103,76 @@ describe("component/photo/clipboard", () => {
       selection: clipboard.selection,
       album: wrapper.vm.album,
       index: 0,
+    });
+  });
+
+  // downloadAll() reports { downloaded, skipped }; the clipboard picks the
+  // prompt: "Downloading…" when a download started, a warning when every
+  // file of the single selected photo was excluded by the download
+  // settings. Multi-photo downloads always produce a zip, so they keep the
+  // unconditional prompt.
+  describe("download() prompt", () => {
+    const warnMessage = "No files to download: all files are excluded by the download settings";
+
+    it("shows the Downloading prompt when the single photo download starts", async () => {
+      const { wrapper } = mountClipboard();
+      const found = new Photo({ UID: "pt5y3865st5p3k5l" });
+      const findSpy = vi.spyOn(Rest.prototype, "find").mockResolvedValue(found);
+      const dlSpy = vi.spyOn(found, "downloadAll").mockReturnValue({ downloaded: 1, skipped: 0 });
+      const successSpy = vi.spyOn($notify, "success").mockImplementation(() => {});
+      const warnSpy = vi.spyOn($notify, "warn").mockImplementation(() => {});
+      wrapper.vm.selection = ["pt5y3865st5p3k5l"];
+
+      wrapper.vm.download();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(findSpy).toHaveBeenCalledWith("pt5y3865st5p3k5l");
+      expect(dlSpy).toHaveBeenCalledTimes(1);
+      expect(successSpy).toHaveBeenCalledWith("Downloading…");
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(wrapper.vm.busy).toBe(false);
+      findSpy.mockRestore();
+      successSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("warns instead when every file was excluded and no download started", async () => {
+      const { wrapper } = mountClipboard();
+      const found = new Photo({ UID: "pt5y3865st5p3k5l" });
+      const findSpy = vi.spyOn(Rest.prototype, "find").mockResolvedValue(found);
+      const dlSpy = vi.spyOn(found, "downloadAll").mockReturnValue({ downloaded: 0, skipped: 1 });
+      const successSpy = vi.spyOn($notify, "success").mockImplementation(() => {});
+      const warnSpy = vi.spyOn($notify, "warn").mockImplementation(() => {});
+      wrapper.vm.selection = ["pt5y3865st5p3k5l"];
+
+      wrapper.vm.download();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(dlSpy).toHaveBeenCalledTimes(1);
+      expect(successSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(warnMessage);
+      expect(wrapper.vm.busy).toBe(false);
+      findSpy.mockRestore();
+      successSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("always shows the Downloading prompt for multi-photo zip downloads", async () => {
+      const { wrapper, clipboard } = mountClipboard();
+      const postSpy = vi.spyOn($api, "post").mockResolvedValue({ data: { filename: "photos-123.zip" } });
+      const successSpy = vi.spyOn($notify, "success").mockImplementation(() => {});
+
+      wrapper.vm.download();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(postSpy).toHaveBeenCalledWith("zip", { photos: clipboard.selection });
+      expect(successSpy).toHaveBeenCalledWith("Downloading…");
+      expect(wrapper.vm.busy).toBe(false);
+      postSpy.mockRestore();
+      successSpy.mockRestore();
     });
   });
 });

--- a/frontend/tests/vitest/model/photo.test.js
+++ b/frontend/tests/vitest/model/photo.test.js
@@ -204,13 +204,7 @@ describe("model/photo", () => {
     expect(result).toBe("/api/v1/dl/97b8cf7b3710bec95f6609487bbdd62489b95fb2?t=2lbh9x09");
   });
 
-  // downloadAll() starts one download per eligible file and reports what
-  // happened as { downloaded, skipped } — the consumers decide which prompt
-  // fits: "Downloading…" when a download started, a warning when every file
-  // was excluded by the settings, silence otherwise.
   describe("downloadAll", () => {
-    // Permissive baseline: download feature on, no originals / sidecar /
-    // raw restriction set.
     const allowAll = (overrides = {}) => ({
       features: { download: true },
       download: { name: "file", ...overrides },
@@ -256,8 +250,6 @@ describe("model/photo", () => {
     });
 
     it("reports every file as skipped when the settings exclude them all", () => {
-      // The reported misconfiguration: RAW downloads are off and the photo
-      // only has a RAW file — before the fix, the click silently did nothing.
       mockSettings(allowAll({ mediaRaw: false }));
       const photo = new Photo({ UID: "pt9x2vksm3p4q8ft", Type: "image", Files: [raw("r1")] });
 

--- a/frontend/tests/vitest/model/photo.test.js
+++ b/frontend/tests/vitest/model/photo.test.js
@@ -3,6 +3,7 @@ import "../fixtures";
 import * as media from "common/media";
 import { Photo, BatchSize, MaxLength } from "model/photo";
 import $event from "common/event";
+import { $config } from "app/session";
 
 // Drains the pubsub-js async queue so subscribers configured as `async: true`
 // have run by the time the test asserts.
@@ -201,6 +202,76 @@ describe("model/photo", () => {
     const photo = new Photo(values);
     const result = photo.getDownloadUrl();
     expect(result).toBe("/api/v1/dl/97b8cf7b3710bec95f6609487bbdd62489b95fb2?t=2lbh9x09");
+  });
+
+  // downloadAll() starts one download per eligible file and reports what
+  // happened as { downloaded, skipped } — the consumers decide which prompt
+  // fits: "Downloading…" when a download started, a warning when every file
+  // was excluded by the settings, silence otherwise.
+  describe("downloadAll", () => {
+    // Permissive baseline: download feature on, no originals / sidecar /
+    // raw restriction set.
+    const allowAll = (overrides = {}) => ({
+      features: { download: true },
+      download: { name: "file", ...overrides },
+    });
+
+    const mockSettings = (settings) => vi.spyOn($config, "getSettings").mockReturnValue(settings);
+    const jpg = (hash, name = "1980/01/kitten.jpg") => ({ Hash: hash, Name: name, Root: "/", FileType: "jpg", MediaType: "image" });
+    const raw = (hash, name = "1980/01/kitten.cr2") => ({ Hash: hash, Name: name, Root: "/", FileType: "cr2", MediaType: "raw" });
+
+    // common/download() renders each started download as a hidden <a
+    // download> click. Spying on the anchor click observes those requests
+    // (and their URLs / file names) without hitting the network.
+    let clicks;
+    let clickSpy;
+
+    const hrefs = () => clicks.map((c) => c.href);
+
+    beforeEach(() => {
+      clicks = [];
+      clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function () {
+        clicks.push({ href: this.getAttribute("href"), name: this.getAttribute("download") });
+      });
+    });
+
+    it("downloads eligible files and reports the counts", () => {
+      mockSettings(allowAll());
+      const photo = new Photo({ UID: "pt9x2vksm3p4q8ft", Type: "image", Files: [jpg("f1"), jpg("f2", "1980/01/second.jpg")] });
+
+      expect(photo.downloadAll()).toEqual({ downloaded: 2, skipped: 0 });
+      expect(clicks).toHaveLength(2);
+      expect(hrefs()).toEqual(["/api/v1/dl/f1?t=2lbh9x09", "/api/v1/dl/f2?t=2lbh9x09"]);
+      expect(clicks.map((c) => c.name)).toEqual(["kitten.jpg", "second.jpg"]);
+    });
+
+    it("downloads the primary file when no file list exists", () => {
+      mockSettings(allowAll());
+      const photo = new Photo({ UID: "pt9x2vksm3p4q8ft", Hash: "primary1", FileName: "1980/01/tiger.jpg" });
+
+      expect(photo.downloadAll()).toEqual({ downloaded: 1, skipped: 0 });
+      expect(clicks).toHaveLength(1);
+      expect(clicks[0].href).toContain("/dl/primary1?t=2lbh9x09");
+      expect(clicks[0].name).toBe("tiger.jpg");
+    });
+
+    it("reports every file as skipped when the settings exclude them all", () => {
+      // The reported misconfiguration: RAW downloads are off and the photo
+      // only has a RAW file — before the fix, the click silently did nothing.
+      mockSettings(allowAll({ mediaRaw: false }));
+      const photo = new Photo({ UID: "pt9x2vksm3p4q8ft", Type: "image", Files: [raw("r1")] });
+
+      expect(photo.downloadAll()).toEqual({ downloaded: 0, skipped: 1 });
+      expect(clicks).toHaveLength(0);
+    });
+
+    it("reports mixed results when only some files are excluded", () => {
+      mockSettings(allowAll({ mediaRaw: false }));
+      const photo = new Photo({ UID: "pt9x2vksm3p4q8ft", Type: "image", Files: [jpg("f1"), raw("r1")] });
+
+      expect(photo.downloadAll()).toEqual({ downloaded: 1, skipped: 1 });
+      expect(hrefs()).toEqual(["/api/v1/dl/f1?t=2lbh9x09"]);
+    });
   });
 
   it("should calculate photo size", () => {


### PR DESCRIPTION
### Description

<!--
We appreciate your interest in contributing! Please provide a brief description of your changes so that we know what is included in this pull request, and confirm that it meets the acceptance criteria:

What does it aim to implement, fix or improve? Why?
-->

When using photoprism I wasn't able to download any files. Upon investigation it turns out I simply set it up to download nothing (my library is mostly RAW files and I had turned off RAW download). These changes add a warning that shows up when the download will do nothing so the user doesn't think it's a bug. Comes with related tests.

#### Related Issues

None

### Acceptance Criteria

<!-- You may add additional criteria and/or remove criteria that do not apply, e.g. because your PR does not include frontend changes: -->

- [x] New features or enhancements are fully implemented and do not break existing functionality, so that they can be released at any time without requiring additional work
- [X] Automated unit and/or acceptance tests are included to ensure that changes work as expected and to reduce repetitive manual work
- [X] The user interface has been tested on Chrome, Safari, and Firefox and is fully responsive for use on phones, tablets, and desktop computers

<!--
Contribution Agreement:

After submitting your first pull request, you will be asked to confirm our contribution agreement. This allows us to safely use your Contribution in all our projects without risking unexpected legal disputes or having to repeatedly ask for permission.
The agreement is solely for our protection and that of our users. It does not grant us exclusive rights to your code.

PhotoPrism UG ("PhotoPrism", "we" or "us") hereby confirms to you that, to the fullest extent permitted by applicable law, this Contribution is provided "AS IS" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OR CONDITIONS OF NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. You have no obligation to provide support, maintenance, or other services for your Contribution.

Thank you very much! 🌈💎✨
-->